### PR TITLE
feat: add upgrade apply support

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ bun src/cli.ts ship --message "feat: ready for review" --push --pr --reviewer oc
 bun src/cli.ts ship --dry-run --pr --verify-url http://127.0.0.1:4173/dashboard --verify-flow portal-dashboard --verify-snapshot portal-dashboard
 bun src/cli.ts retro --since "7 days ago" --repo anup4khandelwal/codex-stack
 bun src/cli.ts upgrade --offline --json
+bun src/cli.ts upgrade --offline --apply
 bun src/cli.ts browse doctor
 bun src/cli.ts browse flows
 bun src/cli.ts browse snapshot https://example.com marketing-home --session staging
@@ -176,6 +177,7 @@ bun run qa -- http://127.0.0.1:4173/dashboard --flow portal-dashboard --snapshot
 bun run ship:dry
 bun run retro
 bun run upgrade
+bun run upgrade:apply
 bun run weekly
 ```
 
@@ -228,6 +230,7 @@ Examples:
 ```bash
 bun src/cli.ts upgrade --offline
 bun src/cli.ts upgrade --json
+bun src/cli.ts upgrade --offline --apply
 bun src/cli.ts upgrade --markdown-out docs/daily-update-check.md --json-out docs/daily-update-check.json
 ```
 
@@ -237,6 +240,9 @@ The upgrade report covers:
 - dependency drift from npm when network access is available
 - GitHub Actions `uses:` ref drift
 - local wrapper and installed Codex skill link health
+- optional safe local refresh results when `--apply` is used
+
+`--apply` is intentionally narrow. It regenerates `.codex-stack/bin` wrappers with dependency install skipped and refreshes project skill links under `.codex/skills`. It does not mutate dependency versions or workflow refs.
 
 `.github/workflows/daily-update-check.yml` runs that same report on a daily schedule, uploads the markdown/json artifacts, writes the markdown into the workflow summary, and syncs a stable GitHub issue titled `Daily codex-stack update check`.
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -21,6 +21,7 @@ bun src/cli.ts retro --since "7 days ago" --repo anup4khandelwal/codex-stack
 bun src/cli.ts retro --since "7 days ago" --no-github
 bun src/cli.ts upgrade --offline
 bun src/cli.ts upgrade --json
+bun src/cli.ts upgrade --offline --apply
 bun src/cli.ts upgrade --markdown-out docs/daily-update-check.md --json-out docs/daily-update-check.json
 bun src/cli.ts doctor
 bun src/cli.ts browse doctor
@@ -125,6 +126,7 @@ bun scripts/weekly-digest.ts --since "7 days ago" --no-github
 bun scripts/weekly-digest.ts --since "7 days ago" --publish-dir docs/weekly-digest-publish --no-github
 bun scripts/upgrade-check.ts --offline
 bun scripts/upgrade-check.ts --json
+bun scripts/upgrade-check.ts --offline --apply
 bun scripts/upgrade-check.ts --repo anup4khandelwal/codex-stack --markdown-out docs/daily-update-check.md --json-out docs/daily-update-check.json
 ```
 
@@ -139,6 +141,7 @@ Notes:
 ```bash
 bun scripts/upgrade-check.ts --offline
 bun scripts/upgrade-check.ts --json
+bun scripts/upgrade-check.ts --offline --apply
 bun scripts/upgrade-check.ts --repo anup4khandelwal/codex-stack --markdown-out docs/daily-update-check.md --json-out docs/daily-update-check.json
 ```
 
@@ -146,6 +149,7 @@ Notes:
 
 - `upgrade-check.ts` audits Bun alignment, dependency drift, workflow action drift, and install health.
 - Use `--offline` for deterministic local or CI smoke runs that should skip network calls.
+- Use `--apply` when you want the script to run the safe local refresh path for wrappers and project skill links after the audit.
 - `.github/workflows/daily-update-check.yml` runs the same script on a daily schedule and syncs the report into a stable GitHub issue.
 
 ## Browse workflow

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -91,5 +91,6 @@ CLI:
 ```bash
 bun src/cli.ts upgrade --offline
 bun src/cli.ts upgrade --json
+bun src/cli.ts upgrade --offline --apply
 bun src/cli.ts upgrade --markdown-out docs/daily-update-check.md --json-out docs/daily-update-check.json
 ```

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "retro": "bun scripts/retro-report.ts --since '7 days ago'",
     "upgrade": "bun scripts/upgrade-check.ts",
     "upgrade:offline": "bun scripts/upgrade-check.ts --offline",
+    "upgrade:apply": "bun scripts/upgrade-check.ts --offline --apply",
     "weekly": "bun scripts/weekly-digest.ts --since '7 days ago' --no-github",
     "qa:site": "bun scripts/render-qa-pages.ts --out .site",
     "browse:doctor": "bun browse/src/cli.ts doctor",

--- a/scripts/upgrade-check.spec.ts
+++ b/scripts/upgrade-check.spec.ts
@@ -1,5 +1,8 @@
 #!/usr/bin/env bun
 import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import process from "node:process";
 import { execFileSync } from "node:child_process";
 
@@ -38,5 +41,62 @@ const markdownOutput = execFileSync(bun, ["scripts/upgrade-check.ts", "--offline
 
 assert.match(markdownOutput, /codex-stack daily update check/);
 assert.match(markdownOutput, /Recommended actions/);
+assert.match(markdownOutput, /Apply results/);
+assert.match(markdownOutput, /Requested: no/);
+
+const applyFixtureDir = fs.mkdtempSync(path.join(os.tmpdir(), "codex-stack-upgrade-apply-"));
+try {
+  for (const entry of ["package.json", "setup", "scripts", "skills", "src", "browse"]) {
+    fs.cpSync(path.join(rootDir, entry), path.join(applyFixtureDir, entry), { recursive: true });
+  }
+
+  const applyJsonOutput = execFileSync(bun, ["scripts/upgrade-check.ts", "--offline", "--apply", "--json"], {
+    cwd: applyFixtureDir,
+    encoding: "utf8",
+  });
+
+  const applyReport = JSON.parse(applyJsonOutput) as {
+    applyRequested?: boolean;
+    overallStatus?: string;
+    applyResults?: Array<{ status?: string; command?: string }>;
+    checks?: {
+      installHealth?: Array<{ name?: string; status?: string }>;
+    };
+  };
+
+  assert.equal(applyReport.applyRequested, true);
+  assert.ok(["ok", "warning"].includes(String(applyReport.overallStatus)));
+  assert.equal(applyReport.applyResults?.length, 2);
+  assert.deepEqual(
+    applyReport.applyResults?.map((item) => item.status),
+    ["ok", "ok"],
+  );
+  assert.match(String(applyReport.applyResults?.[0]?.command), /SKIP_INSTALL=1 bash \.\/setup/);
+  assert.match(String(applyReport.applyResults?.[1]?.command), /bash scripts\/install-skills\.sh project \$\(pwd\)/);
+
+  const upgradeWrapper = path.join(applyFixtureDir, ".codex-stack", "bin", "upgrade");
+  const projectSkillLink = path.join(applyFixtureDir, ".codex", "skills", "codex-stack-upgrade");
+  assert.ok(fs.existsSync(upgradeWrapper));
+  assert.ok(fs.existsSync(projectSkillLink));
+  assert.equal(
+    fs.realpathSync(projectSkillLink),
+    fs.realpathSync(path.join(applyFixtureDir, "skills", "upgrade")),
+  );
+  assert.equal(
+    applyReport.checks?.installHealth?.find((item) => item.name === "Project skill links")?.status,
+    "ok",
+  );
+
+  const applyMarkdownOutput = execFileSync(bun, ["scripts/upgrade-check.ts", "--offline", "--apply"], {
+    cwd: applyFixtureDir,
+    encoding: "utf8",
+  });
+  assert.match(applyMarkdownOutput, /Apply results/);
+  assert.match(applyMarkdownOutput, /Requested: yes/);
+  assert.match(applyMarkdownOutput, /Local wrapper refresh/);
+  assert.match(applyMarkdownOutput, /Project skill link refresh/);
+} finally {
+  fs.rmSync(applyFixtureDir, { recursive: true, force: true });
+}
 
 console.log("upgrade-check spec passed");

--- a/scripts/upgrade-check.ts
+++ b/scripts/upgrade-check.ts
@@ -2,7 +2,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import process from "node:process";
-import { execSync, type ExecSyncOptionsWithStringEncoding } from "node:child_process";
+import { execSync, spawnSync, type ExecSyncOptionsWithStringEncoding } from "node:child_process";
 
 type CheckStatus = "ok" | "warning" | "error" | "skipped";
 type CheckCategory = "runtime" | "dependencies" | "workflows" | "installHealth";
@@ -17,6 +17,7 @@ interface ParsedArgs {
   markdownOut: string;
   repo: string;
   offline: boolean;
+  apply: boolean;
 }
 
 interface PackageManifest {
@@ -50,10 +51,28 @@ interface UpgradeReport {
   generatedAt: string;
   repo: string;
   offline: boolean;
+  applyRequested: boolean;
+  applyResults: ApplyResult[];
   overallStatus: CheckStatus;
   counts: CheckCounts;
   checks: Record<CheckCategory, CheckItem[]>;
   recommendedActions: string[];
+}
+
+interface ApplyResult {
+  name: string;
+  status: CheckStatus;
+  command: string;
+  detail: string;
+}
+
+interface ApplyStep {
+  name: string;
+  command: string;
+  program: string;
+  args: string[];
+  env?: Record<string, string>;
+  successDetail: string;
 }
 
 interface WorkflowReference {
@@ -71,7 +90,7 @@ function usage(): never {
   console.log(`upgrade-check
 
 Usage:
-  bun scripts/upgrade-check.ts [--json] [--json-out <path>] [--markdown-out <path>] [--repo <owner/name>] [--offline]
+  bun scripts/upgrade-check.ts [--json] [--json-out <path>] [--markdown-out <path>] [--repo <owner/name>] [--offline] [--apply]
 `);
   process.exit(0);
 }
@@ -99,6 +118,7 @@ function parseArgs(argv: string[]): ParsedArgs {
     markdownOut: "",
     repo: "",
     offline: false,
+    apply: false,
   };
   for (let i = 0; i < argv.length; i += 1) {
     const arg = argv[i];
@@ -115,6 +135,8 @@ function parseArgs(argv: string[]): ParsedArgs {
       i += 1;
     } else if (arg === "--offline") {
       args.offline = true;
+    } else if (arg === "--apply") {
+      args.apply = true;
     } else if (arg === "--help" || arg === "-h") {
       usage();
     }
@@ -581,6 +603,56 @@ function collectInstallHealthChecks(modeNames: string[]): CheckItem[] {
   return checks;
 }
 
+function applyLocalRefreshes(): ApplyResult[] {
+  const cwd = process.cwd();
+  const steps: ApplyStep[] = [
+    {
+      name: "Local wrapper refresh",
+      command: "SKIP_INSTALL=1 bash ./setup",
+      program: "bash",
+      args: ["./setup"],
+      env: { SKIP_INSTALL: "1" },
+      successDetail: "Regenerated local codex-stack wrappers without reinstalling dependencies.",
+    },
+    {
+      name: "Project skill link refresh",
+      command: "bash scripts/install-skills.sh project $(pwd)",
+      program: "bash",
+      args: ["scripts/install-skills.sh", "project", cwd],
+      successDetail: "Refreshed project-level Codex skill links under `.codex/skills`.",
+    },
+  ];
+
+  return steps.map((step) => {
+    const result = spawnSync(step.program, step.args, {
+      cwd,
+      env: { ...process.env, ...step.env },
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    if (result.status === 0) {
+      return {
+        name: step.name,
+        status: "ok",
+        command: step.command,
+        detail: step.successDetail,
+      };
+    }
+
+    const errorOutput = [result.stderr, result.stdout]
+      .map((value) => String(value || "").trim())
+      .filter(Boolean)
+      .join(" | ");
+
+    return {
+      name: step.name,
+      status: "error",
+      command: step.command,
+      detail: errorOutput || `${step.command} exited with status ${result.status ?? 1}.`,
+    };
+  });
+}
+
 function flattenChecks(checks: Record<CheckCategory, CheckItem[]>): CheckItem[] {
   return [...checks.runtime, ...checks.dependencies, ...checks.workflows, ...checks.installHealth];
 }
@@ -650,6 +722,19 @@ function renderSection(items: CheckItem[], emptyMessage: string): string {
     .join("\n");
 }
 
+function renderApplySection(report: UpgradeReport): string {
+  if (!report.applyRequested) {
+    return "- Requested: no";
+  }
+  if (!report.applyResults.length) {
+    return "- Requested: yes\n- No apply steps were executed.";
+  }
+  return [
+    "- Requested: yes",
+    ...report.applyResults.map((item) => `- **${statusIcon(item.status)}** ${item.name}: ${item.detail} | command: ${item.command}`),
+  ].join("\n");
+}
+
 function renderMarkdown(report: UpgradeReport): string {
   return `${report.marker}
 # codex-stack daily update check
@@ -676,6 +761,10 @@ ${renderSection(report.checks.workflows, "No workflow checks were generated.")}
 
 ${renderSection(report.checks.installHealth, "No install health checks were generated.")}
 
+## Apply results
+
+${renderApplySection(report)}
+
 ## Recommended actions
 
 ${report.recommendedActions.map((item) => `- ${item}`).join("\n")}
@@ -695,14 +784,22 @@ async function main(): Promise<void> {
     installHealth: collectInstallHealthChecks(modeNames),
   };
 
+  const applyResults = args.apply ? applyLocalRefreshes() : [];
+  if (args.apply) {
+    checks.installHealth = collectInstallHealthChecks(modeNames);
+  }
+
   const allChecks = flattenChecks(checks);
   const counts = countStatuses(allChecks);
+  const reportStatus = applyResults.some((item) => item.status === "error") ? "error" : overallStatus(counts);
   const report: UpgradeReport = {
     marker: "<!-- codex-stack:daily-update-check -->",
     generatedAt: new Date().toISOString(),
     repo,
     offline: args.offline,
-    overallStatus: overallStatus(counts),
+    applyRequested: args.apply,
+    applyResults,
+    overallStatus: reportStatus,
     counts,
     checks,
     recommendedActions: recommendedActions(checks),

--- a/skills/upgrade/SKILL.md
+++ b/skills/upgrade/SKILL.md
@@ -21,7 +21,7 @@ Turn upgrade work into a repeatable audit instead of an ad hoc sweep through pac
 3. Check dependency drift when network access is available.
 4. Check GitHub Actions `uses:` refs for stale majors or exact tags.
 5. Verify local wrapper and installed skill link health.
-6. Report the recommended follow-up commands instead of mutating the repo unless the operator explicitly asks for changes.
+6. If the operator explicitly asks for changes, use `--apply` to run the safe local refresh path.
 7. When operating in CI, publish the markdown report into the step summary or a stable issue.
 
 ## CLI
@@ -29,6 +29,7 @@ Turn upgrade work into a repeatable audit instead of an ad hoc sweep through pac
 ```bash
 bun src/cli.ts upgrade --offline
 bun src/cli.ts upgrade --json
+bun src/cli.ts upgrade --offline --apply
 bun src/cli.ts upgrade --markdown-out docs/daily-update-check.md --json-out docs/daily-update-check.json
 ```
 
@@ -39,10 +40,12 @@ bun src/cli.ts upgrade --markdown-out docs/daily-update-check.md --json-out docs
 - Dependency drift
 - Workflow action drift
 - Install health
+- Apply results
 - Recommended actions
 
 ## Guardrails
 
 - Do not claim a dependency or workflow update exists without current evidence.
 - Treat offline runs as partial audits and mark skipped checks clearly.
-- Do not auto-edit dependency versions or workflow refs unless the user explicitly asks for the upgrade to be applied.
+- `--apply` is limited to safe local refreshes: regenerating `.codex-stack/bin` wrappers and refreshing project skill links under `.codex/skills`.
+- Do not auto-edit dependency versions or workflow refs unless the user explicitly asks for those upgrades and you have current evidence for them.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -24,7 +24,7 @@ Usage:
   codex-stack qa <url> [--flow <name>] [--snapshot <name>] [--update-snapshot] [--session <name>] [--mode <quick|full|regression>] [--json]
   codex-stack ship [--dry-run] [--message <msg>] [--push] [--pr] [--template <path>] [--reviewer <user>] [--team-reviewer <org/team>] [--assignee <user>] [--assign-self] [--project <title>] [--label <name>] [--milestone <title>] [--verify-url <url>] [--verify-flow <name>] [--verify-snapshot <name>] [--verify-session <name>] [--update-verify-snapshot] [--draft]
   codex-stack retro [--since <range>] [--out <path>] [--json] [--artifact-dir <path>] [--no-artifacts] [--repo <owner/name>] [--no-github]
-  codex-stack upgrade [--json] [--json-out <path>] [--markdown-out <path>] [--repo <owner/name>] [--offline]
+  codex-stack upgrade [--json] [--json-out <path>] [--markdown-out <path>] [--repo <owner/name>] [--offline] [--apply]
   codex-stack browse <args...>
 `);
   process.exit(1);


### PR DESCRIPTION
## Summary
- add a safe local `upgrade --apply` path for wrapper and project-skill refreshes
- re-run install health after apply so the report reflects the refreshed state
- cover the apply path with a fixture-backed spec and document the new commands

## Validation
- bun run typecheck
- bun scripts/upgrade-check.spec.ts
- bun run smoke

Closes #7