### PR TITLE
feat: add advanced browser actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Use the repo in this order:
 
 - Installable Codex skills under `skills/`
 - Checked-in root CLI under `src/cli.ts`
-- Playwright-backed browser runtime under `browse/src/cli.ts`
+- Playwright-backed browser runtime under `browse/src/cli.ts` with upload, dialog, wait-state, and element-state assertions
 - Persistent named browser sessions
 - Portable session import/export with cookie and storage-state bundles
 - Checked-in and local browser flows with import/export for JSON, YAML, and Markdown
@@ -171,6 +171,9 @@ bun src/cli.ts browse flows
 bun src/cli.ts browse export-session ./tmp/staging-session.json --session staging
 bun src/cli.ts browse import-session ./tmp/staging-session.json --session staging-copy
 bun src/cli.ts browse probe https://example.com/settings --session staging
+bun src/cli.ts browse upload https://example.com/profile "input[type=file]" ./fixtures/avatar.png --session staging
+bun src/cli.ts browse dialog https://example.com/settings accept "#delete-confirm" --session staging
+bun src/cli.ts browse assert-focused https://example.com/login "input[name=email]" --session staging
 bun src/cli.ts browse snapshot https://example.com marketing-home --session staging
 bun src/cli.ts browse compare-snapshot https://example.com marketing-home --session staging
 ```

--- a/browse/src/cli.ts
+++ b/browse/src/cli.ts
@@ -134,6 +134,9 @@ interface ProbeResult {
   bodyLength: number;
 }
 
+type WaitState = "visible" | "hidden" | "attached" | "detached";
+type LoadState = "load" | "domcontentloaded" | "networkidle" | "commit";
+
 const ROOT_DIR = path.resolve(process.cwd(), ".codex-stack");
 const STATE_DIR = path.join(ROOT_DIR, "browse");
 const STATE_PATH = path.join(STATE_DIR, "state.json");
@@ -172,9 +175,17 @@ Usage:
   codex-stack browse eval <url> <expression> [--session <name>]
   codex-stack browse click <url> <selector> [--session <name>]
   codex-stack browse fill <url> <selector> <value> [--session <name>]
-  codex-stack browse wait <url> [selector|ms:<n>|url:<target>] [--session <name>]
+  codex-stack browse upload <url> <selector> <path> [--session <name>]
+  codex-stack browse dialog <url> <accept|dismiss> [selector] [prompt] [--session <name>]
+  codex-stack browse wait <url> [selector|ms:<n>|url:<target>|load:<state>|state:<state>:<selector>] [--session <name>]
   codex-stack browse press <url> <selector> <key> [--session <name>]
   codex-stack browse assert-visible <url> <selector> [--session <name>]
+  codex-stack browse assert-hidden <url> <selector> [--session <name>]
+  codex-stack browse assert-enabled <url> <selector> [--session <name>]
+  codex-stack browse assert-disabled <url> <selector> [--session <name>]
+  codex-stack browse assert-checked <url> <selector> [--session <name>]
+  codex-stack browse assert-editable <url> <selector> [--session <name>]
+  codex-stack browse assert-focused <url> <selector> [--session <name>]
   codex-stack browse assert-text <url> <selector> <expected> [--session <name>]
   codex-stack browse assert-url <url> <expected> [--session <name>]
   codex-stack browse assert-count <url> <selector> <expected-count> [--session <name>]
@@ -904,9 +915,74 @@ function assertCondition(condition: unknown, message: string): asserts condition
   }
 }
 
+function parseWaitState(value: unknown, fallback: WaitState = "visible"): WaitState {
+  const normalized = String(value || fallback).toLowerCase();
+  if (normalized === "hidden" || normalized === "attached" || normalized === "detached") return normalized;
+  return "visible";
+}
+
+function parseLoadState(value: unknown, fallback: LoadState = "networkidle"): LoadState {
+  const normalized = String(value || fallback).toLowerCase();
+  if (normalized === "load" || normalized === "domcontentloaded" || normalized === "commit") return normalized;
+  return "networkidle";
+}
+
+async function armDialog(
+  page: PlaywrightPage,
+  mode: string,
+  promptText = "",
+): Promise<{ mode: "accept" | "dismiss"; promptText: string }> {
+  const normalizedMode: "accept" | "dismiss" = String(mode || "accept").toLowerCase() === "dismiss" ? "dismiss" : "accept";
+  page.once("dialog", async (dialog: Record<string, unknown>) => {
+    if (normalizedMode === "dismiss") {
+      await (dialog.dismiss as () => Promise<void>)();
+    } else {
+      await (dialog.accept as (value?: string) => Promise<void>)(promptText || undefined);
+    }
+  });
+  return {
+    mode: normalizedMode,
+    promptText,
+  };
+}
+
+async function assertLocatorState(page: PlaywrightPage, selector: string, state: string): Promise<void> {
+  const locator = page.locator(selector).first();
+  if (state === "visible") {
+    await locator.waitFor({ state: "visible" });
+    return;
+  }
+  if (state === "hidden") {
+    await locator.waitFor({ state: "hidden" });
+    return;
+  }
+  if (state === "enabled") {
+    assertCondition(await locator.isEnabled(), `Expected ${selector} to be enabled.`);
+    return;
+  }
+  if (state === "disabled") {
+    assertCondition(await locator.isDisabled(), `Expected ${selector} to be disabled.`);
+    return;
+  }
+  if (state === "checked") {
+    assertCondition(await locator.isChecked(), `Expected ${selector} to be checked.`);
+    return;
+  }
+  if (state === "editable") {
+    assertCondition(await locator.isEditable(), `Expected ${selector} to be editable.`);
+    return;
+  }
+  if (state === "focused") {
+    const isFocused = await locator.evaluate((element: Element) => element === document.activeElement);
+    assertCondition(isFocused, `Expected ${selector} to be focused.`);
+    return;
+  }
+  throw new Error(`Unsupported assertion state: ${state}`);
+}
+
 async function loadPlaywright(): Promise<PlaywrightModule | null> {
   try {
-    const mod = await import("playwright");
+    const mod = await import(process.env.CODEX_STACK_PLAYWRIGHT_MODULE || "playwright");
     return mod;
   } catch {
     return null;
@@ -975,14 +1051,33 @@ async function runStep(page: PlaywrightPage, step: FlowStep, sessionName: string
     await page.locator(String(step.selector)).first().fill(String(step.value || ""));
     return { action, selector: step.selector, status: "ok" };
   }
+  if (action === "upload") {
+    const selector = String(step.selector || "");
+    const files = Array.isArray(step.files)
+      ? step.files.map((item) => String(item))
+      : [String(step.path ?? step.value ?? "")].filter(Boolean);
+    assertCondition(selector, "upload steps require a selector.");
+    assertCondition(files.length > 0, "upload steps require a file path.");
+    await page.locator(selector).first().setInputFiles(files.length === 1 ? files[0] : files);
+    return { action, selector, files, status: "ok" };
+  }
+  if (action === "dialog") {
+    const dialog = await armDialog(page, String(step.mode ?? step.value ?? "accept"), String(step.prompt ?? ""));
+    const selector = String(step.selector || "");
+    if (selector) {
+      await page.locator(selector).first().click();
+    }
+    return { action, selector, mode: dialog.mode, promptText: dialog.promptText, status: "ok" };
+  }
   if (action === "press") {
     await page.locator(String(step.selector)).first().press(String(step.key || "Enter"));
     return { action, selector: step.selector, key: step.key || "Enter", status: "ok" };
   }
   if (action === "wait") {
     if (step.selector) {
-      await page.locator(String(step.selector)).first().waitFor({ state: "visible" });
-      return { action, selector: step.selector, status: "ok" };
+      const state = parseWaitState(step.state);
+      await page.locator(String(step.selector)).first().waitFor({ state });
+      return { action, selector: step.selector, state, status: "ok" };
     }
     if (step.url) {
       await page.waitForURL(String(step.url));
@@ -992,8 +1087,8 @@ async function runStep(page: PlaywrightPage, step: FlowStep, sessionName: string
       await page.waitForTimeout(step.ms);
       return { action, ms: step.ms, status: "ok" };
     }
-    await page.waitForLoadState("networkidle");
-    return { action, status: "ok" };
+    await page.waitForLoadState(parseLoadState(step.loadState));
+    return { action, loadState: parseLoadState(step.loadState), status: "ok" };
   }
   if (action === "screenshot") {
     const target = String(step.path || path.join(os.tmpdir(), `codex-stack-flow-${sessionName}.png`));
@@ -1012,7 +1107,37 @@ async function runStep(page: PlaywrightPage, step: FlowStep, sessionName: string
   }
   if (action === "assert-visible") {
     const selector = String(step.selector || "");
-    await page.locator(selector).first().waitFor({ state: "visible" });
+    await assertLocatorState(page, selector, "visible");
+    return { action, selector, status: "ok" };
+  }
+  if (action === "assert-hidden") {
+    const selector = String(step.selector || "");
+    await assertLocatorState(page, selector, "hidden");
+    return { action, selector, status: "ok" };
+  }
+  if (action === "assert-enabled") {
+    const selector = String(step.selector || "");
+    await assertLocatorState(page, selector, "enabled");
+    return { action, selector, status: "ok" };
+  }
+  if (action === "assert-disabled") {
+    const selector = String(step.selector || "");
+    await assertLocatorState(page, selector, "disabled");
+    return { action, selector, status: "ok" };
+  }
+  if (action === "assert-checked") {
+    const selector = String(step.selector || "");
+    await assertLocatorState(page, selector, "checked");
+    return { action, selector, status: "ok" };
+  }
+  if (action === "assert-editable") {
+    const selector = String(step.selector || "");
+    await assertLocatorState(page, selector, "editable");
+    return { action, selector, status: "ok" };
+  }
+  if (action === "assert-focused") {
+    const selector = String(step.selector || "");
+    await assertLocatorState(page, selector, "focused");
     return { action, selector, status: "ok" };
   }
   if (action === "assert-text") {
@@ -1123,7 +1248,7 @@ async function main(): Promise<void> {
     console.log(`- snapshot root: ${SNAPSHOT_DIR}`);
     console.log(`- artifact root: ${ARTIFACT_DIR}`);
     console.log("- session model: persistent browser profile per named session");
-    console.log("- commands: sessions, flows, save-flow, save-repo-flow, import-flow, import-repo-flow, export-flow, show-flow, delete-flow, clear-session, export-session, import-session, import-cookies, snapshot, compare-snapshot, probe, text, html, links, screenshot, eval, click, fill, wait, press, assert-visible, assert-text, assert-url, assert-count, flow, run-flow, login");
+    console.log("- commands: sessions, flows, save-flow, save-repo-flow, import-flow, import-repo-flow, export-flow, show-flow, delete-flow, clear-session, export-session, import-session, import-cookies, snapshot, compare-snapshot, probe, text, html, links, screenshot, eval, click, fill, upload, dialog, wait, press, assert-visible, assert-hidden, assert-enabled, assert-disabled, assert-checked, assert-editable, assert-focused, assert-text, assert-url, assert-count, flow, run-flow, login");
     console.log(`- repo flow root: ${REPO_FLOW_DIR}`);
     console.log("- flow search order: local .codex-stack flow overrides checked-in repo flow with the same name");
     console.log("- interchange formats: json, yaml, markdown (fenced yaml/json)");
@@ -1434,6 +1559,34 @@ async function main(): Promise<void> {
     return;
   }
 
+  if (command === "upload") {
+    const [url, selector, filePath] = rest;
+    if (!url || !selector || !filePath) usage();
+    const absolute = path.resolve(process.cwd(), filePath);
+    assertCondition(fs.existsSync(absolute), `Upload file not found: ${absolute}`);
+    await withPage(session, url, async ({ page }: { page: PlaywrightPage }) => {
+      await page.locator(selector).first().setInputFiles(absolute);
+    });
+    recordSession(session, { lastCommand: "upload", lastUrl: url, output: `${selector}:${absolute}` });
+    console.log(`uploaded ${absolute} into ${selector}`);
+    return;
+  }
+
+  if (command === "dialog") {
+    const [url, modeRaw, selector, promptText] = rest;
+    if (!url || !modeRaw) usage();
+    const mode = String(modeRaw || "accept").toLowerCase() === "dismiss" ? "dismiss" : "accept";
+    await withPage(session, url, async ({ page }: { page: PlaywrightPage }) => {
+      await armDialog(page, mode, promptText || "");
+      if (selector) {
+        await page.locator(selector).first().click();
+      }
+    });
+    recordSession(session, { lastCommand: "dialog", lastUrl: url, output: `${mode}${selector ? `:${selector}` : ""}` });
+    console.log(`${mode}ed dialog${selector ? ` via ${selector}` : ""}`);
+    return;
+  }
+
   if (command === "wait") {
     const [url, target] = rest;
     if (!url) usage();
@@ -1448,6 +1601,17 @@ async function main(): Promise<void> {
       }
       if (target.startsWith("url:")) {
         await page.waitForURL(target.slice(4));
+        return;
+      }
+      if (target.startsWith("load:")) {
+        await page.waitForLoadState(parseLoadState(target.slice(5)));
+        return;
+      }
+      if (target.startsWith("state:")) {
+        const [, stateRaw = "visible", ...selectorParts] = target.split(":");
+        const selector = selectorParts.join(":");
+        assertCondition(selector, "state waits require a selector. Use state:<state>:<selector>.");
+        await page.locator(selector).first().waitFor({ state: parseWaitState(stateRaw) });
         return;
       }
       await page.locator(target).first().waitFor({ state: "visible" });
@@ -1472,10 +1636,76 @@ async function main(): Promise<void> {
     const [url, selector] = rest;
     if (!url || !selector) usage();
     await withPage(session, url, async ({ page }: { page: PlaywrightPage }) => {
-      await page.locator(selector).first().waitFor({ state: "visible" });
+      await assertLocatorState(page, selector, "visible");
     });
     recordSession(session, { lastCommand: "assert-visible", lastUrl: url, output: selector });
     console.log(`asserted visible ${selector}`);
+    return;
+  }
+
+  if (command === "assert-hidden") {
+    const [url, selector] = rest;
+    if (!url || !selector) usage();
+    await withPage(session, url, async ({ page }: { page: PlaywrightPage }) => {
+      await assertLocatorState(page, selector, "hidden");
+    });
+    recordSession(session, { lastCommand: "assert-hidden", lastUrl: url, output: selector });
+    console.log(`asserted hidden ${selector}`);
+    return;
+  }
+
+  if (command === "assert-enabled") {
+    const [url, selector] = rest;
+    if (!url || !selector) usage();
+    await withPage(session, url, async ({ page }: { page: PlaywrightPage }) => {
+      await assertLocatorState(page, selector, "enabled");
+    });
+    recordSession(session, { lastCommand: "assert-enabled", lastUrl: url, output: selector });
+    console.log(`asserted enabled ${selector}`);
+    return;
+  }
+
+  if (command === "assert-disabled") {
+    const [url, selector] = rest;
+    if (!url || !selector) usage();
+    await withPage(session, url, async ({ page }: { page: PlaywrightPage }) => {
+      await assertLocatorState(page, selector, "disabled");
+    });
+    recordSession(session, { lastCommand: "assert-disabled", lastUrl: url, output: selector });
+    console.log(`asserted disabled ${selector}`);
+    return;
+  }
+
+  if (command === "assert-checked") {
+    const [url, selector] = rest;
+    if (!url || !selector) usage();
+    await withPage(session, url, async ({ page }: { page: PlaywrightPage }) => {
+      await assertLocatorState(page, selector, "checked");
+    });
+    recordSession(session, { lastCommand: "assert-checked", lastUrl: url, output: selector });
+    console.log(`asserted checked ${selector}`);
+    return;
+  }
+
+  if (command === "assert-editable") {
+    const [url, selector] = rest;
+    if (!url || !selector) usage();
+    await withPage(session, url, async ({ page }: { page: PlaywrightPage }) => {
+      await assertLocatorState(page, selector, "editable");
+    });
+    recordSession(session, { lastCommand: "assert-editable", lastUrl: url, output: selector });
+    console.log(`asserted editable ${selector}`);
+    return;
+  }
+
+  if (command === "assert-focused") {
+    const [url, selector] = rest;
+    if (!url || !selector) usage();
+    await withPage(session, url, async ({ page }: { page: PlaywrightPage }) => {
+      await assertLocatorState(page, selector, "focused");
+    });
+    recordSession(session, { lastCommand: "assert-focused", lastUrl: url, output: selector });
+    console.log(`asserted focused ${selector}`);
     return;
   }
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -33,6 +33,8 @@ bun src/cli.ts browse import-session ./tmp/staging-session.json --session stagin
 bun src/cli.ts browse import-cookies ./tmp/cookies.json --session staging-copy
 bun src/cli.ts browse text https://example.com --session staging
 bun src/cli.ts browse probe https://example.com/settings --session staging
+bun src/cli.ts browse upload https://example.com/profile "input[type=file]" ./fixtures/avatar.png --session staging
+bun src/cli.ts browse dialog https://example.com/settings accept "#delete-confirm" --session staging
 bun src/cli.ts browse save-flow login-local '[{"action":"fill","selector":"input[name=email]","value":"demo@example.com"},{"action":"fill","selector":"input[name=password]","value":"demo-pass"},{"action":"click","selector":"button[type=submit]"}]'
 bun src/cli.ts browse save-repo-flow landing-smoke '[{"action":"assert-visible","selector":"main"}]'
 bun src/cli.ts browse import-flow login-local ./docs/login-flow.md
@@ -44,7 +46,15 @@ bun src/cli.ts browse login https://example.com/login login-local --session stag
 bun src/cli.ts browse click https://example.com "button[type=submit]" --session staging
 bun src/cli.ts browse fill https://example.com/login "input[name=email]" demo@example.com --session staging
 bun src/cli.ts browse wait https://example.com/dashboard "text=Dashboard" --session staging
+bun src/cli.ts browse wait https://example.com/dashboard load:domcontentloaded --session staging
+bun src/cli.ts browse wait https://example.com/dashboard state:hidden:#toast --session staging
 bun src/cli.ts browse assert-visible https://example.com "main" --session staging
+bun src/cli.ts browse assert-hidden https://example.com "#toast" --session staging
+bun src/cli.ts browse assert-enabled https://example.com "button[type=submit]" --session staging
+bun src/cli.ts browse assert-disabled https://example.com "button[disabled]" --session staging
+bun src/cli.ts browse assert-checked https://example.com "input[type=checkbox]" --session staging
+bun src/cli.ts browse assert-editable https://example.com "textarea" --session staging
+bun src/cli.ts browse assert-focused https://example.com "input[name=email]" --session staging
 bun src/cli.ts browse assert-text https://example.com "h1" "Example Domain" --session staging
 bun src/cli.ts browse assert-count https://example.com "a" 1 --session staging
 bun src/cli.ts browse run-flow http://127.0.0.1:4173/login portal-full-demo --session friend-demo
@@ -201,6 +211,8 @@ Notes:
 - Checked-in flows live under `browse/flows/`.
 - Local flows live under `.codex-stack/browse/flows/` and override same-named repo flows.
 - Session bundles capture cookies plus origin storage so authenticated QA setups can move between named sessions.
+- `upload`, `dialog`, and the expanded assertion set are available both as direct commands and as flow actions.
+- `wait` supports `load:<state>` plus `state:<visible|hidden|attached|detached>:<selector>` for richer synchronization.
 - Use `{"action":"use-flow","name":"portal-login"}` inside a checked-in flow to compose a larger QA sequence.
 - Flow import/export supports `.json`, `.yaml` / `.yml`, and Markdown files with fenced JSON or YAML blocks.
 - Leading `{"action":"clear-storage"}` steps run before navigation, which is useful for repeatable login flows on persistent sessions.

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -77,6 +77,10 @@ bun src/cli.ts browse import-flow portal-copy /tmp/portal-full-demo.md
 bun src/cli.ts browse export-session /tmp/portal-session.json --session friend-demo
 bun src/cli.ts browse import-session /tmp/portal-session.json --session friend-demo-copy
 bun src/cli.ts browse probe http://127.0.0.1:4173/dashboard --session friend-demo
+bun src/cli.ts browse upload http://127.0.0.1:4173/profile "input[type=file]" ./fixtures/avatar.png --session friend-demo
+bun src/cli.ts browse dialog http://127.0.0.1:4173/settings accept "#delete-confirm" --session friend-demo
+bun src/cli.ts browse wait http://127.0.0.1:4173/dashboard load:domcontentloaded --session friend-demo
+bun src/cli.ts browse assert-focused http://127.0.0.1:4173/login "input[name=email]" --session friend-demo
 bun src/cli.ts browse snapshot http://127.0.0.1:4173/dashboard portal-dashboard --session friend-demo
 bun src/cli.ts browse compare-snapshot http://127.0.0.1:4173/dashboard portal-dashboard --session friend-demo
 bun src/cli.ts browse run-flow http://127.0.0.1:4173/login portal-login --session friend-demo

--- a/scripts/browse-advanced.spec.ts
+++ b/scripts/browse-advanced.spec.ts
@@ -1,0 +1,143 @@
+#!/usr/bin/env bun
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import process from "node:process";
+import { execFileSync } from "node:child_process";
+
+const rootDir = process.cwd();
+const bun = process.execPath || "bun";
+const fixtureRoot = fs.mkdtempSync(path.join(os.tmpdir(), "codex-stack-browse-advanced-"));
+const uploadPath = path.join(fixtureRoot, "upload.txt");
+const logPath = path.join(fixtureRoot, "playwright-log.json");
+const modulePath = path.join(fixtureRoot, "playwright-stub.mjs");
+
+function runBrowse(args: string[]): string {
+  return execFileSync(bun, [path.join(rootDir, "browse", "src", "cli.ts"), ...args], {
+    cwd: fixtureRoot,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      CODEX_STACK_PLAYWRIGHT_MODULE: modulePath,
+      CODEX_STACK_PLAYWRIGHT_LOG: logPath,
+    },
+  }).trim();
+}
+
+async function main(): Promise<void> {
+  fs.writeFileSync(uploadPath, "demo upload\n");
+  fs.writeFileSync(
+    modulePath,
+    `import fs from "node:fs";
+const LOG_PATH = process.env.CODEX_STACK_PLAYWRIGHT_LOG;
+function append(entry) {
+  const rows = fs.existsSync(LOG_PATH) ? JSON.parse(fs.readFileSync(LOG_PATH, "utf8")) : [];
+  rows.push(entry);
+  fs.writeFileSync(LOG_PATH, JSON.stringify(rows, null, 2));
+}
+class FakeLocator {
+  constructor(page, selector) { this.page = page; this.selector = selector; }
+  first() { return this; }
+  async click() {
+    append({ action: "click", selector: this.selector });
+    if (this.page.dialogHandler && this.selector === "#dialog-button") {
+      const handler = this.page.dialogHandler;
+      this.page.dialogHandler = null;
+      await handler({
+        accept: async (value) => append({ action: "dialog-accept", value: value || "" }),
+        dismiss: async () => append({ action: "dialog-dismiss" }),
+      });
+    }
+    if (this.selector === "#focus") this.page.activeSelector = this.selector;
+  }
+  async fill(value) { append({ action: "fill", selector: this.selector, value }); }
+  async press(key) { append({ action: "press", selector: this.selector, key }); }
+  async waitFor(options) { append({ action: "waitFor", selector: this.selector, state: options?.state || "visible" }); }
+  async setInputFiles(files) { append({ action: "setInputFiles", selector: this.selector, files: Array.isArray(files) ? files : [files] }); }
+  async innerText() { return this.selector === "body" ? "Example Domain" : this.selector; }
+  async count() { return 1; }
+  async isEnabled() { return this.selector !== "#disabled"; }
+  async isDisabled() { return this.selector === "#disabled"; }
+  async isChecked() { return this.selector === "#checked"; }
+  async isEditable() { return this.selector === "#editable"; }
+  async evaluate(fn) {
+    const element = { selector: this.selector };
+    const previousDocument = globalThis.document;
+    globalThis.document = { activeElement: this.page.activeSelector === this.selector ? element : { selector: this.page.activeSelector } };
+    try { return fn(element); } finally { globalThis.document = previousDocument; }
+  }
+}
+class FakePage {
+  constructor() { this.currentUrl = ""; this.dialogHandler = null; this.activeSelector = "#focus"; }
+  locator(selector) { return new FakeLocator(this, selector); }
+  async goto(url, options = {}) { this.currentUrl = url; append({ action: "goto", url, waitUntil: options.waitUntil || "" }); return { status: () => 200, ok: () => true }; }
+  async waitForURL(url) { this.currentUrl = url; append({ action: "waitForURL", url }); }
+  async waitForTimeout(ms) { append({ action: "waitForTimeout", ms }); }
+  async waitForLoadState(state) { append({ action: "waitForLoadState", state }); }
+  async title() { return "Stub"; }
+  url() { return this.currentUrl; }
+  async screenshot(options) { fs.writeFileSync(options.path, "stub"); append({ action: "screenshot", path: options.path }); }
+  async content() { return "<html></html>"; }
+  async evaluate(fn, arg) { return typeof fn === "function" ? fn(arg) : null; }
+  once(event, handler) { if (event === "dialog") { this.dialogHandler = handler; append({ action: "dialog-armed" }); } }
+}
+const page = new FakePage();
+const context = {
+  pages() { return [page]; },
+  async newPage() { return page; },
+  async close() { append({ action: "close" }); },
+  async storageState() { return { cookies: [], origins: [] }; },
+  async clearCookies() {},
+  async addCookies() {},
+};
+export const chromium = {
+  async launchPersistentContext() {
+    append({ action: "launch" });
+    return context;
+  }
+};
+`,
+  );
+
+  const flowOutput = runBrowse([
+    "flow",
+    "https://example.com/login",
+    JSON.stringify([
+      { action: "dialog", mode: "dismiss" },
+      { action: "click", selector: "#dialog-button" },
+      { action: "upload", selector: "#file", path: uploadPath },
+      { action: "wait", loadState: "load" },
+      { action: "wait", selector: "#toast", state: "hidden" },
+      { action: "assert-hidden", selector: "#hidden" },
+    ]),
+    "--session",
+    "advanced",
+  ]);
+  const flowResults = JSON.parse(flowOutput) as Array<{ action?: string; mode?: string; files?: string[] }>;
+  assert.ok(flowResults.some((entry) => entry.action === "dialog" && entry.mode === "dismiss"));
+  assert.ok(flowResults.some((entry) => entry.action === "upload"));
+
+  runBrowse(["assert-enabled", "https://example.com/settings", "#enabled", "--session", "advanced"]);
+  runBrowse(["assert-disabled", "https://example.com/settings", "#disabled", "--session", "advanced"]);
+  runBrowse(["assert-checked", "https://example.com/settings", "#checked", "--session", "advanced"]);
+  runBrowse(["assert-editable", "https://example.com/settings", "#editable", "--session", "advanced"]);
+  runBrowse(["assert-focused", "https://example.com/settings", "#focus", "--session", "advanced"]);
+  runBrowse(["wait", "https://example.com/settings", "load:domcontentloaded", "--session", "advanced"]);
+  runBrowse(["wait", "https://example.com/settings", "state:hidden:#toast", "--session", "advanced"]);
+
+  const log = JSON.parse(fs.readFileSync(logPath, "utf8")) as Array<Record<string, unknown>>;
+  assert.ok(log.some((entry) => entry.action === "dialog-armed"));
+  assert.ok(log.some((entry) => entry.action === "dialog-dismiss"));
+  assert.ok(log.some((entry) => entry.action === "setInputFiles" && Array.isArray(entry.files) && String(entry.files[0]).includes("upload.txt")));
+  assert.ok(log.some((entry) => entry.action === "waitForLoadState" && entry.state === "load"));
+  assert.ok(log.some((entry) => entry.action === "waitFor" && entry.selector === "#toast" && entry.state === "hidden"));
+
+  console.log("browse-advanced spec passed");
+}
+
+try {
+  await main();
+} finally {
+  fs.rmSync(fixtureRoot, { recursive: true, force: true });
+}

--- a/scripts/ci-check.sh
+++ b/scripts/ci-check.sh
@@ -38,6 +38,8 @@ run_ts browse/src/cli.ts doctor >/tmp/codex-stack-browse-doctor.log
 grep -q 'snapshot' /tmp/codex-stack-browse-doctor.log
 grep -q 'export-session' /tmp/codex-stack-browse-doctor.log
 grep -q 'probe' /tmp/codex-stack-browse-doctor.log
+grep -q 'assert-focused' /tmp/codex-stack-browse-doctor.log
+grep -q 'upload' /tmp/codex-stack-browse-doctor.log
 
 echo "[4/8] browse flow registry"
 run_ts browse/src/cli.ts save-flow smoke '[{"action":"wait","ms":1},{"action":"assert-url","value":"example.com"}]' >/tmp/codex-stack-flow-save.log
@@ -70,6 +72,7 @@ run_ts scripts/review-diff.ts --help >/tmp/codex-stack-review-help.log
 run_ts scripts/issue-flow.ts --help >/tmp/codex-stack-issue-flow-help.log
 run_ts scripts/issue-flow.spec.ts >/tmp/codex-stack-issue-flow-spec.log
 run_ts scripts/render-pr-review.spec.ts >/tmp/codex-stack-render-pr-review-spec.log
+run_ts scripts/browse-advanced.spec.ts >/tmp/codex-stack-browse-advanced-spec.log
 run_ts scripts/qa-diff.spec.ts >/tmp/codex-stack-qa-diff-spec.log
 run_ts scripts/qa-run.ts --help >/tmp/codex-stack-qa-help.log
 run_ts scripts/qa-run.spec.ts >/tmp/codex-stack-qa-spec.log

--- a/skills/browse/SKILL.md
+++ b/skills/browse/SKILL.md
@@ -41,9 +41,17 @@ Give the agent eyes for QA and deployment checks.
 - `eval <url> <expression>`
 - `click <url> <selector>`
 - `fill <url> <selector> <value>`
-- `wait <url> [selector|ms:<n>|url:<target>]`
+- `upload <url> <selector> <path>`
+- `dialog <url> <accept|dismiss> [selector] [prompt]`
+- `wait <url> [selector|ms:<n>|url:<target>|load:<state>|state:<state>:<selector>]`
 - `press <url> <selector> <key>`
 - `assert-visible <url> <selector>`
+- `assert-hidden <url> <selector>`
+- `assert-enabled <url> <selector>`
+- `assert-disabled <url> <selector>`
+- `assert-checked <url> <selector>`
+- `assert-editable <url> <selector>`
+- `assert-focused <url> <selector>`
 - `assert-text <url> <selector> <expected>`
 - `assert-url <url> <expected>`
 - `assert-count <url> <selector> <expected-count>`
@@ -63,9 +71,14 @@ bun src/cli.ts browse export-flow portal-full-demo ./docs/portal-full-demo.yaml
 bun src/cli.ts browse export-session ./tmp/staging-session.json --session staging
 bun src/cli.ts browse import-session ./tmp/staging-session.json --session staging-copy
 bun src/cli.ts browse probe https://example.com/settings --session staging
+bun src/cli.ts browse upload https://example.com/profile "input[type=file]" ./fixtures/avatar.png --session staging
+bun src/cli.ts browse dialog https://example.com/settings accept "#delete-confirm" --session staging
+bun src/cli.ts browse wait https://example.com/dashboard load:domcontentloaded --session staging
 bun src/cli.ts browse snapshot https://example.com marketing-home --session staging
 bun src/cli.ts browse compare-snapshot https://example.com marketing-home --session staging
 bun src/cli.ts browse login https://example.com/login login-local --session staging
+bun src/cli.ts browse assert-focused https://example.com/login "input[name=email]" --session staging
+bun src/cli.ts browse assert-disabled https://example.com/settings "button[disabled]" --session staging
 bun src/cli.ts browse assert-text https://example.com "h1" "Example Domain" --session staging
 bun src/cli.ts browse screenshot https://example.com /tmp/example.png --session staging
 bun src/cli.ts browse sessions
@@ -77,6 +90,7 @@ bun src/cli.ts browse sessions
 - Prefer deterministic selectors and stable flows.
 - Reuse named sessions for authenticated flows so login state persists.
 - Export/import session bundles when authenticated QA needs to move between machines or named sessions.
+- Use `dialog` before the click that triggers a modal or confirm prompt so the handler is armed in time.
 - Check in shared flows under `browse/flows/`; keep machine-specific experiments in `.codex-stack/browse/flows/`.
 - Prefer composing shared flows with `use-flow` instead of duplicating login/setup steps across many files.
 - Prefer Markdown or YAML exports when flows need code review, because they diff more cleanly than inline JSON strings.


### PR DESCRIPTION
## Summary
- add upload, dialog, richer wait handling, and expanded element-state assertions to the browse runtime
- support the same capabilities in flow steps so CLI commands and saved flows stay aligned
- add a stubbed Playwright regression spec plus smoke/docs updates

## Validation
- bun run typecheck
- bun run smoke
- bun src/cli.ts review --json

Closes #25