### PR TITLE
feat: add download capture to browse

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Use the repo in this order:
 
 - Installable Codex skills under `skills/`
 - Checked-in root CLI under `src/cli.ts`
-- Playwright-backed browser runtime under `browse/src/cli.ts` with semantic selectors, device presets, iframe targeting, request mocking/blocking, upload, dialog, wait-state, and element-state assertions
+- Playwright-backed browser runtime under `browse/src/cli.ts` with semantic selectors, device presets, iframe targeting, request mocking/blocking, download capture, upload, dialog, wait-state, and element-state assertions
 - Persistent named browser sessions
 - Portable session import/export with cookie and storage-state bundles
 - Checked-in and local browser flows with import/export for JSON, YAML, and Markdown
@@ -178,6 +178,7 @@ bun src/cli.ts browse fill https://example.com/login "label:Email" demo@example.
 bun src/cli.ts browse assert-visible https://example.com/home "testid:hero" --session staging
 bun src/cli.ts browse click https://example.com/checkout "role:button:Pay now" --session staging --frame "name:payment"
 bun src/cli.ts browse mock https://example.com/app "**/api/profile" '{"status":503,"json":{"error":"offline"}}' --session staging
+bun src/cli.ts browse download https://example.com/reports "role:button:Export CSV" ./artifacts/report.csv --session staging
 bun src/cli.ts browse assert-focused https://example.com/login "input[name=email]" --session staging
 bun src/cli.ts browse snapshot https://example.com marketing-home --session staging
 bun src/cli.ts browse compare-snapshot https://example.com marketing-home --session staging
@@ -216,6 +217,7 @@ Use `browse` when you want raw control:
 - semantic selectors and responsive viewport presets
 - iframe targeting by frame name, URL fragment, or iframe selector
 - request blocking and mocked responses for repeatable QA and failure-path testing
+- download capture and filename assertions for export flows
 - screenshots and artifacts
 
 Use `qa` when you want a decision-ready report:

--- a/browse/src/cli.ts
+++ b/browse/src/cli.ts
@@ -196,6 +196,8 @@ Usage:
   codex-stack browse screenshot <url> [path] [--session <name>] [--device <desktop|tablet|mobile>]
   codex-stack browse mock <url> <pattern> <json-config> [--session <name>] [--device <desktop|tablet|mobile>]
   codex-stack browse block <url> <pattern> [--session <name>] [--device <desktop|tablet|mobile>]
+  codex-stack browse download <url> <selector> [path] [--session <name>] [--device <desktop|tablet|mobile>]
+  codex-stack browse assert-download <url> <selector> <expected-name-fragment> [path] [--session <name>] [--device <desktop|tablet|mobile>]
   codex-stack browse eval <url> <expression> [--session <name>] [--device <desktop|tablet|mobile>]
   codex-stack browse click <url> <selector> [--session <name>] [--device <desktop|tablet|mobile>]
   codex-stack browse fill <url> <selector> <value> [--session <name>] [--device <desktop|tablet|mobile>]
@@ -1056,6 +1058,33 @@ async function clearRouteRules(page: PlaywrightPage): Promise<void> {
   }
 }
 
+function resolveDownloadPath(targetPath: string, suggestedFilename: string): string {
+  const raw = String(targetPath || "").trim();
+  if (!raw) return path.join(os.tmpdir(), suggestedFilename || `codex-stack-download-${Date.now()}`);
+  const absolute = path.resolve(process.cwd(), raw);
+  if (fs.existsSync(absolute) && fs.statSync(absolute).isDirectory()) {
+    return path.join(absolute, suggestedFilename || `codex-stack-download-${Date.now()}`);
+  }
+  return absolute;
+}
+
+async function captureDownload(page: PlaywrightPage, scope: PlaywrightScope, selector: string, targetPath = ""): Promise<{ path: string; suggestedFilename: string }> {
+  const [download] = await Promise.all([
+    page.waitForEvent("download"),
+    resolveLocator(scope, selector).click(),
+  ]);
+  const suggestedFilename = typeof download.suggestedFilename === "function" ? String(download.suggestedFilename() || "") : "";
+  const outputPath = resolveDownloadPath(targetPath, suggestedFilename);
+  ensureDir(path.dirname(outputPath));
+  if (typeof download.saveAs === "function") {
+    await download.saveAs(outputPath);
+  }
+  return {
+    path: outputPath,
+    suggestedFilename,
+  };
+}
+
 async function installRouteRule(page: PlaywrightPage, step: FlowStep): Promise<StepResult> {
   const pattern = String(step.pattern ?? step.match ?? step.url ?? "").trim();
   assertCondition(pattern, "route steps require a pattern.");
@@ -1277,6 +1306,22 @@ async function runStep(page: PlaywrightPage, step: FlowStep, sessionName: string
     const target = String(step.path || path.join(os.tmpdir(), `codex-stack-flow-${sessionName}.png`));
     await page.screenshot({ path: target, fullPage: true });
     return { action, path: target, frame: frame || undefined, status: "ok" };
+  }
+  if (action === "download") {
+    const selector = String(step.selector || "");
+    const download = await captureDownload(page, scope, selector, String(step.path || ""));
+    return { action, selector, frame: frame || undefined, ...download, status: "ok" };
+  }
+  if (action === "assert-download") {
+    const selector = String(step.selector || "");
+    const expected = String(step.expected ?? step.value ?? step.name ?? "");
+    assertCondition(expected, "assert-download steps require an expected filename fragment.");
+    const download = await captureDownload(page, scope, selector, String(step.path || ""));
+    assertCondition(
+      download.suggestedFilename.includes(expected),
+      `Expected downloaded filename to include ${JSON.stringify(expected)} but got ${JSON.stringify(download.suggestedFilename)}.`,
+    );
+    return { action, selector, expected, frame: frame || undefined, ...download, status: "ok" };
   }
   if (action === "route") {
     const configured = await installRouteRule(page, step);
@@ -1790,6 +1835,38 @@ async function main(): Promise<void> {
       };
     });
     recordSession(session, { lastCommand: "block", lastUrl: url, output: pattern });
+    printJson(result);
+    return;
+  }
+
+  if (command === "download") {
+    const [url, selector, targetPath] = rest;
+    if (!url || !selector) usage();
+    const result = await withPage(session, url, device, async ({ page }: { page: PlaywrightPage }) => {
+      const scope = await resolveScope(page, frame);
+      return captureDownload(page, scope, selector, targetPath || "");
+    });
+    recordSession(session, { lastCommand: "download", lastUrl: url, output: result.path });
+    printJson(result);
+    return;
+  }
+
+  if (command === "assert-download") {
+    const [url, selector, expected, targetPath] = rest;
+    if (!url || !selector || !expected) usage();
+    const result = await withPage(session, url, device, async ({ page }: { page: PlaywrightPage }) => {
+      const scope = await resolveScope(page, frame);
+      const download = await captureDownload(page, scope, selector, targetPath || "");
+      assertCondition(
+        download.suggestedFilename.includes(expected),
+        `Expected downloaded filename to include ${JSON.stringify(expected)} but got ${JSON.stringify(download.suggestedFilename)}.`,
+      );
+      return {
+        ...download,
+        expected,
+      };
+    });
+    recordSession(session, { lastCommand: "assert-download", lastUrl: url, output: `${result.path}:${expected}` });
     printJson(result);
     return;
   }

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -42,6 +42,8 @@ bun src/cli.ts browse assert-visible https://example.com/home "testid:hero" --se
 bun src/cli.ts browse click https://example.com/checkout "role:button:Pay now" --session staging --frame "name:payment"
 bun src/cli.ts browse mock https://example.com/app "**/api/profile" '{"status":503,"json":{"error":"offline"}}' --session staging
 bun src/cli.ts browse block https://example.com/app "**/analytics/**" --session staging
+bun src/cli.ts browse download https://example.com/reports "role:button:Export CSV" ./artifacts/report.csv --session staging
+bun src/cli.ts browse assert-download https://example.com/reports "role:button:Export CSV" report.csv ./artifacts/report.csv --session staging
 bun src/cli.ts browse save-flow login-local '[{"action":"fill","selector":"input[name=email]","value":"demo@example.com"},{"action":"fill","selector":"input[name=password]","value":"demo-pass"},{"action":"click","selector":"button[type=submit]"}]'
 bun src/cli.ts browse save-repo-flow landing-smoke '[{"action":"assert-visible","selector":"main"}]'
 bun src/cli.ts browse import-flow login-local ./docs/login-flow.md
@@ -226,6 +228,8 @@ Notes:
 - Flow steps can override the default frame with a `frame` property, for example `{ "action": "assert-text", "selector": "text:Frame ready", "frame": "name:payment" }`.
 - Use `mock` for one-off fulfilled responses and `block` for one-off aborted requests on direct browser commands.
 - Flow steps also support `{ "action": "route", ... }` and `{ "action": "clear-routes" }` so network controls can be armed before navigation.
+- Use `download` to save a file to disk and `assert-download` when the filename fragment itself is part of the assertion.
+- Flow steps also support `{ "action": "download", ... }` and `{ "action": "assert-download", ... }` for checked-in export flows.
 - Use `{"action":"use-flow","name":"portal-login"}` inside a checked-in flow to compose a larger QA sequence.
 - Flow import/export supports `.json`, `.yaml` / `.yml`, and Markdown files with fenced JSON or YAML blocks.
 - Leading `{"action":"clear-storage"}` steps run before navigation, which is useful for repeatable login flows on persistent sessions.

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -85,6 +85,7 @@ bun src/cli.ts browse fill http://127.0.0.1:4173/login "label:Email" demo@exampl
 bun src/cli.ts browse assert-visible http://127.0.0.1:4173/dashboard "testid:hero" --session friend-demo
 bun src/cli.ts browse click http://127.0.0.1:4173/checkout "role:button:Pay now" --session friend-demo --frame "name:payment"
 bun src/cli.ts browse mock http://127.0.0.1:4173/dashboard "**/api/profile" '{"status":503,"json":{"error":"offline"}}' --session friend-demo
+bun src/cli.ts browse download http://127.0.0.1:4173/reports "role:button:Export CSV" ./artifacts/report.csv --session friend-demo
 bun src/cli.ts browse assert-focused http://127.0.0.1:4173/login "input[name=email]" --session friend-demo
 bun src/cli.ts browse snapshot http://127.0.0.1:4173/dashboard portal-dashboard --session friend-demo
 bun src/cli.ts browse compare-snapshot http://127.0.0.1:4173/dashboard portal-dashboard --session friend-demo

--- a/scripts/browse-download.spec.ts
+++ b/scripts/browse-download.spec.ts
@@ -1,0 +1,153 @@
+#!/usr/bin/env bun
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import process from "node:process";
+import { execFileSync } from "node:child_process";
+
+const rootDir = process.cwd();
+const bun = process.execPath || "bun";
+const fixtureRoot = fs.mkdtempSync(path.join(os.tmpdir(), "codex-stack-browse-download-"));
+const logPath = path.join(fixtureRoot, "playwright-log.json");
+const modulePath = path.join(fixtureRoot, "playwright-stub.mjs");
+
+function runBrowse(args: string[]): string {
+  return execFileSync(bun, [path.join(rootDir, "browse", "src", "cli.ts"), ...args], {
+    cwd: fixtureRoot,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      CODEX_STACK_PLAYWRIGHT_MODULE: modulePath,
+      CODEX_STACK_PLAYWRIGHT_LOG: logPath,
+    },
+  }).trim();
+}
+
+async function main(): Promise<void> {
+  fs.writeFileSync(
+    modulePath,
+    `import fs from "node:fs";
+import path from "node:path";
+const LOG_PATH = process.env.CODEX_STACK_PLAYWRIGHT_LOG;
+function append(entry) {
+  const rows = fs.existsSync(LOG_PATH) ? JSON.parse(fs.readFileSync(LOG_PATH, "utf8")) : [];
+  rows.push(entry);
+  fs.writeFileSync(LOG_PATH, JSON.stringify(rows, null, 2));
+}
+class FakeLocator {
+  constructor(kind, value, extra = "") { this.kind = kind; this.value = value; this.extra = extra; }
+  first() { return this; }
+  async click() { append({ action: "click", kind: this.kind, value: this.value, extra: this.extra }); }
+  async innerText() { return this.extra || this.value; }
+  async waitFor() {}
+  async count() { return 1; }
+  async isEnabled() { return true; }
+  async isDisabled() { return false; }
+  async isChecked() { return false; }
+  async isEditable() { return true; }
+  async evaluate() { return true; }
+}
+class FakePage {
+  constructor() { this.currentUrl = ""; }
+  locator(selector) { return new FakeLocator("css", selector); }
+  getByRole(role, options = {}) { append({ action: "getByRole", role, name: options.name || "" }); return new FakeLocator("role", role, options.name || ""); }
+  getByLabel(text) { return new FakeLocator("label", text); }
+  getByPlaceholder(text) { return new FakeLocator("placeholder", text); }
+  getByText(text) { return new FakeLocator("text", text); }
+  getByTestId(value) { return new FakeLocator("testid", value); }
+  async goto(url, options = {}) { this.currentUrl = url; append({ action: "goto", url, waitUntil: options.waitUntil || "" }); return { status: () => 200, ok: () => true }; }
+  async waitForEvent(event) {
+    append({ action: "waitForEvent", event });
+    return {
+      suggestedFilename() { return "report.csv"; },
+      async saveAs(targetPath) { fs.mkdirSync(path.dirname(targetPath), { recursive: true }); fs.writeFileSync(targetPath, "stub report\\n"); append({ action: "saveAs", path: targetPath }); },
+    };
+  }
+  async waitForURL(url) { this.currentUrl = url; }
+  async waitForTimeout(ms) { append({ action: "waitForTimeout", ms }); }
+  async waitForLoadState(state) { append({ action: "waitForLoadState", state }); }
+  async title() { return "Stub"; }
+  url() { return this.currentUrl; }
+  async screenshot(options) { fs.writeFileSync(options.path, "stub"); }
+  async content() { return "<html></html>"; }
+  async evaluate(fn, arg) { return typeof fn === "function" ? fn(arg) : null; }
+  once() {}
+}
+const page = new FakePage();
+const context = {
+  pages() { return [page]; },
+  async newPage() { return page; },
+  async close() { append({ action: "close" }); },
+  async storageState() { return { cookies: [], origins: [] }; },
+  async clearCookies() {},
+  async addCookies() {},
+};
+export const chromium = {
+  async launchPersistentContext() {
+    append({ action: "launch" });
+    return context;
+  }
+};
+`,
+  );
+
+  const downloadPath = path.join(fixtureRoot, "report-direct.csv");
+  const directOutput = runBrowse([
+    "download",
+    "https://example.com/reports",
+    "role:button:Export CSV",
+    downloadPath,
+    "--session",
+    "download",
+  ]);
+  const directResult = JSON.parse(directOutput) as { path?: string; suggestedFilename?: string };
+  assert.equal(directResult.path, downloadPath);
+  assert.equal(directResult.suggestedFilename, "report.csv");
+  assert.ok(fs.existsSync(downloadPath));
+
+  const assertPath = path.join(fixtureRoot, "report-assert.csv");
+  const assertOutput = runBrowse([
+    "assert-download",
+    "https://example.com/reports",
+    "role:button:Export CSV",
+    "report.csv",
+    assertPath,
+    "--session",
+    "download",
+  ]);
+  const assertResult = JSON.parse(assertOutput) as { expected?: string; path?: string };
+  assert.equal(assertResult.expected, "report.csv");
+  assert.equal(assertResult.path, assertPath);
+  assert.ok(fs.existsSync(assertPath));
+
+  const flowOutput = runBrowse([
+    "flow",
+    "https://example.com/reports",
+    JSON.stringify([
+      { action: "download", selector: "role:button:Export CSV", path: "./flow-report.csv" },
+      { action: "assert-download", selector: "role:button:Export CSV", expected: "report.csv", path: "./flow-assert.csv" },
+    ]),
+    "--session",
+    "download",
+  ]);
+  const flowResults = JSON.parse(flowOutput) as Array<{ action?: string; path?: string; status?: string }>;
+  assert.ok(flowResults.some((entry) => entry.action === "download" && entry.status === "ok"));
+  assert.ok(flowResults.some((entry) => entry.action === "assert-download" && entry.status === "ok"));
+  assert.ok(fs.existsSync(path.join(fixtureRoot, "flow-report.csv")));
+  assert.ok(fs.existsSync(path.join(fixtureRoot, "flow-assert.csv")));
+
+  const log = JSON.parse(fs.readFileSync(logPath, "utf8")) as Array<Record<string, unknown>>;
+  assert.ok(log.some((entry) => entry.action === "waitForEvent" && entry.event === "download"));
+  assert.ok(log.some((entry) => entry.action === "getByRole" && entry.role === "button" && entry.name === "Export CSV"));
+  assert.ok(log.some((entry) => entry.action === "saveAs" && String(entry.path).includes("report-direct.csv")));
+  assert.ok(log.some((entry) => entry.action === "saveAs" && String(entry.path).includes("flow-assert.csv")));
+
+  console.log("browse-download spec passed");
+}
+
+try {
+  await main();
+} finally {
+  fs.rmSync(fixtureRoot, { recursive: true, force: true });
+}

--- a/scripts/ci-check.sh
+++ b/scripts/ci-check.sh
@@ -76,6 +76,7 @@ run_ts scripts/browse-advanced.spec.ts >/tmp/codex-stack-browse-advanced-spec.lo
 run_ts scripts/browse-semantic-device.spec.ts >/tmp/codex-stack-browse-semantic-device-spec.log
 run_ts scripts/browse-iframe.spec.ts >/tmp/codex-stack-browse-iframe-spec.log
 run_ts scripts/browse-network.spec.ts >/tmp/codex-stack-browse-network-spec.log
+run_ts scripts/browse-download.spec.ts >/tmp/codex-stack-browse-download-spec.log
 run_ts scripts/qa-diff.spec.ts >/tmp/codex-stack-qa-diff-spec.log
 run_ts scripts/qa-run.ts --help >/tmp/codex-stack-qa-help.log
 run_ts scripts/qa-run.spec.ts >/tmp/codex-stack-qa-spec.log

--- a/skills/browse/SKILL.md
+++ b/skills/browse/SKILL.md
@@ -40,6 +40,8 @@ Give the agent eyes for QA and deployment checks.
 - `screenshot <url> [path]`
 - `mock <url> <pattern> <json-config>`
 - `block <url> <pattern>`
+- `download <url> <selector> [path]`
+- `assert-download <url> <selector> <expected-name-fragment> [path]`
 - `eval <url> <expression>`
 - `click <url> <selector>`
 - `fill <url> <selector> <value>`
@@ -63,6 +65,8 @@ Give the agent eyes for QA and deployment checks.
 - flow step action: `use-flow`
 - flow step action: `route`
 - flow step action: `clear-routes`
+- flow step action: `download`
+- flow step action: `assert-download`
 
 ## Example
 
@@ -85,6 +89,8 @@ bun src/cli.ts browse assert-visible https://example.com/home "testid:hero" --se
 bun src/cli.ts browse click https://example.com/checkout "role:button:Pay now" --session staging --frame "name:payment"
 bun src/cli.ts browse mock https://example.com/app "**/api/profile" '{"status":503,"json":{"error":"offline"}}' --session staging
 bun src/cli.ts browse block https://example.com/app "**/analytics/**" --session staging
+bun src/cli.ts browse download https://example.com/reports "role:button:Export CSV" ./artifacts/report.csv --session staging
+bun src/cli.ts browse assert-download https://example.com/reports "role:button:Export CSV" report.csv ./artifacts/report.csv --session staging
 bun src/cli.ts browse snapshot https://example.com marketing-home --session staging
 bun src/cli.ts browse compare-snapshot https://example.com marketing-home --session staging
 bun src/cli.ts browse login https://example.com/login login-local --session staging
@@ -102,6 +108,7 @@ bun src/cli.ts browse sessions
 - Prefer semantic selectors when possible: `role:button:Save`, `label:Email`, `placeholder:Search`, `text:Welcome back`, `testid:hero`.
 - Use `--frame name:<name>`, `--frame url:<fragment>`, or `--frame <iframe-selector>` when the target element lives inside an iframe.
 - Use `route` / `clear-routes` flow steps or the `mock` / `block` commands to stabilize flaky third-party calls and test failure paths before navigation starts.
+- Use `download` / `assert-download` when the flow should prove that an export file was actually saved, not just that the export button was clicked.
 - Reuse named sessions for authenticated flows so login state persists.
 - Use `--device mobile|tablet|desktop` when the check is viewport-sensitive or when a bug only reproduces responsively.
 - Export/import session bundles when authenticated QA needs to move between machines or named sessions.


### PR DESCRIPTION
## Summary
- add direct browse commands for download capture and filename assertions
- add flow-step download support for export regressions
- add regression coverage and docs for the new export path

## Validation
- bun run typecheck
- bun src/cli.ts review --json
- bun run smoke

Closes #33