### PR TITLE
fix: preserve markdown bodies in issue-flow

### DIFF
--- a/scripts/ci-check.sh
+++ b/scripts/ci-check.sh
@@ -66,6 +66,7 @@ test -x .codex-stack/bin/upgrade
 echo "[5/8] review, ship, retro, and demo interfaces"
 run_ts scripts/review-diff.ts --help >/tmp/codex-stack-review-help.log
 run_ts scripts/issue-flow.ts --help >/tmp/codex-stack-issue-flow-help.log
+run_ts scripts/issue-flow.spec.ts >/tmp/codex-stack-issue-flow-spec.log
 run_ts scripts/qa-run.ts --help >/tmp/codex-stack-qa-help.log
 run_ts scripts/preview-verify.ts --help >/tmp/codex-stack-preview-help.log
 run_ts scripts/ship-branch.ts --help >/tmp/codex-stack-ship-help.log
@@ -254,6 +255,7 @@ test -f .github/workflows/daily-update-check.yml
 test -f .github/workflows/preview-verify.yml
 test -f .github/ISSUE_TEMPLATE/work-item.yml
 test -f scripts/issue-flow.ts
+test -f scripts/issue-flow.spec.ts
 test -f scripts/preview-verify.ts
 test -f scripts/preview-verify.spec.ts
 test -f scripts/upgrade-check.ts

--- a/scripts/issue-flow.spec.ts
+++ b/scripts/issue-flow.spec.ts
@@ -1,0 +1,142 @@
+#!/usr/bin/env bun
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import process from "node:process";
+import { execFileSync } from "node:child_process";
+
+const rootDir = process.cwd();
+const bun = process.execPath || "bun";
+const fixtureRoot = fs.mkdtempSync(path.join(os.tmpdir(), "codex-stack-issue-flow-"));
+const fakeBin = path.join(fixtureRoot, "bin");
+const ghPath = path.join(fakeBin, "gh");
+
+function writeFakeGh(): void {
+  fs.mkdirSync(fakeBin, { recursive: true });
+  fs.writeFileSync(ghPath, `#!/usr/bin/env bun
+import fs from "node:fs";
+import process from "node:process";
+
+const capturePath = process.env.ISSUE_FLOW_CAPTURE_FILE || "";
+if (capturePath) {
+  fs.writeFileSync(capturePath, JSON.stringify({ argv: process.argv.slice(2) }, null, 2));
+}
+
+if (process.argv[2] === "issue" && process.argv[3] === "create") {
+  console.log("https://github.com/acme/repo/issues/123");
+  process.exit(0);
+}
+
+if (process.argv[2] === "issue" && process.argv[3] === "view") {
+  console.log("Loaded issue title");
+  process.exit(0);
+}
+
+console.error("unexpected gh invocation");
+process.exit(1);
+`);
+  fs.chmodSync(ghPath, 0o755);
+}
+
+function runIssueFlow(args: string[], captureName: string): { stdout: string; captured: { argv: string[] } } {
+  const capturePath = path.join(fixtureRoot, captureName);
+  const stdout = execFileSync(bun, ["scripts/issue-flow.ts", ...args], {
+    cwd: rootDir,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      PATH: `${fakeBin}${path.delimiter}${process.env.PATH || ""}`,
+      ISSUE_FLOW_CAPTURE_FILE: capturePath,
+    },
+  });
+  return {
+    stdout,
+    captured: JSON.parse(fs.readFileSync(capturePath, "utf8")) as { argv: string[] },
+  };
+}
+
+try {
+  writeFakeGh();
+
+  const markdownBody = [
+    "## Summary",
+    "",
+    "```bash",
+    "echo \"hello\"",
+    "```",
+    "",
+    "Use `codex-stack` here.",
+  ].join("\n");
+
+  const bodyFlag = runIssueFlow([
+    "create",
+    "--repo",
+    "acme/repo",
+    "--title",
+    "Fix issue flow",
+    "--body",
+    markdownBody,
+    "--json",
+  ], "body-flag.json");
+
+  const issueFromBodyFlag = JSON.parse(bodyFlag.stdout) as { issue?: { number?: number } };
+  assert.equal(issueFromBodyFlag.issue?.number, 123);
+  assert.deepEqual(bodyFlag.captured.argv, [
+    "issue",
+    "create",
+    "--repo",
+    "acme/repo",
+    "--title",
+    "Fix issue flow",
+    "--body",
+    markdownBody,
+  ]);
+
+  const markdownFilePath = path.join(fixtureRoot, "issue-body.md");
+  fs.writeFileSync(markdownFilePath, [
+    "# Context",
+    "",
+    "- Preserve backticks like `bun run smoke`",
+    "",
+    "```ts",
+    "console.log(\"ok\");",
+    "```",
+  ].join("\n"));
+
+  const bodyFile = runIssueFlow([
+    "create",
+    "--repo",
+    "acme/repo",
+    "--title",
+    "Fix issue flow from file",
+    "--body-file",
+    markdownFilePath,
+    "--label",
+    "automation",
+    "--assignee",
+    "anup4khandelwal",
+    "--json",
+  ], "body-file.json");
+
+  const issueFromBodyFile = JSON.parse(bodyFile.stdout) as { issue?: { number?: number } };
+  assert.equal(issueFromBodyFile.issue?.number, 123);
+  assert.deepEqual(bodyFile.captured.argv, [
+    "issue",
+    "create",
+    "--repo",
+    "acme/repo",
+    "--title",
+    "Fix issue flow from file",
+    "--body",
+    fs.readFileSync(markdownFilePath, "utf8"),
+    "--label",
+    "automation",
+    "--assignee",
+    "anup4khandelwal",
+  ]);
+
+  console.log("issue-flow spec passed");
+} finally {
+  fs.rmSync(fixtureRoot, { recursive: true, force: true });
+}

--- a/scripts/issue-flow.ts
+++ b/scripts/issue-flow.ts
@@ -1,7 +1,8 @@
 #!/usr/bin/env bun
+import fs from "node:fs";
 import process from "node:process";
 import path from "node:path";
-import { execSync, type ExecSyncOptionsWithStringEncoding } from "node:child_process";
+import { execSync, spawnSync, type ExecSyncOptionsWithStringEncoding } from "node:child_process";
 
 interface RunOptions extends Partial<ExecSyncOptionsWithStringEncoding> {
   allowFailure?: boolean;
@@ -84,6 +85,18 @@ function run(cmd: string, options: RunOptions = {}): string {
     const message = error instanceof Error ? error.message : String(error);
     throw new Error(clean(stderr || message));
   }
+}
+
+function runArgs(program: string, args: string[]): string {
+  const result = spawnSync(program, args, {
+    cwd: process.cwd(),
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  if ((result.status ?? 1) !== 0) {
+    throw new Error(clean(result.stderr || result.stdout || `${program} exited with status ${result.status ?? 1}`));
+  }
+  return clean(result.stdout || "");
 }
 
 function uniq(items: string[]): string[] {
@@ -207,7 +220,7 @@ function parseArgs(argv: string[]): ParsedArgs {
 
 function loadBody(args: ParsedArgs): string {
   if (args.bodyFile) {
-    return run(`cat ${quote(path.resolve(process.cwd(), args.bodyFile))}`);
+    return fs.readFileSync(path.resolve(process.cwd(), args.bodyFile), "utf8");
   }
   return args.body;
 }
@@ -221,17 +234,20 @@ function createIssue(args: ParsedArgs): IssueRecord {
   }
 
   const body = loadBody(args);
-  const cmd = [
-    "gh issue create",
-    `--repo ${quote(args.repo)}`,
-    `--title ${quote(args.title)}`,
+  const ghArgs = [
+    "issue",
+    "create",
+    "--repo",
+    args.repo,
+    "--title",
+    args.title,
   ];
-  if (body) cmd.push(`--body ${quote(body)}`);
-  for (const label of args.labels) cmd.push(`--label ${quote(label)}`);
-  for (const assignee of args.assignees) cmd.push(`--assignee ${quote(assignee)}`);
-  if (args.milestone) cmd.push(`--milestone ${quote(args.milestone)}`);
+  if (body) ghArgs.push("--body", body);
+  for (const label of args.labels) ghArgs.push("--label", label);
+  for (const assignee of args.assignees) ghArgs.push("--assignee", assignee);
+  if (args.milestone) ghArgs.push("--milestone", args.milestone);
 
-  const issueUrl = clean(run(cmd.join(" ")));
+  const issueUrl = clean(runArgs("gh", ghArgs));
   const issueNumber = parseUrlIssue(issueUrl);
   return {
     repo: args.repo,
@@ -246,7 +262,7 @@ function issueTitle(repo: string, issueNumber: number, fallbackTitle: string): s
   if (!repo || !issueNumber) {
     throw new Error("Issue title is required when repo lookup is unavailable.");
   }
-  const title = clean(run(`gh issue view ${quote(String(issueNumber))} --repo ${quote(repo)} --json title --jq .title`));
+  const title = clean(runArgs("gh", ["issue", "view", String(issueNumber), "--repo", repo, "--json", "title", "--jq", ".title"]));
   if (!title) {
     throw new Error(`Unable to load title for issue #${issueNumber}.`);
   }


### PR DESCRIPTION
## Summary
- stop building `gh issue create` as a shell string in `issue-flow.ts`
- pass `--body` and `--body-file` content to GitHub CLI via argv so markdown is preserved exactly
- add a stubbed `gh` spec and wire it into smoke coverage

## Validation
- bun run typecheck
- bun scripts/issue-flow.spec.ts
- bun run smoke

Closes #11