### PR TITLE
feat: surface preview QA in PR review

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -33,8 +33,53 @@ jobs:
       - name: Run codex-stack review
         run: bun scripts/review-diff.ts --json --base "origin/${{ github.event.pull_request.base.ref }}" > review.json
 
+      - name: Run preview verification for review evidence
+        if: vars.CODEX_STACK_PREVIEW_URL_TEMPLATE != ''
+        env:
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_SERVER_URL: ${{ github.server_url }}
+          GITHUB_RUN_ID: ${{ github.run_id }}
+          GITHUB_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          GITHUB_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          CODEX_STACK_PREVIEW_URL_TEMPLATE: ${{ vars.CODEX_STACK_PREVIEW_URL_TEMPLATE }}
+          CODEX_STACK_PREVIEW_FLOW: ${{ vars.CODEX_STACK_PREVIEW_FLOW }}
+          CODEX_STACK_PREVIEW_SNAPSHOT: ${{ vars.CODEX_STACK_PREVIEW_SNAPSHOT }}
+        run: |
+          set -euo pipefail
+          args=(
+            "--repo" "${GITHUB_REPOSITORY}"
+            "--branch" "${GITHUB_HEAD_REF}"
+            "--sha" "${GITHUB_SHA}"
+            "--pr" "${PR_NUMBER}"
+            "--url-template" "${CODEX_STACK_PREVIEW_URL_TEMPLATE}"
+            "--publish-dir" "preview-artifacts"
+            "--markdown-out" "preview.md"
+            "--json-out" "preview.json"
+            "--comment-out" "preview-comment.md"
+          )
+
+          if [ -n "${CODEX_STACK_PREVIEW_FLOW}" ]; then
+            args+=("--flow" "${CODEX_STACK_PREVIEW_FLOW}")
+          fi
+          if [ -n "${CODEX_STACK_PREVIEW_SNAPSHOT}" ]; then
+            args+=("--snapshot" "${CODEX_STACK_PREVIEW_SNAPSHOT}")
+          fi
+
+          bun scripts/preview-verify.ts "${args[@]}"
+
       - name: Render review outputs
-        run: bun scripts/render-pr-review.ts --input review.json --markdown-out review.md --summary-out review-summary.json
+        run: |
+          set -euo pipefail
+          args=(
+            "--input" "review.json"
+            "--markdown-out" "review.md"
+            "--summary-out" "review-summary.json"
+          )
+          if [ -f preview.json ]; then
+            args+=("--preview-input" "preview.json")
+          fi
+          bun scripts/render-pr-review.ts "${args[@]}"
 
       - name: Add step summary
         run: cat review.md >> "$GITHUB_STEP_SUMMARY"
@@ -73,4 +118,13 @@ jobs:
             }
 
       - name: Fail on critical findings
-        run: bun scripts/render-pr-review.ts --input review.json --fail-on-critical >/tmp/codex-stack-pr-review.md
+        run: |
+          set -euo pipefail
+          args=(
+            "--input" "review.json"
+            "--fail-on-critical"
+          )
+          if [ -f preview.json ]; then
+            args+=("--preview-input" "preview.json")
+          fi
+          bun scripts/render-pr-review.ts "${args[@]}" >/tmp/codex-stack-pr-review.md

--- a/README.md
+++ b/README.md
@@ -145,8 +145,9 @@ bun src/cli.ts ship --message "feat: add issue-first workflow" --push --pr
 What happens next:
 
 - `pr-review.yml` runs `codex-stack` review on the PR diff
-- the workflow posts or updates a PR comment with findings
-- the job fails if critical findings are detected
+- when `CODEX_STACK_PREVIEW_URL_TEMPLATE` is configured, the same review workflow also runs preview QA and folds the visual evidence into the PR review comment
+- the workflow posts or updates a PR comment with structural findings plus any preview QA evidence
+- the job fails if critical findings are detected in either structural review or preview QA
 - if the PR has the `automerge` label, `pr-automerge.yml` enables GitHub auto-merge
 
 Branch naming matters: when the branch follows `<prefix>/<issue-number>-slug`, `ship` includes `Closes #<issue-number>` in the generated PR body so the issue closes on merge.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -61,12 +61,14 @@ bun scripts/review-diff.ts
 bun scripts/review-diff.ts --json
 bun scripts/review-diff.ts --base origin/main
 bun scripts/render-pr-review.ts --input review.json --markdown-out review.md --summary-out review-summary.json
+bun scripts/render-pr-review.ts --input review.json --preview-input preview.json --markdown-out review.md --summary-out review-summary.json
 ```
 
 Notes:
 
 - `pr-review.yml` uses `review-diff.ts` plus `render-pr-review.ts` to comment on every PR.
-- The review workflow fails when critical findings are present.
+- When `CODEX_STACK_PREVIEW_URL_TEMPLATE` is configured, `pr-review.yml` also runs `preview-verify.ts` and merges the preview QA evidence into the review comment.
+- The review workflow fails when critical findings are present in either structural review or preview QA.
 
 ## Issue workflow
 

--- a/scripts/ci-check.sh
+++ b/scripts/ci-check.sh
@@ -69,6 +69,7 @@ echo "[5/8] review, ship, retro, and demo interfaces"
 run_ts scripts/review-diff.ts --help >/tmp/codex-stack-review-help.log
 run_ts scripts/issue-flow.ts --help >/tmp/codex-stack-issue-flow-help.log
 run_ts scripts/issue-flow.spec.ts >/tmp/codex-stack-issue-flow-spec.log
+run_ts scripts/render-pr-review.spec.ts >/tmp/codex-stack-render-pr-review-spec.log
 run_ts scripts/qa-diff.spec.ts >/tmp/codex-stack-qa-diff-spec.log
 run_ts scripts/qa-run.ts --help >/tmp/codex-stack-qa-help.log
 run_ts scripts/qa-run.spec.ts >/tmp/codex-stack-qa-spec.log

--- a/scripts/render-pr-review.spec.ts
+++ b/scripts/render-pr-review.spec.ts
@@ -1,0 +1,133 @@
+#!/usr/bin/env bun
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import process from "node:process";
+import { execFileSync, spawnSync } from "node:child_process";
+
+const rootDir = process.cwd();
+const bun = process.execPath || "bun";
+const fixtureRoot = fs.mkdtempSync(path.join(os.tmpdir(), "codex-stack-render-pr-review-"));
+
+async function main(): Promise<void> {
+  const reviewPath = path.join(fixtureRoot, "review.json");
+  const previewPath = path.join(fixtureRoot, "preview.json");
+  const markdownOut = path.join(fixtureRoot, "review.md");
+  const summaryOut = path.join(fixtureRoot, "summary.json");
+
+  fs.writeFileSync(reviewPath, JSON.stringify({
+    status: "ok",
+    branch: "feat/23-pr-review-preview-evidence",
+    baseRef: "origin/main",
+    fileNames: ["scripts/render-pr-review.ts", ".github/workflows/pr-review.yml"],
+    findings: [
+      {
+        severity: "warning",
+        title: "Large review surface",
+        detail: "The diff is broad.",
+        files: ["scripts/render-pr-review.ts"],
+      },
+    ],
+  }, null, 2));
+
+  fs.writeFileSync(previewPath, JSON.stringify({
+    status: "critical",
+    url: "https://preview-23.example.com",
+    runUrl: "https://github.com/anup4khandelwal/codex-stack/actions/runs/123456",
+    recommendation: "Do not merge until the preview is fixed.",
+    readiness: {
+      status: "ready",
+      attempts: 2,
+      httpStatus: 200,
+    },
+    qa: {
+      healthScore: 60,
+      findings: [
+        {
+          severity: "critical",
+          category: "visual",
+          title: "Expected UI selectors are missing",
+          detail: "The preview no longer renders the dashboard heading.",
+        },
+      ],
+      artifacts: {
+        published: {
+          markdown: "preview-artifacts/report.md",
+          annotation: "preview-artifacts/annotation.svg",
+          screenshot: "preview-artifacts/screenshot.png",
+        },
+      },
+      snapshotResult: {
+        name: "dashboard",
+        status: "changed",
+        annotation: "preview-artifacts/annotation.svg",
+        screenshot: "preview-artifacts/screenshot.png",
+      },
+    },
+  }, null, 2));
+
+  const stdout = execFileSync(
+    bun,
+    [
+      path.join(rootDir, "scripts", "render-pr-review.ts"),
+      "--input",
+      reviewPath,
+      "--preview-input",
+      previewPath,
+      "--markdown-out",
+      markdownOut,
+      "--summary-out",
+      summaryOut,
+    ],
+    {
+      cwd: rootDir,
+      encoding: "utf8",
+    },
+  );
+
+  assert.match(stdout, /codex-stack PR review/);
+  assert.match(stdout, /## Preview QA/);
+  assert.match(stdout, /Preview URL: https:\/\/preview-23\.example\.com/);
+  assert.match(stdout, /Workflow run: https:\/\/github\.com\/anup4khandelwal\/codex-stack\/actions\/runs\/123456/);
+  assert.match(stdout, /CRITICAL\/VISUAL/);
+  assert.match(stdout, /annotation\.svg/);
+  assert.ok(fs.existsSync(markdownOut));
+  assert.ok(fs.existsSync(summaryOut));
+
+  const summary = JSON.parse(fs.readFileSync(summaryOut, "utf8")) as {
+    blocking?: boolean;
+    previewIncluded?: boolean;
+    previewBlocking?: boolean;
+    previewStatus?: string;
+  };
+  assert.equal(summary.previewIncluded, true);
+  assert.equal(summary.previewBlocking, true);
+  assert.equal(summary.previewStatus, "critical");
+  assert.equal(summary.blocking, true);
+
+  const failed = spawnSync(
+    bun,
+    [
+      path.join(rootDir, "scripts", "render-pr-review.ts"),
+      "--input",
+      reviewPath,
+      "--preview-input",
+      previewPath,
+      "--fail-on-critical",
+    ],
+    {
+      cwd: rootDir,
+      encoding: "utf8",
+    },
+  );
+  assert.equal(failed.status, 2);
+
+  console.log("render-pr-review spec passed");
+}
+
+try {
+  await main();
+} finally {
+  fs.rmSync(fixtureRoot, { recursive: true, force: true });
+}

--- a/scripts/render-pr-review.ts
+++ b/scripts/render-pr-review.ts
@@ -18,6 +18,47 @@ interface ReviewReport {
   findings?: ReviewFinding[];
 }
 
+interface PreviewFinding {
+  severity?: string;
+  category?: string;
+  title?: string;
+  detail?: string;
+}
+
+interface PreviewQaReport {
+  status?: string;
+  healthScore?: number;
+  recommendation?: string;
+  findings?: PreviewFinding[];
+  snapshotResult?: {
+    name?: string;
+    status?: string;
+    screenshot?: string;
+    annotation?: string;
+  };
+  artifacts?: {
+    published?: {
+      markdown?: string;
+      json?: string;
+      annotation?: string;
+      screenshot?: string;
+    };
+  };
+}
+
+interface PreviewReport {
+  status?: string;
+  url?: string;
+  runUrl?: string;
+  recommendation?: string;
+  readiness?: {
+    status?: string;
+    attempts?: number;
+    httpStatus?: number | null;
+  };
+  qa?: PreviewQaReport;
+}
+
 interface ReviewSummary {
   status: string;
   branch: string;
@@ -27,10 +68,14 @@ interface ReviewSummary {
   warningCount: number;
   infoCount: number;
   blocking?: boolean;
+  previewIncluded?: boolean;
+  previewStatus?: string;
+  previewBlocking?: boolean;
 }
 
 interface ParsedArgs {
   input: string;
+  previewInput: string;
   markdownOut: string;
   summaryOut: string;
   failOnCritical: boolean;
@@ -41,7 +86,7 @@ function usage(): never {
   console.log(`render-pr-review
 
 Usage:
-  bun scripts/render-pr-review.ts --input <review.json> [--markdown-out <path>] [--summary-out <path>] [--fail-on-critical] [--json]
+  bun scripts/render-pr-review.ts --input <review.json> [--preview-input <preview.json>] [--markdown-out <path>] [--summary-out <path>] [--fail-on-critical] [--json]
 `);
   process.exit(0);
 }
@@ -49,6 +94,7 @@ Usage:
 function parseArgs(argv: string[]): ParsedArgs {
   const out: ParsedArgs = {
     input: "",
+    previewInput: "",
     markdownOut: "",
     summaryOut: "",
     failOnCritical: false,
@@ -58,6 +104,9 @@ function parseArgs(argv: string[]): ParsedArgs {
     const arg = argv[i];
     if (arg === "--input") {
       out.input = argv[i + 1] || "";
+      i += 1;
+    } else if (arg === "--preview-input") {
+      out.previewInput = argv[i + 1] || "";
       i += 1;
     } else if (arg === "--markdown-out") {
       out.markdownOut = argv[i + 1] || "";
@@ -87,6 +136,10 @@ function readJson(filePath: string): ReviewReport {
   return JSON.parse(fs.readFileSync(path.resolve(process.cwd(), filePath), "utf8")) as ReviewReport;
 }
 
+function readPreviewJson(filePath: string): PreviewReport {
+  return JSON.parse(fs.readFileSync(path.resolve(process.cwd(), filePath), "utf8")) as PreviewReport;
+}
+
 function countBySeverity(findings: ReviewFinding[], severity: string): number {
   return findings.filter((item) => item.severity === severity).length;
 }
@@ -99,7 +152,42 @@ function findingLines(findings: ReviewFinding[]): string[] {
   });
 }
 
-function renderMarkdown(review: ReviewReport, summary: ReviewSummary): string {
+function previewFindingLines(findings: PreviewFinding[]): string[] {
+  if (!findings.length) return ["- No preview findings."];
+  return findings.slice(0, 6).map((item) => {
+    const label = `${String(item.severity || "info").toUpperCase()}${item.category ? `/${String(item.category).toUpperCase()}` : ""}`;
+    return `- **${label}** ${item.title || "Finding"}${item.detail ? `: ${item.detail}` : ""}`;
+  });
+}
+
+function renderPreviewSection(preview: PreviewReport | null, summary: ReviewSummary): string {
+  if (!preview) return "";
+  const findings = Array.isArray(preview.qa?.findings) ? preview.qa?.findings : [];
+  const published = preview.qa?.artifacts?.published || {};
+  const snapshot = preview.qa?.snapshotResult;
+  return `
+## Preview QA
+
+- Included: yes
+- Status: ${preview.status || "unknown"}
+- Readiness: ${preview.readiness?.status || "unknown"}${preview.readiness?.attempts ? ` after ${preview.readiness.attempts} attempt(s)` : ""}
+- Health score: ${preview.qa?.healthScore ?? "n/a"}
+- Block merge: ${summary.previewBlocking ? "yes" : "no"}
+- Recommendation: ${preview.recommendation || preview.qa?.recommendation || "n/a"}
+${preview.url ? `- Preview URL: ${preview.url}` : ""}
+${preview.runUrl ? `- Workflow run: ${preview.runUrl}` : ""}
+${published.markdown ? `- QA report: \`${published.markdown}\`` : ""}
+${published.annotation ? `- Annotation: \`${published.annotation}\`` : ""}
+${published.screenshot ? `- Screenshot: \`${published.screenshot}\`` : ""}
+${snapshot?.status ? `- Snapshot: ${snapshot.status}${snapshot.name ? ` (${snapshot.name})` : ""}` : ""}
+
+### Preview findings
+
+${previewFindingLines(findings).join("\n")}
+`;
+}
+
+function renderMarkdown(review: ReviewReport, summary: ReviewSummary, preview: PreviewReport | null): string {
   return `<!-- codex-stack:pr-review -->
 # codex-stack PR review
 
@@ -114,11 +202,12 @@ function renderMarkdown(review: ReviewReport, summary: ReviewSummary): string {
 ## Findings
 
 ${findingLines(review.findings ?? []).join("\n")}
-`;
+${renderPreviewSection(preview, summary)}`;
 }
 
 const args = parseArgs(process.argv.slice(2));
 const review = readJson(args.input);
+const preview = args.previewInput ? readPreviewJson(args.previewInput) : null;
 const findings: ReviewFinding[] = Array.isArray(review.findings) ? review.findings : [];
 const summary: ReviewSummary = {
   status: review.status || "ok",
@@ -129,8 +218,11 @@ const summary: ReviewSummary = {
   warningCount: countBySeverity(findings, "warning"),
   infoCount: countBySeverity(findings, "info"),
 };
-summary.blocking = summary.criticalCount > 0;
-const markdown = renderMarkdown(review, summary);
+summary.previewIncluded = Boolean(preview);
+summary.previewStatus = preview?.status || "";
+summary.previewBlocking = ["critical", "error"].includes(String(preview?.status || "").toLowerCase());
+summary.blocking = summary.criticalCount > 0 || summary.previewBlocking;
+const markdown = renderMarkdown(review, summary, preview);
 
 if (args.markdownOut) {
   const target = path.resolve(process.cwd(), args.markdownOut);


### PR DESCRIPTION
## Summary
- let `pr-review` optionally run preview verification when preview configuration exists
- merge preview QA status, recommendation, and artifact references into the main PR review comment
- block the review gate on critical preview status and add regression coverage for the combined renderer

## Validation
- bun run typecheck
- bun run smoke
- bun src/cli.ts review --json

Closes #23