### PR TITLE
feat: add semantic locators and device presets

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Use the repo in this order:
 
 - Installable Codex skills under `skills/`
 - Checked-in root CLI under `src/cli.ts`
-- Playwright-backed browser runtime under `browse/src/cli.ts` with upload, dialog, wait-state, and element-state assertions
+- Playwright-backed browser runtime under `browse/src/cli.ts` with semantic selectors, device presets, upload, dialog, wait-state, and element-state assertions
 - Persistent named browser sessions
 - Portable session import/export with cookie and storage-state bundles
 - Checked-in and local browser flows with import/export for JSON, YAML, and Markdown
@@ -173,6 +173,9 @@ bun src/cli.ts browse import-session ./tmp/staging-session.json --session stagin
 bun src/cli.ts browse probe https://example.com/settings --session staging
 bun src/cli.ts browse upload https://example.com/profile "input[type=file]" ./fixtures/avatar.png --session staging
 bun src/cli.ts browse dialog https://example.com/settings accept "#delete-confirm" --session staging
+bun src/cli.ts browse click https://example.com/login "role:button:Continue" --session staging --device mobile
+bun src/cli.ts browse fill https://example.com/login "label:Email" demo@example.com --session staging
+bun src/cli.ts browse assert-visible https://example.com/home "testid:hero" --session staging
 bun src/cli.ts browse assert-focused https://example.com/login "input[name=email]" --session staging
 bun src/cli.ts browse snapshot https://example.com marketing-home --session staging
 bun src/cli.ts browse compare-snapshot https://example.com marketing-home --session staging
@@ -208,6 +211,7 @@ Use `browse` when you want raw control:
 - snapshots
 - route probes
 - ad hoc assertions
+- semantic selectors and responsive viewport presets
 - screenshots and artifacts
 
 Use `qa` when you want a decision-ready report:

--- a/browse/src/cli.ts
+++ b/browse/src/cli.ts
@@ -40,6 +40,7 @@ interface BrowseState {
 
 interface ParsedGlobalArgs {
   session: string;
+  device: string;
   command: string;
   rest: string[];
 }
@@ -136,6 +137,20 @@ interface ProbeResult {
 
 type WaitState = "visible" | "hidden" | "attached" | "detached";
 type LoadState = "load" | "domcontentloaded" | "networkidle" | "commit";
+type DevicePresetName = "desktop" | "tablet" | "mobile";
+
+interface DevicePreset {
+  name: DevicePresetName;
+  width: number;
+  height: number;
+}
+
+interface LocatorDescriptor {
+  mode: "css" | "role" | "label" | "placeholder" | "text" | "testid";
+  value: string;
+  name?: string;
+  raw: string;
+}
 
 const ROOT_DIR = path.resolve(process.cwd(), ".codex-stack");
 const STATE_DIR = path.join(ROOT_DIR, "browse");
@@ -145,53 +160,58 @@ const FLOW_DIR = path.join(STATE_DIR, "flows");
 const SNAPSHOT_DIR = path.join(STATE_DIR, "snapshots");
 const ARTIFACT_DIR = path.join(STATE_DIR, "artifacts");
 const REPO_FLOW_DIR = path.resolve(process.cwd(), "browse", "flows");
+const DEVICE_PRESETS: Record<DevicePresetName, DevicePreset> = {
+  desktop: { name: "desktop", width: 1440, height: 960 },
+  tablet: { name: "tablet", width: 834, height: 1194 },
+  mobile: { name: "mobile", width: 390, height: 844 },
+};
 
 function usage(): never {
   console.log(`codex-stack browse
 
 Usage:
   codex-stack browse doctor
-  codex-stack browse status [--session <name>]
-  codex-stack browse sessions
-  codex-stack browse flows
-  codex-stack browse save-flow <name> <json-steps>
-  codex-stack browse save-repo-flow <name> <json-steps>
-  codex-stack browse import-flow <name> <path>
-  codex-stack browse import-repo-flow <name> <path>
-  codex-stack browse export-flow <name> <path>
-  codex-stack browse show-flow <name>
-  codex-stack browse delete-flow <name>
-  codex-stack browse clear-session [name]
-  codex-stack browse export-session <path> [--url <url>] [--session <name>]
-  codex-stack browse import-session <path> [--session <name>]
-  codex-stack browse import-cookies <path> [--session <name>]
-  codex-stack browse snapshot <url> [name] [--session <name>]
-  codex-stack browse compare-snapshot <url> <name> [--session <name>]
-  codex-stack browse probe <url> [--session <name>]
-  codex-stack browse text <url> [--session <name>]
-  codex-stack browse html <url> [selector] [--session <name>]
-  codex-stack browse links <url> [--session <name>]
-  codex-stack browse screenshot <url> [path] [--session <name>]
-  codex-stack browse eval <url> <expression> [--session <name>]
-  codex-stack browse click <url> <selector> [--session <name>]
-  codex-stack browse fill <url> <selector> <value> [--session <name>]
-  codex-stack browse upload <url> <selector> <path> [--session <name>]
-  codex-stack browse dialog <url> <accept|dismiss> [selector] [prompt] [--session <name>]
-  codex-stack browse wait <url> [selector|ms:<n>|url:<target>|load:<state>|state:<state>:<selector>] [--session <name>]
-  codex-stack browse press <url> <selector> <key> [--session <name>]
-  codex-stack browse assert-visible <url> <selector> [--session <name>]
-  codex-stack browse assert-hidden <url> <selector> [--session <name>]
-  codex-stack browse assert-enabled <url> <selector> [--session <name>]
-  codex-stack browse assert-disabled <url> <selector> [--session <name>]
-  codex-stack browse assert-checked <url> <selector> [--session <name>]
-  codex-stack browse assert-editable <url> <selector> [--session <name>]
-  codex-stack browse assert-focused <url> <selector> [--session <name>]
-  codex-stack browse assert-text <url> <selector> <expected> [--session <name>]
-  codex-stack browse assert-url <url> <expected> [--session <name>]
-  codex-stack browse assert-count <url> <selector> <expected-count> [--session <name>]
-  codex-stack browse flow <url> <json-steps> [--session <name>]
-  codex-stack browse run-flow <url> <name> [--session <name>]
-  codex-stack browse login <url> <name> [--session <name>]
+  codex-stack browse status [--session <name>] [--device <desktop|tablet|mobile>]
+  codex-stack browse sessions [--device <desktop|tablet|mobile>]
+  codex-stack browse flows [--device <desktop|tablet|mobile>]
+  codex-stack browse save-flow <name> <json-steps> [--device <desktop|tablet|mobile>]
+  codex-stack browse save-repo-flow <name> <json-steps> [--device <desktop|tablet|mobile>]
+  codex-stack browse import-flow <name> <path> [--device <desktop|tablet|mobile>]
+  codex-stack browse import-repo-flow <name> <path> [--device <desktop|tablet|mobile>]
+  codex-stack browse export-flow <name> <path> [--device <desktop|tablet|mobile>]
+  codex-stack browse show-flow <name> [--device <desktop|tablet|mobile>]
+  codex-stack browse delete-flow <name> [--device <desktop|tablet|mobile>]
+  codex-stack browse clear-session [name] [--device <desktop|tablet|mobile>]
+  codex-stack browse export-session <path> [--url <url>] [--session <name>] [--device <desktop|tablet|mobile>]
+  codex-stack browse import-session <path> [--session <name>] [--device <desktop|tablet|mobile>]
+  codex-stack browse import-cookies <path> [--session <name>] [--device <desktop|tablet|mobile>]
+  codex-stack browse snapshot <url> [name] [--session <name>] [--device <desktop|tablet|mobile>]
+  codex-stack browse compare-snapshot <url> <name> [--session <name>] [--device <desktop|tablet|mobile>]
+  codex-stack browse probe <url> [--session <name>] [--device <desktop|tablet|mobile>]
+  codex-stack browse text <url> [--session <name>] [--device <desktop|tablet|mobile>]
+  codex-stack browse html <url> [selector] [--session <name>] [--device <desktop|tablet|mobile>]
+  codex-stack browse links <url> [--session <name>] [--device <desktop|tablet|mobile>]
+  codex-stack browse screenshot <url> [path] [--session <name>] [--device <desktop|tablet|mobile>]
+  codex-stack browse eval <url> <expression> [--session <name>] [--device <desktop|tablet|mobile>]
+  codex-stack browse click <url> <selector> [--session <name>] [--device <desktop|tablet|mobile>]
+  codex-stack browse fill <url> <selector> <value> [--session <name>] [--device <desktop|tablet|mobile>]
+  codex-stack browse upload <url> <selector> <path> [--session <name>] [--device <desktop|tablet|mobile>]
+  codex-stack browse dialog <url> <accept|dismiss> [selector] [prompt] [--session <name>] [--device <desktop|tablet|mobile>]
+  codex-stack browse wait <url> [selector|ms:<n>|url:<target>|load:<state>|state:<state>:<selector>] [--session <name>] [--device <desktop|tablet|mobile>]
+  codex-stack browse press <url> <selector> <key> [--session <name>] [--device <desktop|tablet|mobile>]
+  codex-stack browse assert-visible <url> <selector> [--session <name>] [--device <desktop|tablet|mobile>]
+  codex-stack browse assert-hidden <url> <selector> [--session <name>] [--device <desktop|tablet|mobile>]
+  codex-stack browse assert-enabled <url> <selector> [--session <name>] [--device <desktop|tablet|mobile>]
+  codex-stack browse assert-disabled <url> <selector> [--session <name>] [--device <desktop|tablet|mobile>]
+  codex-stack browse assert-checked <url> <selector> [--session <name>] [--device <desktop|tablet|mobile>]
+  codex-stack browse assert-editable <url> <selector> [--session <name>] [--device <desktop|tablet|mobile>]
+  codex-stack browse assert-focused <url> <selector> [--session <name>] [--device <desktop|tablet|mobile>]
+  codex-stack browse assert-text <url> <selector> <expected> [--session <name>] [--device <desktop|tablet|mobile>]
+  codex-stack browse assert-url <url> <expected> [--session <name>] [--device <desktop|tablet|mobile>]
+  codex-stack browse assert-count <url> <selector> <expected-count> [--session <name>] [--device <desktop|tablet|mobile>]
+  codex-stack browse flow <url> <json-steps> [--session <name>] [--device <desktop|tablet|mobile>]
+  codex-stack browse run-flow <url> <name> [--session <name>] [--device <desktop|tablet|mobile>]
+  codex-stack browse login <url> <name> [--session <name>] [--device <desktop|tablet|mobile>]
 `);
   process.exit(1);
 }
@@ -299,7 +319,7 @@ function assertFlowName(name: string): void {
 }
 
 function parseGlobalArgs(argv: string[]): ParsedGlobalArgs {
-  const out: ParsedGlobalArgs = { session: "default", command: "", rest: [] };
+  const out: ParsedGlobalArgs = { session: "default", device: "", command: "", rest: [] };
   const copy = [...argv];
   out.command = copy.shift() || "doctor";
 
@@ -307,6 +327,10 @@ function parseGlobalArgs(argv: string[]): ParsedGlobalArgs {
     const item = copy.shift();
     if (item === "--session") {
       out.session = copy.shift() || "default";
+      continue;
+    }
+    if (item === "--device") {
+      out.device = copy.shift() || "";
       continue;
     }
     if (typeof item === "string") {
@@ -893,22 +917,6 @@ async function applySessionBundle(sessionName: string, bundle: BrowserSessionBun
   });
 }
 
-async function probeUrl(sessionName: string, url: string): Promise<ProbeResult> {
-  return withPersistentContext(sessionName, async ({ context }) => {
-    const page = context.pages()[0] || (await context.newPage());
-    const response = (await page.goto(url, { waitUntil: "networkidle" })) as PlaywrightResponse | null;
-    const bodyText = await page.locator("body").innerText().catch(() => "");
-    return {
-      url,
-      finalUrl: page.url(),
-      title: await page.title().catch(() => ""),
-      status: response ? response.status() : null,
-      ok: response ? response.ok() : true,
-      bodyLength: String(bodyText || "").trim().length,
-    };
-  });
-}
-
 function assertCondition(condition: unknown, message: string): asserts condition {
   if (!condition) {
     throw new Error(message);
@@ -925,6 +933,72 @@ function parseLoadState(value: unknown, fallback: LoadState = "networkidle"): Lo
   const normalized = String(value || fallback).toLowerCase();
   if (normalized === "load" || normalized === "domcontentloaded" || normalized === "commit") return normalized;
   return "networkidle";
+}
+
+function parseDevicePreset(value: unknown): DevicePreset | null {
+  const normalized = String(value || "").trim().toLowerCase();
+  if (!normalized) return null;
+  if (normalized === "desktop" || normalized === "tablet" || normalized === "mobile") {
+    return DEVICE_PRESETS[normalized];
+  }
+  throw new Error(`Unknown device preset: ${JSON.stringify(value)}. Use desktop, tablet, or mobile.`);
+}
+
+function parseLocatorDescriptor(selector: string): LocatorDescriptor {
+  const raw = String(selector || "");
+  const value = raw.trim();
+  const [prefix, ...rest] = value.split(":");
+  const mode = prefix.toLowerCase();
+  if (mode === "role" && rest.length) {
+    const [role, ...nameParts] = rest;
+    return {
+      mode: "role",
+      value: role.trim(),
+      name: nameParts.join(":").trim() || undefined,
+      raw,
+    };
+  }
+  if ((mode === "label" || mode === "placeholder" || mode === "text" || mode === "testid") && rest.length) {
+    return {
+      mode,
+      value: rest.join(":").trim(),
+      raw,
+    };
+  }
+  return {
+    mode: "css",
+    value,
+    raw,
+  };
+}
+
+function resolveLocator(page: PlaywrightPage, selector: string): Record<string, any> {
+  const descriptor = parseLocatorDescriptor(selector);
+  assertCondition(Boolean(descriptor.value), `Selector cannot be empty: ${JSON.stringify(selector)}.`);
+  if (descriptor.mode === "role") {
+    const options = descriptor.name ? { name: descriptor.name } : undefined;
+    return page.getByRole(descriptor.value, options).first();
+  }
+  if (descriptor.mode === "label") {
+    return page.getByLabel(descriptor.value).first();
+  }
+  if (descriptor.mode === "placeholder") {
+    return page.getByPlaceholder(descriptor.value).first();
+  }
+  if (descriptor.mode === "text") {
+    return page.getByText(descriptor.value).first();
+  }
+  if (descriptor.mode === "testid") {
+    return page.getByTestId(descriptor.value).first();
+  }
+  return page.locator(descriptor.value).first();
+}
+
+async function applyDevicePreset(page: PlaywrightPage, preset: DevicePreset | null): Promise<void> {
+  if (!preset) return;
+  if (typeof page.setViewportSize === "function") {
+    await page.setViewportSize({ width: preset.width, height: preset.height });
+  }
 }
 
 async function armDialog(
@@ -947,7 +1021,7 @@ async function armDialog(
 }
 
 async function assertLocatorState(page: PlaywrightPage, selector: string, state: string): Promise<void> {
-  const locator = page.locator(selector).first();
+  const locator = resolveLocator(page, selector);
   if (state === "visible") {
     await locator.waitFor({ state: "visible" });
     return;
@@ -1022,10 +1096,15 @@ async function withPersistentContext<T>(
 async function withPage<T>(
   sessionName: string,
   url: string,
-  callback: ({ page, context }: { page: PlaywrightPage; context: PlaywrightContext }) => Promise<T>,
+  deviceOrCallback: DevicePreset | null | (({ page, context }: { page: PlaywrightPage; context: PlaywrightContext }) => Promise<T>),
+  maybeCallback?: ({ page, context }: { page: PlaywrightPage; context: PlaywrightContext }) => Promise<T>,
 ): Promise<T> {
+  const device = typeof deviceOrCallback === "function" ? null : deviceOrCallback;
+  const callback = typeof deviceOrCallback === "function" ? deviceOrCallback : maybeCallback;
+  assertCondition(typeof callback === "function", "withPage requires a callback.");
   return withPersistentContext(sessionName, async ({ context }) => {
     const page = context.pages()[0] || (await context.newPage());
+    await applyDevicePreset(page, device);
     if (url) {
       await page.goto(url, { waitUntil: "networkidle" });
     }
@@ -1044,11 +1123,11 @@ async function runStep(page: PlaywrightPage, step: FlowStep, sessionName: string
     return { action, url: step.url, status: "ok" };
   }
   if (action === "click") {
-    await page.locator(String(step.selector)).first().click();
+    await resolveLocator(page, String(step.selector)).click();
     return { action, selector: step.selector, status: "ok" };
   }
   if (action === "fill") {
-    await page.locator(String(step.selector)).first().fill(String(step.value || ""));
+    await resolveLocator(page, String(step.selector)).fill(String(step.value || ""));
     return { action, selector: step.selector, status: "ok" };
   }
   if (action === "upload") {
@@ -1058,25 +1137,25 @@ async function runStep(page: PlaywrightPage, step: FlowStep, sessionName: string
       : [String(step.path ?? step.value ?? "")].filter(Boolean);
     assertCondition(selector, "upload steps require a selector.");
     assertCondition(files.length > 0, "upload steps require a file path.");
-    await page.locator(selector).first().setInputFiles(files.length === 1 ? files[0] : files);
+    await resolveLocator(page, selector).setInputFiles(files.length === 1 ? files[0] : files);
     return { action, selector, files, status: "ok" };
   }
   if (action === "dialog") {
     const dialog = await armDialog(page, String(step.mode ?? step.value ?? "accept"), String(step.prompt ?? ""));
     const selector = String(step.selector || "");
     if (selector) {
-      await page.locator(selector).first().click();
+      await resolveLocator(page, selector).click();
     }
     return { action, selector, mode: dialog.mode, promptText: dialog.promptText, status: "ok" };
   }
   if (action === "press") {
-    await page.locator(String(step.selector)).first().press(String(step.key || "Enter"));
+    await resolveLocator(page, String(step.selector)).press(String(step.key || "Enter"));
     return { action, selector: step.selector, key: step.key || "Enter", status: "ok" };
   }
   if (action === "wait") {
     if (step.selector) {
       const state = parseWaitState(step.state);
-      await page.locator(String(step.selector)).first().waitFor({ state });
+      await resolveLocator(page, String(step.selector)).waitFor({ state });
       return { action, selector: step.selector, state, status: "ok" };
     }
     if (step.url) {
@@ -1096,12 +1175,12 @@ async function runStep(page: PlaywrightPage, step: FlowStep, sessionName: string
     return { action, path: target, status: "ok" };
   }
   if (action === "text") {
-    const text = await page.locator(String(step.selector || "body")).first().innerText();
+    const text = await resolveLocator(page, String(step.selector || "body")).innerText();
     return { action, selector: step.selector || "body", text, status: "ok" };
   }
   if (action === "html") {
     const html = step.selector
-      ? await page.locator(String(step.selector)).first().innerHTML()
+      ? await resolveLocator(page, String(step.selector)).innerHTML()
       : await page.content();
     return { action, selector: step.selector || "document", html, status: "ok" };
   }
@@ -1143,7 +1222,7 @@ async function runStep(page: PlaywrightPage, step: FlowStep, sessionName: string
   if (action === "assert-text") {
     const selector = String(step.selector || "body");
     const expected = String(step.value ?? step.text ?? "");
-    const text = await page.locator(selector).first().innerText();
+    const text = await resolveLocator(page, selector).innerText();
     assertCondition(text.includes(expected), `Expected text ${JSON.stringify(expected)} in ${selector}.`);
     return { action, selector, expected, status: "ok" };
   }
@@ -1156,7 +1235,7 @@ async function runStep(page: PlaywrightPage, step: FlowStep, sessionName: string
   if (action === "assert-count") {
     const selector = String(step.selector || "");
     const expectedCount = Number(step.count ?? step.value ?? 0);
-    const count = await page.locator(selector).count();
+    const count = await resolveLocator(page, selector).count();
     assertCondition(count === expectedCount, `Expected ${expectedCount} matches for ${selector} but got ${count}.`);
     return { action, selector, expectedCount, count, status: "ok" };
   }
@@ -1186,12 +1265,14 @@ async function executeFlow({
   steps,
   recordName,
   authenticated = false,
+  device = null,
 }: {
   sessionName: string;
   url: string;
   steps: FlowStep[];
   recordName: string;
   authenticated?: boolean;
+  device?: DevicePreset | null;
 }): Promise<StepResult[]> {
   const expandedSteps = expandFlowSteps(steps);
   const preNavigationSteps: FlowStep[] = [];
@@ -1201,7 +1282,7 @@ async function executeFlow({
     else postNavigationSteps.push(step);
   }
 
-  const results = await withPage(sessionName, "", async ({ page }: { page: PlaywrightPage }) => {
+  const results = await withPage(sessionName, "", device, async ({ page }: { page: PlaywrightPage }) => {
     const entries: StepResult[] = [];
     if (preNavigationSteps.length) {
       if (url) {
@@ -1236,7 +1317,8 @@ function printJson(value: unknown): void {
 
 async function main(): Promise<void> {
   const parsed = parseGlobalArgs(process.argv.slice(2));
-  const { command, rest, session } = parsed;
+  const { command, rest, session, device: deviceRaw } = parsed;
+  const device = parseDevicePreset(deviceRaw);
 
   if (command === "doctor") {
     const playwrightInstalled = fs.existsSync(path.resolve(process.cwd(), "node_modules", "playwright"));
@@ -1401,7 +1483,7 @@ async function main(): Promise<void> {
     ensureDir(SNAPSHOT_DIR);
     const baselineJson = snapshotJsonPath(snapshotName);
     const baselineScreenshot = snapshotScreenshotPath(snapshotName);
-    const payload = await withPage(session, url, async ({ page }: { page: PlaywrightPage }) => {
+    const payload = await withPage(session, url, device, async ({ page }: { page: PlaywrightPage }) => {
       const snapshot = await captureSnapshotPayload(page);
       await page.screenshot({ path: baselineScreenshot, fullPage: true });
       return snapshot;
@@ -1443,7 +1525,7 @@ async function main(): Promise<void> {
     const baseline = readJson<SnapshotPayload | null>(baselineJson, null);
     assertCondition(Boolean(baseline), `Unable to read snapshot baseline: ${baselineJson}`);
     const baselineSnapshot = baseline as SnapshotPayload;
-    const current = await withPage(session, url, async ({ page }: { page: PlaywrightPage }) => {
+    const current = await withPage(session, url, device, async ({ page }: { page: PlaywrightPage }) => {
       const payload = await captureSnapshotPayload(page);
       await page.screenshot({ path: artifactScreenshot, fullPage: true });
       return payload;
@@ -1478,7 +1560,18 @@ async function main(): Promise<void> {
   if (command === "probe") {
     const [url] = rest;
     if (!url) usage();
-    const result = await probeUrl(session, url);
+    const result = await withPage(session, url, device, async ({ page }: { page: PlaywrightPage }) => {
+      const response = (await page.goto(url, { waitUntil: "networkidle" })) as PlaywrightResponse | null;
+      const bodyText = await resolveLocator(page, "body").innerText().catch(() => "");
+      return {
+        url,
+        finalUrl: page.url(),
+        title: await page.title().catch(() => ""),
+        status: response ? response.status() : null,
+        ok: response ? response.ok() : true,
+        bodyLength: String(bodyText || "").trim().length,
+      };
+    });
     recordSession(session, { lastCommand: "probe", lastUrl: url, output: `${result.status ?? "n/a"}:${result.bodyLength}` });
     printJson(result);
     return;
@@ -1487,7 +1580,7 @@ async function main(): Promise<void> {
   if (command === "text") {
     const url = rest[0];
     if (!url) usage();
-    const text = await withPage(session, url, async ({ page }: { page: PlaywrightPage }) => page.locator("body").innerText());
+    const text = await withPage(session, url, device, async ({ page }: { page: PlaywrightPage }) => resolveLocator(page, "body").innerText());
     recordSession(session, { lastCommand: "text", lastUrl: url, output: `${text.length} chars` });
     console.log(text);
     return;
@@ -1496,7 +1589,7 @@ async function main(): Promise<void> {
   if (command === "html") {
     const [url, selector] = rest;
     if (!url) usage();
-    const html = await withPage(session, url, async ({ page }: { page: PlaywrightPage }) => (selector ? page.locator(selector).first().innerHTML() : page.content()));
+    const html = await withPage(session, url, device, async ({ page }: { page: PlaywrightPage }) => (selector ? resolveLocator(page, selector).innerHTML() : page.content()));
     recordSession(session, { lastCommand: "html", lastUrl: url, output: `${html.length} chars` });
     console.log(html);
     return;
@@ -1505,7 +1598,7 @@ async function main(): Promise<void> {
   if (command === "links") {
     const url = rest[0];
     if (!url) usage();
-    const links = await withPage(session, url, async ({ page }) =>
+    const links = await withPage(session, url, device, async ({ page }) =>
       page.$$eval("a[href]", (anchors) =>
         anchors.map((anchor) => ({
           text: (anchor.textContent || "").trim(),
@@ -1522,7 +1615,7 @@ async function main(): Promise<void> {
     const url = rest[0];
     const outPath = rest[1] || path.join(os.tmpdir(), `codex-stack-browse-${session}.png`);
     if (!url) usage();
-    await withPage(session, url, async ({ page }: { page: PlaywrightPage }) => page.screenshot({ path: outPath, fullPage: true }));
+    await withPage(session, url, device, async ({ page }: { page: PlaywrightPage }) => page.screenshot({ path: outPath, fullPage: true }));
     recordSession(session, { lastCommand: "screenshot", lastUrl: url, output: outPath });
     console.log(outPath);
     return;
@@ -1540,8 +1633,8 @@ async function main(): Promise<void> {
   if (command === "click") {
     const [url, selector] = rest;
     if (!url || !selector) usage();
-    await withPage(session, url, async ({ page }: { page: PlaywrightPage }) => {
-      await page.locator(selector).first().click();
+    await withPage(session, url, device, async ({ page }: { page: PlaywrightPage }) => {
+      await resolveLocator(page, selector).click();
     });
     recordSession(session, { lastCommand: "click", lastUrl: url, output: selector });
     console.log(`clicked ${selector}`);
@@ -1551,8 +1644,8 @@ async function main(): Promise<void> {
   if (command === "fill") {
     const [url, selector, value] = rest;
     if (!url || !selector || value === undefined) usage();
-    await withPage(session, url, async ({ page }: { page: PlaywrightPage }) => {
-      await page.locator(selector).first().fill(value);
+    await withPage(session, url, device, async ({ page }: { page: PlaywrightPage }) => {
+      await resolveLocator(page, selector).fill(value);
     });
     recordSession(session, { lastCommand: "fill", lastUrl: url, output: selector });
     console.log(`filled ${selector}`);
@@ -1564,8 +1657,8 @@ async function main(): Promise<void> {
     if (!url || !selector || !filePath) usage();
     const absolute = path.resolve(process.cwd(), filePath);
     assertCondition(fs.existsSync(absolute), `Upload file not found: ${absolute}`);
-    await withPage(session, url, async ({ page }: { page: PlaywrightPage }) => {
-      await page.locator(selector).first().setInputFiles(absolute);
+    await withPage(session, url, device, async ({ page }: { page: PlaywrightPage }) => {
+      await resolveLocator(page, selector).setInputFiles(absolute);
     });
     recordSession(session, { lastCommand: "upload", lastUrl: url, output: `${selector}:${absolute}` });
     console.log(`uploaded ${absolute} into ${selector}`);
@@ -1576,10 +1669,10 @@ async function main(): Promise<void> {
     const [url, modeRaw, selector, promptText] = rest;
     if (!url || !modeRaw) usage();
     const mode = String(modeRaw || "accept").toLowerCase() === "dismiss" ? "dismiss" : "accept";
-    await withPage(session, url, async ({ page }: { page: PlaywrightPage }) => {
+    await withPage(session, url, device, async ({ page }: { page: PlaywrightPage }) => {
       await armDialog(page, mode, promptText || "");
       if (selector) {
-        await page.locator(selector).first().click();
+        await resolveLocator(page, selector).click();
       }
     });
     recordSession(session, { lastCommand: "dialog", lastUrl: url, output: `${mode}${selector ? `:${selector}` : ""}` });
@@ -1590,7 +1683,7 @@ async function main(): Promise<void> {
   if (command === "wait") {
     const [url, target] = rest;
     if (!url) usage();
-    await withPage(session, url, async ({ page }: { page: PlaywrightPage }) => {
+    await withPage(session, url, device, async ({ page }: { page: PlaywrightPage }) => {
       if (!target) {
         await page.waitForLoadState("networkidle");
         return;
@@ -1611,10 +1704,10 @@ async function main(): Promise<void> {
         const [, stateRaw = "visible", ...selectorParts] = target.split(":");
         const selector = selectorParts.join(":");
         assertCondition(selector, "state waits require a selector. Use state:<state>:<selector>.");
-        await page.locator(selector).first().waitFor({ state: parseWaitState(stateRaw) });
+        await resolveLocator(page, selector).waitFor({ state: parseWaitState(stateRaw) });
         return;
       }
-      await page.locator(target).first().waitFor({ state: "visible" });
+      await resolveLocator(page, target).waitFor({ state: "visible" });
     });
     recordSession(session, { lastCommand: "wait", lastUrl: url, output: target || "networkidle" });
     console.log(`waited for ${target || "networkidle"}`);
@@ -1624,8 +1717,8 @@ async function main(): Promise<void> {
   if (command === "press") {
     const [url, selector, key] = rest;
     if (!url || !selector || !key) usage();
-    await withPage(session, url, async ({ page }: { page: PlaywrightPage }) => {
-      await page.locator(selector).first().press(key);
+    await withPage(session, url, device, async ({ page }: { page: PlaywrightPage }) => {
+      await resolveLocator(page, selector).press(key);
     });
     recordSession(session, { lastCommand: "press", lastUrl: url, output: `${selector}:${key}` });
     console.log(`pressed ${key} on ${selector}`);
@@ -1635,7 +1728,7 @@ async function main(): Promise<void> {
   if (command === "assert-visible") {
     const [url, selector] = rest;
     if (!url || !selector) usage();
-    await withPage(session, url, async ({ page }: { page: PlaywrightPage }) => {
+    await withPage(session, url, device, async ({ page }: { page: PlaywrightPage }) => {
       await assertLocatorState(page, selector, "visible");
     });
     recordSession(session, { lastCommand: "assert-visible", lastUrl: url, output: selector });
@@ -1646,7 +1739,7 @@ async function main(): Promise<void> {
   if (command === "assert-hidden") {
     const [url, selector] = rest;
     if (!url || !selector) usage();
-    await withPage(session, url, async ({ page }: { page: PlaywrightPage }) => {
+    await withPage(session, url, device, async ({ page }: { page: PlaywrightPage }) => {
       await assertLocatorState(page, selector, "hidden");
     });
     recordSession(session, { lastCommand: "assert-hidden", lastUrl: url, output: selector });
@@ -1657,7 +1750,7 @@ async function main(): Promise<void> {
   if (command === "assert-enabled") {
     const [url, selector] = rest;
     if (!url || !selector) usage();
-    await withPage(session, url, async ({ page }: { page: PlaywrightPage }) => {
+    await withPage(session, url, device, async ({ page }: { page: PlaywrightPage }) => {
       await assertLocatorState(page, selector, "enabled");
     });
     recordSession(session, { lastCommand: "assert-enabled", lastUrl: url, output: selector });
@@ -1668,7 +1761,7 @@ async function main(): Promise<void> {
   if (command === "assert-disabled") {
     const [url, selector] = rest;
     if (!url || !selector) usage();
-    await withPage(session, url, async ({ page }: { page: PlaywrightPage }) => {
+    await withPage(session, url, device, async ({ page }: { page: PlaywrightPage }) => {
       await assertLocatorState(page, selector, "disabled");
     });
     recordSession(session, { lastCommand: "assert-disabled", lastUrl: url, output: selector });
@@ -1679,7 +1772,7 @@ async function main(): Promise<void> {
   if (command === "assert-checked") {
     const [url, selector] = rest;
     if (!url || !selector) usage();
-    await withPage(session, url, async ({ page }: { page: PlaywrightPage }) => {
+    await withPage(session, url, device, async ({ page }: { page: PlaywrightPage }) => {
       await assertLocatorState(page, selector, "checked");
     });
     recordSession(session, { lastCommand: "assert-checked", lastUrl: url, output: selector });
@@ -1690,7 +1783,7 @@ async function main(): Promise<void> {
   if (command === "assert-editable") {
     const [url, selector] = rest;
     if (!url || !selector) usage();
-    await withPage(session, url, async ({ page }: { page: PlaywrightPage }) => {
+    await withPage(session, url, device, async ({ page }: { page: PlaywrightPage }) => {
       await assertLocatorState(page, selector, "editable");
     });
     recordSession(session, { lastCommand: "assert-editable", lastUrl: url, output: selector });
@@ -1701,7 +1794,7 @@ async function main(): Promise<void> {
   if (command === "assert-focused") {
     const [url, selector] = rest;
     if (!url || !selector) usage();
-    await withPage(session, url, async ({ page }: { page: PlaywrightPage }) => {
+    await withPage(session, url, device, async ({ page }: { page: PlaywrightPage }) => {
       await assertLocatorState(page, selector, "focused");
     });
     recordSession(session, { lastCommand: "assert-focused", lastUrl: url, output: selector });
@@ -1712,8 +1805,8 @@ async function main(): Promise<void> {
   if (command === "assert-text") {
     const [url, selector, expected] = rest;
     if (!url || !selector || expected === undefined) usage();
-    await withPage(session, url, async ({ page }: { page: PlaywrightPage }) => {
-      const text = await page.locator(selector).first().innerText();
+    await withPage(session, url, device, async ({ page }: { page: PlaywrightPage }) => {
+      const text = await resolveLocator(page, selector).innerText();
       assertCondition(text.includes(expected), `Expected text ${JSON.stringify(expected)} in ${selector}.`);
     });
     recordSession(session, { lastCommand: "assert-text", lastUrl: url, output: `${selector}:${expected}` });
@@ -1724,7 +1817,7 @@ async function main(): Promise<void> {
   if (command === "assert-url") {
     const [url, expected] = rest;
     if (!url || expected === undefined) usage();
-    await withPage(session, url, async ({ page }: { page: PlaywrightPage }) => {
+    await withPage(session, url, device, async ({ page }: { page: PlaywrightPage }) => {
       const currentUrl = page.url();
       assertCondition(currentUrl.includes(expected), `Expected URL to include ${JSON.stringify(expected)} but got ${JSON.stringify(currentUrl)}.`);
     });
@@ -1738,8 +1831,8 @@ async function main(): Promise<void> {
     if (!url || !selector || expectedCountRaw === undefined) usage();
     const expectedCount = Number(expectedCountRaw);
     assertCondition(Number.isInteger(expectedCount), "Expected count must be an integer.");
-    await withPage(session, url, async ({ page }: { page: PlaywrightPage }) => {
-      const count = await page.locator(selector).count();
+    await withPage(session, url, device, async ({ page }: { page: PlaywrightPage }) => {
+      const count = await resolveLocator(page, selector).count();
       assertCondition(count === expectedCount, `Expected ${expectedCount} matches for ${selector} but got ${count}.`);
     });
     recordSession(session, { lastCommand: "assert-count", lastUrl: url, output: `${selector}:${expectedCount}` });
@@ -1758,6 +1851,7 @@ async function main(): Promise<void> {
       url,
       steps,
       recordName: "flow:inline",
+      device,
     });
     printJson(out);
     return;
@@ -1773,6 +1867,7 @@ async function main(): Promise<void> {
       steps,
       recordName: `${command}:${name}`,
       authenticated: command === "login",
+      device,
     });
     printJson(out);
     return;

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -35,6 +35,10 @@ bun src/cli.ts browse text https://example.com --session staging
 bun src/cli.ts browse probe https://example.com/settings --session staging
 bun src/cli.ts browse upload https://example.com/profile "input[type=file]" ./fixtures/avatar.png --session staging
 bun src/cli.ts browse dialog https://example.com/settings accept "#delete-confirm" --session staging
+bun src/cli.ts browse click https://example.com/login "role:button:Continue" --session staging --device mobile
+bun src/cli.ts browse fill https://example.com/login "label:Email" demo@example.com --session staging
+bun src/cli.ts browse html https://example.com/search "placeholder:Search" --session staging
+bun src/cli.ts browse assert-visible https://example.com/home "testid:hero" --session staging
 bun src/cli.ts browse save-flow login-local '[{"action":"fill","selector":"input[name=email]","value":"demo@example.com"},{"action":"fill","selector":"input[name=password]","value":"demo-pass"},{"action":"click","selector":"button[type=submit]"}]'
 bun src/cli.ts browse save-repo-flow landing-smoke '[{"action":"assert-visible","selector":"main"}]'
 bun src/cli.ts browse import-flow login-local ./docs/login-flow.md
@@ -213,6 +217,8 @@ Notes:
 - Session bundles capture cookies plus origin storage so authenticated QA setups can move between named sessions.
 - `upload`, `dialog`, and the expanded assertion set are available both as direct commands and as flow actions.
 - `wait` supports `load:<state>` plus `state:<visible|hidden|attached|detached>:<selector>` for richer synchronization.
+- Selector arguments accept semantic prefixes as well as CSS: `role:<role>[:<name>]`, `label:<text>`, `placeholder:<text>`, `text:<text>`, and `testid:<value>`.
+- Add `--device mobile|tablet|desktop` to browser commands when you need a specific responsive viewport.
 - Use `{"action":"use-flow","name":"portal-login"}` inside a checked-in flow to compose a larger QA sequence.
 - Flow import/export supports `.json`, `.yaml` / `.yml`, and Markdown files with fenced JSON or YAML blocks.
 - Leading `{"action":"clear-storage"}` steps run before navigation, which is useful for repeatable login flows on persistent sessions.

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -80,6 +80,9 @@ bun src/cli.ts browse probe http://127.0.0.1:4173/dashboard --session friend-dem
 bun src/cli.ts browse upload http://127.0.0.1:4173/profile "input[type=file]" ./fixtures/avatar.png --session friend-demo
 bun src/cli.ts browse dialog http://127.0.0.1:4173/settings accept "#delete-confirm" --session friend-demo
 bun src/cli.ts browse wait http://127.0.0.1:4173/dashboard load:domcontentloaded --session friend-demo
+bun src/cli.ts browse click http://127.0.0.1:4173/login "role:button:Continue" --session friend-demo --device mobile
+bun src/cli.ts browse fill http://127.0.0.1:4173/login "label:Email" demo@example.com --session friend-demo
+bun src/cli.ts browse assert-visible http://127.0.0.1:4173/dashboard "testid:hero" --session friend-demo
 bun src/cli.ts browse assert-focused http://127.0.0.1:4173/login "input[name=email]" --session friend-demo
 bun src/cli.ts browse snapshot http://127.0.0.1:4173/dashboard portal-dashboard --session friend-demo
 bun src/cli.ts browse compare-snapshot http://127.0.0.1:4173/dashboard portal-dashboard --session friend-demo

--- a/scripts/browse-semantic-device.spec.ts
+++ b/scripts/browse-semantic-device.spec.ts
@@ -1,0 +1,120 @@
+#!/usr/bin/env bun
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import process from "node:process";
+import { execFileSync } from "node:child_process";
+
+const rootDir = process.cwd();
+const bun = process.execPath || "bun";
+const fixtureRoot = fs.mkdtempSync(path.join(os.tmpdir(), "codex-stack-browse-semantic-"));
+const logPath = path.join(fixtureRoot, "playwright-log.json");
+const modulePath = path.join(fixtureRoot, "playwright-stub.mjs");
+
+function runBrowse(args: string[]): string {
+  return execFileSync(bun, [path.join(rootDir, "browse", "src", "cli.ts"), ...args], {
+    cwd: fixtureRoot,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      CODEX_STACK_PLAYWRIGHT_MODULE: modulePath,
+      CODEX_STACK_PLAYWRIGHT_LOG: logPath,
+    },
+  }).trim();
+}
+
+async function main(): Promise<void> {
+  fs.writeFileSync(
+    modulePath,
+    `import fs from "node:fs";
+const LOG_PATH = process.env.CODEX_STACK_PLAYWRIGHT_LOG;
+function append(entry) {
+  const rows = fs.existsSync(LOG_PATH) ? JSON.parse(fs.readFileSync(LOG_PATH, "utf8")) : [];
+  rows.push(entry);
+  fs.writeFileSync(LOG_PATH, JSON.stringify(rows, null, 2));
+}
+class FakeLocator {
+  constructor(kind, value, extra = "") { this.kind = kind; this.value = value; this.extra = extra; }
+  first() { return this; }
+  async click() { append({ action: "click", kind: this.kind, value: this.value, extra: this.extra }); }
+  async fill(text) { append({ action: "fill", kind: this.kind, value: this.value, extra: this.extra, text }); }
+  async press(key) { append({ action: "press", kind: this.kind, value: this.value, extra: this.extra, key }); }
+  async waitFor(options) { append({ action: "waitFor", kind: this.kind, value: this.value, extra: this.extra, state: options?.state || "visible" }); }
+  async setInputFiles(files) { append({ action: "setInputFiles", kind: this.kind, value: this.value, extra: this.extra, files: Array.isArray(files) ? files : [files] }); }
+  async innerText() { return this.kind === "text" ? this.value : this.extra || this.value; }
+  async innerHTML() { return "<div>stub</div>"; }
+  async count() { return 1; }
+  async isEnabled() { return true; }
+  async isDisabled() { return false; }
+  async isChecked() { return false; }
+  async isEditable() { return true; }
+  async evaluate(fn) {
+    const previousDocument = globalThis.document;
+    const current = { kind: this.kind, value: this.value, extra: this.extra };
+    globalThis.document = { activeElement: current };
+    try { return fn(current); } finally { globalThis.document = previousDocument; }
+  }
+}
+class FakePage {
+  constructor() { this.currentUrl = ""; }
+  locator(selector) { append({ action: "locator", selector }); return new FakeLocator("css", selector); }
+  getByRole(role, options = {}) { append({ action: "getByRole", role, name: options.name || "" }); return new FakeLocator("role", role, options.name || ""); }
+  getByLabel(text) { append({ action: "getByLabel", text }); return new FakeLocator("label", text); }
+  getByPlaceholder(text) { append({ action: "getByPlaceholder", text }); return new FakeLocator("placeholder", text); }
+  getByText(text) { append({ action: "getByText", text }); return new FakeLocator("text", text); }
+  getByTestId(value) { append({ action: "getByTestId", value }); return new FakeLocator("testid", value); }
+  async setViewportSize(size) { append({ action: "viewport", width: size.width, height: size.height }); }
+  async goto(url, options = {}) { this.currentUrl = url; append({ action: "goto", url, waitUntil: options.waitUntil || "" }); return { status: () => 200, ok: () => true }; }
+  async waitForURL(url) { this.currentUrl = url; append({ action: "waitForURL", url }); }
+  async waitForTimeout(ms) { append({ action: "waitForTimeout", ms }); }
+  async waitForLoadState(state) { append({ action: "waitForLoadState", state }); }
+  async title() { return "Stub"; }
+  url() { return this.currentUrl; }
+  async screenshot(options) { fs.writeFileSync(options.path, "stub"); append({ action: "screenshot", path: options.path }); }
+  async content() { return "<html></html>"; }
+  async evaluate(fn, arg) { return typeof fn === "function" ? fn(arg) : null; }
+  once() {}
+}
+const page = new FakePage();
+const context = {
+  pages() { return [page]; },
+  async newPage() { return page; },
+  async close() { append({ action: "close" }); },
+  async storageState() { return { cookies: [], origins: [] }; },
+  async clearCookies() {},
+  async addCookies() {},
+};
+export const chromium = {
+  async launchPersistentContext() {
+    append({ action: "launch" });
+    return context;
+  }
+};
+`,
+  );
+
+  runBrowse(["click", "https://example.com/login", "role:button:Continue", "--session", "semantic", "--device", "mobile"]);
+  runBrowse(["fill", "https://example.com/login", "label:Email", "demo@example.com", "--session", "semantic"]);
+  runBrowse(["html", "https://example.com/search", "placeholder:Search", "--session", "semantic"]);
+  runBrowse(["assert-visible", "https://example.com/home", "testid:hero", "--session", "semantic"]);
+  runBrowse(["assert-text", "https://example.com/home", "text:Welcome back", "Welcome back", "--session", "semantic"]);
+  runBrowse(["wait", "https://example.com/home", "state:hidden:testid:toast", "--session", "semantic"]);
+
+  const log = JSON.parse(fs.readFileSync(logPath, "utf8")) as Array<Record<string, unknown>>;
+  assert.ok(log.some((entry) => entry.action === "viewport" && entry.width === 390 && entry.height === 844));
+  assert.ok(log.some((entry) => entry.action === "getByRole" && entry.role === "button" && entry.name === "Continue"));
+  assert.ok(log.some((entry) => entry.action === "getByLabel" && entry.text === "Email"));
+  assert.ok(log.some((entry) => entry.action === "getByPlaceholder" && entry.text === "Search"));
+  assert.ok(log.some((entry) => entry.action === "getByTestId" && entry.value === "hero"));
+  assert.ok(log.some((entry) => entry.action === "getByText" && entry.text === "Welcome back"));
+  assert.ok(log.some((entry) => entry.action === "waitFor" && entry.kind === "testid" && entry.value === "toast" && entry.state === "hidden"));
+
+  console.log("browse-semantic-device spec passed");
+}
+
+try {
+  await main();
+} finally {
+  fs.rmSync(fixtureRoot, { recursive: true, force: true });
+}

--- a/scripts/ci-check.sh
+++ b/scripts/ci-check.sh
@@ -73,6 +73,7 @@ run_ts scripts/issue-flow.ts --help >/tmp/codex-stack-issue-flow-help.log
 run_ts scripts/issue-flow.spec.ts >/tmp/codex-stack-issue-flow-spec.log
 run_ts scripts/render-pr-review.spec.ts >/tmp/codex-stack-render-pr-review-spec.log
 run_ts scripts/browse-advanced.spec.ts >/tmp/codex-stack-browse-advanced-spec.log
+run_ts scripts/browse-semantic-device.spec.ts >/tmp/codex-stack-browse-semantic-device-spec.log
 run_ts scripts/qa-diff.spec.ts >/tmp/codex-stack-qa-diff-spec.log
 run_ts scripts/qa-run.ts --help >/tmp/codex-stack-qa-help.log
 run_ts scripts/qa-run.spec.ts >/tmp/codex-stack-qa-spec.log

--- a/skills/browse/SKILL.md
+++ b/skills/browse/SKILL.md
@@ -74,6 +74,10 @@ bun src/cli.ts browse probe https://example.com/settings --session staging
 bun src/cli.ts browse upload https://example.com/profile "input[type=file]" ./fixtures/avatar.png --session staging
 bun src/cli.ts browse dialog https://example.com/settings accept "#delete-confirm" --session staging
 bun src/cli.ts browse wait https://example.com/dashboard load:domcontentloaded --session staging
+bun src/cli.ts browse click https://example.com/login "role:button:Continue" --session staging --device mobile
+bun src/cli.ts browse fill https://example.com/login "label:Email" demo@example.com --session staging
+bun src/cli.ts browse html https://example.com/search "placeholder:Search" --session staging
+bun src/cli.ts browse assert-visible https://example.com/home "testid:hero" --session staging
 bun src/cli.ts browse snapshot https://example.com marketing-home --session staging
 bun src/cli.ts browse compare-snapshot https://example.com marketing-home --session staging
 bun src/cli.ts browse login https://example.com/login login-local --session staging
@@ -88,7 +92,9 @@ bun src/cli.ts browse sessions
 
 - Do not claim visual validation without screenshots or runtime output.
 - Prefer deterministic selectors and stable flows.
+- Prefer semantic selectors when possible: `role:button:Save`, `label:Email`, `placeholder:Search`, `text:Welcome back`, `testid:hero`.
 - Reuse named sessions for authenticated flows so login state persists.
+- Use `--device mobile|tablet|desktop` when the check is viewport-sensitive or when a bug only reproduces responsively.
 - Export/import session bundles when authenticated QA needs to move between machines or named sessions.
 - Use `dialog` before the click that triggers a modal or confirm prompt so the handler is armed in time.
 - Check in shared flows under `browse/flows/`; keep machine-specific experiments in `.codex-stack/browse/flows/`.


### PR DESCRIPTION
## Summary
- add semantic selector prefixes for browse commands and flow steps
- add responsive device presets via `--device` for browser commands
- add regression coverage and refresh browse docs

## Validation
- bun run typecheck
- bun scripts/browse-semantic-device.spec.ts
- bun run smoke
- bun src/cli.ts review --json

Closes #27