### PR TITLE
feat: add request mocking for browse flows

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Use the repo in this order:
 
 - Installable Codex skills under `skills/`
 - Checked-in root CLI under `src/cli.ts`
-- Playwright-backed browser runtime under `browse/src/cli.ts` with semantic selectors, device presets, iframe targeting, upload, dialog, wait-state, and element-state assertions
+- Playwright-backed browser runtime under `browse/src/cli.ts` with semantic selectors, device presets, iframe targeting, request mocking/blocking, upload, dialog, wait-state, and element-state assertions
 - Persistent named browser sessions
 - Portable session import/export with cookie and storage-state bundles
 - Checked-in and local browser flows with import/export for JSON, YAML, and Markdown
@@ -177,6 +177,7 @@ bun src/cli.ts browse click https://example.com/login "role:button:Continue" --s
 bun src/cli.ts browse fill https://example.com/login "label:Email" demo@example.com --session staging
 bun src/cli.ts browse assert-visible https://example.com/home "testid:hero" --session staging
 bun src/cli.ts browse click https://example.com/checkout "role:button:Pay now" --session staging --frame "name:payment"
+bun src/cli.ts browse mock https://example.com/app "**/api/profile" '{"status":503,"json":{"error":"offline"}}' --session staging
 bun src/cli.ts browse assert-focused https://example.com/login "input[name=email]" --session staging
 bun src/cli.ts browse snapshot https://example.com marketing-home --session staging
 bun src/cli.ts browse compare-snapshot https://example.com marketing-home --session staging
@@ -214,6 +215,7 @@ Use `browse` when you want raw control:
 - ad hoc assertions
 - semantic selectors and responsive viewport presets
 - iframe targeting by frame name, URL fragment, or iframe selector
+- request blocking and mocked responses for repeatable QA and failure-path testing
 - screenshots and artifacts
 
 Use `qa` when you want a decision-ready report:

--- a/browse/src/cli.ts
+++ b/browse/src/cli.ts
@@ -194,6 +194,8 @@ Usage:
   codex-stack browse html <url> [selector] [--session <name>] [--device <desktop|tablet|mobile>]
   codex-stack browse links <url> [--session <name>] [--device <desktop|tablet|mobile>]
   codex-stack browse screenshot <url> [path] [--session <name>] [--device <desktop|tablet|mobile>]
+  codex-stack browse mock <url> <pattern> <json-config> [--session <name>] [--device <desktop|tablet|mobile>]
+  codex-stack browse block <url> <pattern> [--session <name>] [--device <desktop|tablet|mobile>]
   codex-stack browse eval <url> <expression> [--session <name>] [--device <desktop|tablet|mobile>]
   codex-stack browse click <url> <selector> [--session <name>] [--device <desktop|tablet|mobile>]
   codex-stack browse fill <url> <selector> <value> [--session <name>] [--device <desktop|tablet|mobile>]
@@ -705,7 +707,7 @@ function compareSnapshotData(
 
 function isPreNavigationStep(step: FlowStep): boolean {
   const action = String(step?.action || "");
-  return action === "clear-storage";
+  return action === "clear-storage" || action === "route" || action === "clear-routes";
 }
 
 function expandFlowSteps(steps: FlowStep[], stack: string[] = []): FlowStep[] {
@@ -1041,6 +1043,64 @@ async function applyDevicePreset(page: PlaywrightPage, preset: DevicePreset | nu
   }
 }
 
+function normalizeRouteHeaders(headers: unknown): Record<string, string> {
+  if (!headers || typeof headers !== "object" || Array.isArray(headers)) return {};
+  return Object.fromEntries(
+    Object.entries(headers as Record<string, unknown>).map(([key, value]) => [key, String(value)]),
+  );
+}
+
+async function clearRouteRules(page: PlaywrightPage): Promise<void> {
+  if (typeof page.unrouteAll === "function") {
+    await page.unrouteAll({ behavior: "ignoreErrors" });
+  }
+}
+
+async function installRouteRule(page: PlaywrightPage, step: FlowStep): Promise<StepResult> {
+  const pattern = String(step.pattern ?? step.match ?? step.url ?? "").trim();
+  assertCondition(pattern, "route steps require a pattern.");
+  const requestedMode = String(step.mode || "").trim().toLowerCase();
+  const mode = requestedMode || (step.abort ? "abort" : (step.json !== undefined || step.body !== undefined || step.status !== undefined || step.headers !== undefined ? "fulfill" : "continue"));
+  const errorCode = String(step.errorCode || "failed");
+  const headers = normalizeRouteHeaders(step.headers);
+  const status = Number(step.status ?? 200);
+  const jsonPayload = step.json;
+  const body = step.body === undefined ? "" : String(step.body);
+
+  await page.route(pattern, async (route: Record<string, unknown>) => {
+    if (mode === "abort") {
+      await (route.abort as (code?: string) => Promise<void>)(errorCode);
+      return;
+    }
+    if (mode === "fulfill") {
+      const fulfillHeaders = { ...headers };
+      let responseBody = body;
+      if (jsonPayload !== undefined) {
+        if (!fulfillHeaders["content-type"]) {
+          fulfillHeaders["content-type"] = "application/json";
+        }
+        responseBody = JSON.stringify(jsonPayload);
+      }
+      await (route.fulfill as (payload: Record<string, unknown>) => Promise<void>)({
+        status,
+        headers: fulfillHeaders,
+        body: responseBody,
+      });
+      return;
+    }
+    await (route.continue as () => Promise<void>)();
+  });
+
+  return {
+    action: "route",
+    pattern,
+    mode,
+    status: mode === "fulfill" ? status : undefined,
+    errorCode: mode === "abort" ? errorCode : undefined,
+    frame: undefined,
+  };
+}
+
 async function armDialog(
   page: PlaywrightPage,
   mode: string,
@@ -1217,6 +1277,14 @@ async function runStep(page: PlaywrightPage, step: FlowStep, sessionName: string
     const target = String(step.path || path.join(os.tmpdir(), `codex-stack-flow-${sessionName}.png`));
     await page.screenshot({ path: target, fullPage: true });
     return { action, path: target, frame: frame || undefined, status: "ok" };
+  }
+  if (action === "route") {
+    const configured = await installRouteRule(page, step);
+    return { ...configured, status: "ok" };
+  }
+  if (action === "clear-routes") {
+    await clearRouteRules(page);
+    return { action, status: "ok" };
   }
   if (action === "text") {
     const text = await resolveLocator(scope, String(step.selector || "body")).innerText();
@@ -1675,6 +1743,54 @@ async function main(): Promise<void> {
     await withPage(session, url, device, async ({ page }: { page: PlaywrightPage }) => page.screenshot({ path: outPath, fullPage: true }));
     recordSession(session, { lastCommand: "screenshot", lastUrl: url, output: outPath });
     console.log(outPath);
+    return;
+  }
+
+  if (command === "mock") {
+    const [url, pattern, configText] = rest;
+    if (!url || !pattern || !configText) usage();
+    let config: FlowStep;
+    try {
+      config = JSON.parse(configText) as FlowStep;
+    } catch {
+      throw new Error("mock requires a JSON config object.");
+    }
+    const result = await withPage(session, "", device, async ({ page }: { page: PlaywrightPage }) => {
+      const configured = await installRouteRule(page, { action: "route", pattern, ...config });
+      const response = (await page.goto(url, { waitUntil: "networkidle" })) as PlaywrightResponse | null;
+      return {
+        ...configured,
+        action: "mock",
+        url,
+        finalUrl: page.url(),
+        responseStatus: response ? response.status() : null,
+      };
+    });
+    recordSession(session, {
+      lastCommand: "mock",
+      lastUrl: url,
+      output: `${pattern}:${String((result as Record<string, unknown>).mode || "continue")}`,
+    });
+    printJson(result);
+    return;
+  }
+
+  if (command === "block") {
+    const [url, pattern] = rest;
+    if (!url || !pattern) usage();
+    const result = await withPage(session, "", device, async ({ page }: { page: PlaywrightPage }) => {
+      const configured = await installRouteRule(page, { action: "route", pattern, mode: "abort" });
+      const response = (await page.goto(url, { waitUntil: "networkidle" })) as PlaywrightResponse | null;
+      return {
+        ...configured,
+        action: "block",
+        url,
+        finalUrl: page.url(),
+        responseStatus: response ? response.status() : null,
+      };
+    });
+    recordSession(session, { lastCommand: "block", lastUrl: url, output: pattern });
+    printJson(result);
     return;
   }
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -40,6 +40,8 @@ bun src/cli.ts browse fill https://example.com/login "label:Email" demo@example.
 bun src/cli.ts browse html https://example.com/search "placeholder:Search" --session staging
 bun src/cli.ts browse assert-visible https://example.com/home "testid:hero" --session staging
 bun src/cli.ts browse click https://example.com/checkout "role:button:Pay now" --session staging --frame "name:payment"
+bun src/cli.ts browse mock https://example.com/app "**/api/profile" '{"status":503,"json":{"error":"offline"}}' --session staging
+bun src/cli.ts browse block https://example.com/app "**/analytics/**" --session staging
 bun src/cli.ts browse save-flow login-local '[{"action":"fill","selector":"input[name=email]","value":"demo@example.com"},{"action":"fill","selector":"input[name=password]","value":"demo-pass"},{"action":"click","selector":"button[type=submit]"}]'
 bun src/cli.ts browse save-repo-flow landing-smoke '[{"action":"assert-visible","selector":"main"}]'
 bun src/cli.ts browse import-flow login-local ./docs/login-flow.md
@@ -222,6 +224,8 @@ Notes:
 - Add `--device mobile|tablet|desktop` to browser commands when you need a specific responsive viewport.
 - Add `--frame name:<name>`, `--frame url:<fragment>`, or `--frame <iframe-selector>` when the target lives inside an iframe.
 - Flow steps can override the default frame with a `frame` property, for example `{ "action": "assert-text", "selector": "text:Frame ready", "frame": "name:payment" }`.
+- Use `mock` for one-off fulfilled responses and `block` for one-off aborted requests on direct browser commands.
+- Flow steps also support `{ "action": "route", ... }` and `{ "action": "clear-routes" }` so network controls can be armed before navigation.
 - Use `{"action":"use-flow","name":"portal-login"}` inside a checked-in flow to compose a larger QA sequence.
 - Flow import/export supports `.json`, `.yaml` / `.yml`, and Markdown files with fenced JSON or YAML blocks.
 - Leading `{"action":"clear-storage"}` steps run before navigation, which is useful for repeatable login flows on persistent sessions.

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -84,6 +84,7 @@ bun src/cli.ts browse click http://127.0.0.1:4173/login "role:button:Continue" -
 bun src/cli.ts browse fill http://127.0.0.1:4173/login "label:Email" demo@example.com --session friend-demo
 bun src/cli.ts browse assert-visible http://127.0.0.1:4173/dashboard "testid:hero" --session friend-demo
 bun src/cli.ts browse click http://127.0.0.1:4173/checkout "role:button:Pay now" --session friend-demo --frame "name:payment"
+bun src/cli.ts browse mock http://127.0.0.1:4173/dashboard "**/api/profile" '{"status":503,"json":{"error":"offline"}}' --session friend-demo
 bun src/cli.ts browse assert-focused http://127.0.0.1:4173/login "input[name=email]" --session friend-demo
 bun src/cli.ts browse snapshot http://127.0.0.1:4173/dashboard portal-dashboard --session friend-demo
 bun src/cli.ts browse compare-snapshot http://127.0.0.1:4173/dashboard portal-dashboard --session friend-demo

--- a/scripts/browse-network.spec.ts
+++ b/scripts/browse-network.spec.ts
@@ -1,0 +1,140 @@
+#!/usr/bin/env bun
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import process from "node:process";
+import { execFileSync } from "node:child_process";
+
+const rootDir = process.cwd();
+const bun = process.execPath || "bun";
+const fixtureRoot = fs.mkdtempSync(path.join(os.tmpdir(), "codex-stack-browse-network-"));
+const logPath = path.join(fixtureRoot, "playwright-log.json");
+const modulePath = path.join(fixtureRoot, "playwright-stub.mjs");
+
+function runBrowse(args: string[]): string {
+  return execFileSync(bun, [path.join(rootDir, "browse", "src", "cli.ts"), ...args], {
+    cwd: fixtureRoot,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      CODEX_STACK_PLAYWRIGHT_MODULE: modulePath,
+      CODEX_STACK_PLAYWRIGHT_LOG: logPath,
+    },
+  }).trim();
+}
+
+async function main(): Promise<void> {
+  fs.writeFileSync(
+    modulePath,
+    `import fs from "node:fs";
+const LOG_PATH = process.env.CODEX_STACK_PLAYWRIGHT_LOG;
+function append(entry) {
+  const rows = fs.existsSync(LOG_PATH) ? JSON.parse(fs.readFileSync(LOG_PATH, "utf8")) : [];
+  rows.push(entry);
+  fs.writeFileSync(LOG_PATH, JSON.stringify(rows, null, 2));
+}
+class FakePage {
+  constructor() { this.currentUrl = ""; this.routes = []; }
+  locator(selector) { return { first: () => ({ innerText: async () => selector, waitFor: async () => {}, count: async () => 1, isEnabled: async () => true, isDisabled: async () => false, isChecked: async () => false, isEditable: async () => true, evaluate: async () => true }) }; }
+  getByRole(role, options = {}) { return { first: () => ({ click: async () => append({ action: "getByRole-click", role, name: options.name || "" }) }) }; }
+  getByLabel(text) { return { first: () => ({ fill: async (value) => append({ action: "getByLabel-fill", text, value }) }) }; }
+  getByPlaceholder(text) { return { first: () => ({ innerHTML: async () => text }) }; }
+  getByText(text) { return { first: () => ({ innerText: async () => text, waitFor: async () => append({ action: "getByText-wait", text }) }) }; }
+  getByTestId(value) { return { first: () => ({ waitFor: async (options) => append({ action: "getByTestId-wait", value, state: options?.state || "visible" }) }) }; }
+  async route(pattern, handler) { this.routes.push({ pattern, handler }); append({ action: "route-registered", pattern }); }
+  async unrouteAll() { this.routes = []; append({ action: "unrouteAll" }); }
+  async goto(url, options = {}) {
+    this.currentUrl = url;
+    append({ action: "goto", url, waitUntil: options.waitUntil || "" });
+    for (const entry of this.routes) {
+      await entry.handler({
+        abort: async (code) => append({ action: "route-abort", pattern: entry.pattern, code: code || "" }),
+        continue: async () => append({ action: "route-continue", pattern: entry.pattern }),
+        fulfill: async (payload) => append({ action: "route-fulfill", pattern: entry.pattern, status: payload.status, body: payload.body || "", headers: payload.headers || {} }),
+      });
+    }
+    return { status: () => 200, ok: () => true };
+  }
+  async waitForURL(url) { this.currentUrl = url; append({ action: "waitForURL", url }); }
+  async waitForTimeout(ms) { append({ action: "waitForTimeout", ms }); }
+  async waitForLoadState(state) { append({ action: "waitForLoadState", state }); }
+  async title() { return "Stub"; }
+  url() { return this.currentUrl; }
+  async screenshot(options) { fs.writeFileSync(options.path, "stub"); append({ action: "screenshot", path: options.path }); }
+  async content() { return "<html></html>"; }
+  async evaluate(fn, arg) { return typeof fn === "function" ? fn(arg) : null; }
+  once() {}
+}
+const page = new FakePage();
+const context = {
+  pages() { return [page]; },
+  async newPage() { return page; },
+  async close() { append({ action: "close" }); },
+  async storageState() { return { cookies: [], origins: [] }; },
+  async clearCookies() {},
+  async addCookies() {},
+};
+export const chromium = {
+  async launchPersistentContext() {
+    append({ action: "launch" });
+    return context;
+  }
+};
+`,
+  );
+
+  const mockOutput = runBrowse([
+    "mock",
+    "https://example.com/app",
+    "**/api/profile",
+    '{"status":503,"json":{"error":"offline"}}',
+    "--session",
+    "network",
+  ]);
+  const mockResult = JSON.parse(mockOutput) as { action?: string; mode?: string; status?: number };
+  assert.equal(mockResult.action, "mock");
+  assert.equal(mockResult.mode, "fulfill");
+  assert.equal(mockResult.status, 503);
+
+  const blockOutput = runBrowse([
+    "block",
+    "https://example.com/app",
+    "**/analytics/**",
+    "--session",
+    "network",
+  ]);
+  const blockResult = JSON.parse(blockOutput) as { action?: string; mode?: string };
+  assert.equal(blockResult.action, "block");
+  assert.equal(blockResult.mode, "abort");
+
+  const flowOutput = runBrowse([
+    "flow",
+    "https://example.com/app",
+    JSON.stringify([
+      { action: "route", pattern: "**/api/orders", json: { orders: [] } },
+      { action: "clear-routes" },
+      { action: "wait", ms: 1 },
+    ]),
+    "--session",
+    "network",
+  ]);
+  const flowResults = JSON.parse(flowOutput) as Array<{ action?: string; status?: string; mode?: string }>;
+  assert.ok(flowResults.some((entry) => entry.action === "route" && entry.mode === "fulfill" && entry.status === "ok"));
+  assert.ok(flowResults.some((entry) => entry.action === "clear-routes" && entry.status === "ok"));
+
+  const log = JSON.parse(fs.readFileSync(logPath, "utf8")) as Array<Record<string, unknown>>;
+  assert.ok(log.some((entry) => entry.action === "route-registered" && entry.pattern === "**/api/profile"));
+  assert.ok(log.some((entry) => entry.action === "route-fulfill" && entry.pattern === "**/api/profile" && entry.status === 503));
+  assert.ok(log.some((entry) => entry.action === "route-abort" && entry.pattern === "**/analytics/**"));
+  assert.ok(log.some((entry) => entry.action === "route-registered" && entry.pattern === "**/api/orders"));
+  assert.ok(log.some((entry) => entry.action === "unrouteAll"));
+
+  console.log("browse-network spec passed");
+}
+
+try {
+  await main();
+} finally {
+  fs.rmSync(fixtureRoot, { recursive: true, force: true });
+}

--- a/scripts/ci-check.sh
+++ b/scripts/ci-check.sh
@@ -75,6 +75,7 @@ run_ts scripts/render-pr-review.spec.ts >/tmp/codex-stack-render-pr-review-spec.
 run_ts scripts/browse-advanced.spec.ts >/tmp/codex-stack-browse-advanced-spec.log
 run_ts scripts/browse-semantic-device.spec.ts >/tmp/codex-stack-browse-semantic-device-spec.log
 run_ts scripts/browse-iframe.spec.ts >/tmp/codex-stack-browse-iframe-spec.log
+run_ts scripts/browse-network.spec.ts >/tmp/codex-stack-browse-network-spec.log
 run_ts scripts/qa-diff.spec.ts >/tmp/codex-stack-qa-diff-spec.log
 run_ts scripts/qa-run.ts --help >/tmp/codex-stack-qa-help.log
 run_ts scripts/qa-run.spec.ts >/tmp/codex-stack-qa-spec.log

--- a/skills/browse/SKILL.md
+++ b/skills/browse/SKILL.md
@@ -38,6 +38,8 @@ Give the agent eyes for QA and deployment checks.
 - `html <url> [selector]`
 - `links <url>`
 - `screenshot <url> [path]`
+- `mock <url> <pattern> <json-config>`
+- `block <url> <pattern>`
 - `eval <url> <expression>`
 - `click <url> <selector>`
 - `fill <url> <selector> <value>`
@@ -59,6 +61,8 @@ Give the agent eyes for QA and deployment checks.
 - `run-flow <url> <name>`
 - `login <url> <name>`
 - flow step action: `use-flow`
+- flow step action: `route`
+- flow step action: `clear-routes`
 
 ## Example
 
@@ -79,6 +83,8 @@ bun src/cli.ts browse fill https://example.com/login "label:Email" demo@example.
 bun src/cli.ts browse html https://example.com/search "placeholder:Search" --session staging
 bun src/cli.ts browse assert-visible https://example.com/home "testid:hero" --session staging
 bun src/cli.ts browse click https://example.com/checkout "role:button:Pay now" --session staging --frame "name:payment"
+bun src/cli.ts browse mock https://example.com/app "**/api/profile" '{"status":503,"json":{"error":"offline"}}' --session staging
+bun src/cli.ts browse block https://example.com/app "**/analytics/**" --session staging
 bun src/cli.ts browse snapshot https://example.com marketing-home --session staging
 bun src/cli.ts browse compare-snapshot https://example.com marketing-home --session staging
 bun src/cli.ts browse login https://example.com/login login-local --session staging
@@ -95,6 +101,7 @@ bun src/cli.ts browse sessions
 - Prefer deterministic selectors and stable flows.
 - Prefer semantic selectors when possible: `role:button:Save`, `label:Email`, `placeholder:Search`, `text:Welcome back`, `testid:hero`.
 - Use `--frame name:<name>`, `--frame url:<fragment>`, or `--frame <iframe-selector>` when the target element lives inside an iframe.
+- Use `route` / `clear-routes` flow steps or the `mock` / `block` commands to stabilize flaky third-party calls and test failure paths before navigation starts.
 - Reuse named sessions for authenticated flows so login state persists.
 - Use `--device mobile|tablet|desktop` when the check is viewport-sensitive or when a bug only reproduces responsively.
 - Export/import session bundles when authenticated QA needs to move between machines or named sessions.


### PR DESCRIPTION
## Summary
- add one-off request mocking and blocking commands for browse
- add pre-navigation `route` and `clear-routes` flow steps
- cover the new route controls with regression tests and docs

## Validation
- bun run typecheck
- bun src/cli.ts review --json
- bun run smoke

Closes #31