### PR TITLE
feat: add QA trend tracking reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Use the repo in this order:
 - Checked-in and local browser flows with import/export for JSON, YAML, and Markdown
 - Page snapshots and snapshot comparison artifacts
 - QA reports with typed categories, severity, health score, diff-aware route inference, saved evidence, and annotated screenshots for snapshot failures
+- Historical QA trend artifacts under `.codex-stack/qa/trends.json` and `.codex-stack/qa/trends.md`
 - Preview verification with URL template resolution, readiness polling, QA execution, and PR comment output for preview deployments
 - Shipping automation with PR body generation, labels, reviewers, assignees, projects, and optional QA verification
 - PR comments with QA verification summaries and artifact references after `ship --pr`
@@ -228,6 +229,7 @@ Use `qa` when you want a decision-ready report:
 - diff-aware route inference from changed files
 - annotated SVG evidence for snapshot-based failures
 - saved markdown/json report under `.codex-stack/qa/`
+- automatic trend summaries across saved QA runs
 
 ## Preview verification
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -129,6 +129,7 @@ Notes:
 bun scripts/qa-run.ts http://127.0.0.1:4173/dashboard --flow portal-dashboard --snapshot portal-dashboard --session demo --json
 bun scripts/qa-run.ts http://127.0.0.1:4173/login --flow portal-full-demo --snapshot portal-login --session demo
 bun scripts/qa-run.ts https://preview.example.com --mode diff-aware --base-ref origin/main --session preview --json
+bun scripts/qa-trends.ts --dir .codex-stack/qa --json
 ```
 
 Notes:
@@ -137,6 +138,7 @@ Notes:
 - It upgrades raw browser evidence into categorized findings, severity, health score, and recommendation.
 - `--mode diff-aware` inspects the git diff, infers changed routes for common app/page layouts, and probes those URLs from the supplied base URL.
 - Snapshot-based failures also emit annotated SVG evidence under `.codex-stack/qa/annotations/`.
+- Every `qa-run` also refreshes `.codex-stack/qa/trends.json` and `.codex-stack/qa/trends.md` so you can compare the latest run against prior QA history.
 - Use `--publish-dir docs/qa/<name>` when you want tracked copies of the QA report and evidence.
 - Use `--update-snapshot` when the UI change is intentional and the baseline should move.
 - Run `bun scripts/render-qa-pages.ts --out .site` to turn tracked `docs/qa/` artifacts into a static site locally or in CI.

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "review": "bun scripts/review-diff.ts",
     "issue": "bun scripts/issue-flow.ts",
     "qa": "bun scripts/qa-run.ts",
+    "qa:trends": "bun scripts/qa-trends.ts",
     "preview": "bun scripts/preview-verify.ts",
     "ship:dry": "bun scripts/ship-branch.ts --dry-run",
     "retro": "bun scripts/retro-report.ts --since '7 days ago'",

--- a/scripts/ci-check.sh
+++ b/scripts/ci-check.sh
@@ -80,6 +80,7 @@ run_ts scripts/browse-download.spec.ts >/tmp/codex-stack-browse-download-spec.lo
 run_ts scripts/qa-diff.spec.ts >/tmp/codex-stack-qa-diff-spec.log
 run_ts scripts/qa-run.ts --help >/tmp/codex-stack-qa-help.log
 run_ts scripts/qa-run.spec.ts >/tmp/codex-stack-qa-spec.log
+run_ts scripts/qa-trends.spec.ts >/tmp/codex-stack-qa-trends-spec.log
 run_ts scripts/qa-diff-mode.spec.ts >/tmp/codex-stack-qa-diff-mode-spec.log
 run_ts scripts/browse-session.spec.ts >/tmp/codex-stack-browse-session-spec.log
 run_ts scripts/preview-verify.ts --help >/tmp/codex-stack-preview-help.log
@@ -174,6 +175,8 @@ test -f /tmp/codex-stack-weekly-publish/email.md
 test -f /tmp/codex-stack-weekly-publish/manifest.json
 test -f .codex-stack/qa/latest.md
 test -f .codex-stack/qa/latest.json
+test -f .codex-stack/qa/trends.md
+test -f .codex-stack/qa/trends.json
 test -n "$(find .codex-stack/qa/annotations -name '*.svg' -print -quit)"
 
 git -C "$TMP_REPO" init -b main >/tmp/codex-stack-temp-git-init.log

--- a/scripts/qa-run.ts
+++ b/scripts/qa-run.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import process from "node:process";
 import { spawnSync } from "node:child_process";
 import { inferChangedRoutes, type RouteCandidate } from "./qa-diff.ts";
+import { writeQaTrendArtifacts } from "./qa-trends.ts";
 
 type QaMode = "quick" | "full" | "regression" | string;
 type FindingSeverity = "critical" | "high" | "medium" | "low";
@@ -133,6 +134,8 @@ interface QaArtifacts {
   latestJson?: string;
   latestMarkdown?: string;
   annotation?: string;
+  trendsJson?: string;
+  trendsMarkdown?: string;
   published?: PublishedArtifacts;
 }
 
@@ -1143,6 +1146,24 @@ if (fixture?.snapshot) {
 }
 
 report = writeArtifacts(report);
+const trendArtifacts = writeQaTrendArtifacts({ dir: QA_DIR });
+report.artifacts = {
+  ...report.artifacts,
+  trendsJson: path.relative(process.cwd(), trendArtifacts.jsonPath),
+  trendsMarkdown: path.relative(process.cwd(), trendArtifacts.markdownPath),
+};
+if (report.artifacts.json) {
+  fs.writeFileSync(path.resolve(process.cwd(), report.artifacts.json), JSON.stringify(report, null, 2));
+}
+if (report.artifacts.markdown) {
+  fs.writeFileSync(path.resolve(process.cwd(), report.artifacts.markdown), buildMarkdown(report));
+}
+if (report.artifacts.latestJson) {
+  fs.writeFileSync(path.resolve(process.cwd(), report.artifacts.latestJson), JSON.stringify(report, null, 2));
+}
+if (report.artifacts.latestMarkdown) {
+  fs.writeFileSync(path.resolve(process.cwd(), report.artifacts.latestMarkdown), buildMarkdown(report));
+}
 if (args.publishDir) {
   report = publishArtifacts(report, args.publishDir);
 }

--- a/scripts/qa-trends.spec.ts
+++ b/scripts/qa-trends.spec.ts
@@ -1,0 +1,88 @@
+#!/usr/bin/env bun
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import process from "node:process";
+import { execFileSync } from "node:child_process";
+
+const rootDir = process.cwd();
+const bun = process.execPath || "bun";
+const fixtureRoot = fs.mkdtempSync(path.join(os.tmpdir(), "codex-stack-qa-trends-"));
+const qaDir = path.join(fixtureRoot, ".codex-stack", "qa");
+const jsonOut = path.join(qaDir, "trends.json");
+const markdownOut = path.join(qaDir, "trends.md");
+
+function writeReport(name: string, payload: object): void {
+  fs.mkdirSync(qaDir, { recursive: true });
+  fs.writeFileSync(path.join(qaDir, `${name}.json`), JSON.stringify(payload, null, 2));
+}
+
+async function main(): Promise<void> {
+  writeReport("20260314-1", {
+    generatedAt: "2026-03-14T09:00:00.000Z",
+    url: "https://example.com/one",
+    status: "critical",
+    healthScore: 40,
+    findings: [
+      { severity: "critical", category: "functional", title: "Login broken", detail: "Login fails." },
+      { severity: "medium", category: "visual", title: "Header shifted", detail: "Header spacing regressed." },
+    ],
+  });
+  writeReport("20260314-2", {
+    generatedAt: "2026-03-14T10:00:00.000Z",
+    url: "https://example.com/two",
+    status: "warning",
+    healthScore: 70,
+    findings: [
+      { severity: "medium", category: "visual", title: "Header shifted", detail: "Header spacing regressed." },
+    ],
+  });
+  writeReport("20260314-3", {
+    generatedAt: "2026-03-14T11:00:00.000Z",
+    url: "https://example.com/three",
+    status: "warning",
+    healthScore: 60,
+    findings: [
+      { severity: "medium", category: "visual", title: "Header shifted", detail: "Header spacing regressed." },
+      { severity: "high", category: "content", title: "Price copy stale", detail: "Pricing copy is outdated." },
+    ],
+  });
+
+  const output = execFileSync(bun, [path.join(rootDir, "scripts", "qa-trends.ts"), "--dir", qaDir, "--json-out", jsonOut, "--markdown-out", markdownOut, "--json"], {
+    cwd: fixtureRoot,
+    encoding: "utf8",
+  }).trim();
+  const report = JSON.parse(output) as {
+    totalRuns: number;
+    deltaHealthScore: number;
+    latest?: { status?: string; healthScore?: number };
+    newFindings: Array<{ title?: string }>;
+    fixedFindings: Array<{ title?: string }>;
+    recurringFindings: Array<{ title?: string; occurrences?: number }>;
+    recurringHotspots: Array<{ title?: string; occurrences?: number }>;
+    currentStatusStreak?: { status?: string; length?: number };
+  };
+
+  assert.equal(report.totalRuns, 3);
+  assert.equal(report.latest?.status, "warning");
+  assert.equal(report.latest?.healthScore, 60);
+  assert.equal(report.deltaHealthScore, -10);
+  assert.ok(report.newFindings.some((item) => item.title === "Price copy stale"));
+  assert.ok(report.fixedFindings.length === 0);
+  assert.ok(report.recurringFindings.some((item) => item.title === "Header shifted" && item.occurrences === 3));
+  assert.ok(report.recurringHotspots.some((item) => item.title === "Header shifted" && item.occurrences === 3));
+  assert.equal(report.currentStatusStreak?.status, "warning");
+  assert.equal(report.currentStatusStreak?.length, 2);
+  assert.ok(fs.existsSync(jsonOut));
+  assert.ok(fs.existsSync(markdownOut));
+  assert.ok(fs.readFileSync(markdownOut, "utf8").includes("Price copy stale"));
+
+  console.log("qa-trends spec passed");
+}
+
+try {
+  await main();
+} finally {
+  fs.rmSync(fixtureRoot, { recursive: true, force: true });
+}

--- a/scripts/qa-trends.ts
+++ b/scripts/qa-trends.ts
@@ -1,0 +1,304 @@
+#!/usr/bin/env bun
+import fs from "node:fs";
+import path from "node:path";
+import process from "node:process";
+
+type FindingSeverity = "critical" | "high" | "medium" | "low" | string;
+type FindingCategory = "functional" | "visual" | "ux" | "content" | "console" | "performance" | "accessibility" | "qa-system" | string;
+type ReportStatus = "critical" | "warning" | "pass" | string;
+
+interface QaFinding {
+  severity: FindingSeverity;
+  category: FindingCategory;
+  title: string;
+  detail: string;
+}
+
+interface QaHistoryReport {
+  generatedAt?: string;
+  url?: string;
+  mode?: string;
+  status?: ReportStatus;
+  healthScore?: number;
+  findings?: QaFinding[];
+}
+
+interface QaTrendArgs {
+  dir: string;
+  jsonOut: string;
+  markdownOut: string;
+  json: boolean;
+  limit: number;
+}
+
+interface TrendFinding {
+  signature: string;
+  severity: FindingSeverity;
+  category: FindingCategory;
+  title: string;
+  detail: string;
+  occurrences: number;
+}
+
+interface TrendTimelineEntry {
+  generatedAt: string;
+  status: ReportStatus;
+  healthScore: number;
+  url: string;
+  findings: number;
+}
+
+interface QaTrendReport {
+  generatedAt: string;
+  sourceDir: string;
+  totalRuns: number;
+  latest: TrendTimelineEntry | null;
+  previous: TrendTimelineEntry | null;
+  deltaHealthScore: number;
+  currentStatusStreak: {
+    status: ReportStatus | "unknown";
+    length: number;
+  };
+  statusCounts: Record<string, number>;
+  timeline: TrendTimelineEntry[];
+  newFindings: TrendFinding[];
+  fixedFindings: TrendFinding[];
+  recurringFindings: TrendFinding[];
+  recurringHotspots: TrendFinding[];
+}
+
+const DEFAULT_QA_DIR = path.resolve(process.cwd(), ".codex-stack", "qa");
+
+function usage(): never {
+  console.log(`qa-trends
+
+Usage:
+  bun scripts/qa-trends.ts [--dir <path>] [--json-out <path>] [--markdown-out <path>] [--limit <n>] [--json]
+`);
+  process.exit(1);
+}
+
+function parseArgs(argv: string[]): QaTrendArgs {
+  const args: QaTrendArgs = {
+    dir: DEFAULT_QA_DIR,
+    jsonOut: path.join(DEFAULT_QA_DIR, "trends.json"),
+    markdownOut: path.join(DEFAULT_QA_DIR, "trends.md"),
+    json: false,
+    limit: 20,
+  };
+
+  const copy = [...argv];
+  while (copy.length) {
+    const item = copy.shift();
+    if (!item) continue;
+    if (item === "--dir") {
+      args.dir = path.resolve(process.cwd(), copy.shift() || args.dir);
+      continue;
+    }
+    if (item === "--json-out") {
+      args.jsonOut = path.resolve(process.cwd(), copy.shift() || args.jsonOut);
+      continue;
+    }
+    if (item === "--markdown-out") {
+      args.markdownOut = path.resolve(process.cwd(), copy.shift() || args.markdownOut);
+      continue;
+    }
+    if (item === "--limit") {
+      args.limit = Math.max(1, Number.parseInt(copy.shift() || "20", 10) || 20);
+      continue;
+    }
+    if (item === "--json") {
+      args.json = true;
+      continue;
+    }
+    if (item === "--help" || item === "-h") {
+      usage();
+    }
+    throw new Error(`Unknown arg: ${item}`);
+  }
+
+  return args;
+}
+
+function ensureDir(dirPath: string): void {
+  fs.mkdirSync(dirPath, { recursive: true });
+}
+
+function findingSignature(finding: QaFinding): string {
+  return JSON.stringify([finding.category || "", finding.severity || "", finding.title || "", finding.detail || ""]);
+}
+
+function normalizeFinding(finding: QaFinding, occurrences = 1): TrendFinding {
+  return {
+    signature: findingSignature(finding),
+    severity: String(finding.severity || "low"),
+    category: String(finding.category || "qa-system"),
+    title: String(finding.title || ""),
+    detail: String(finding.detail || ""),
+    occurrences,
+  };
+}
+
+function loadReports(dirPath: string): Array<Required<Pick<QaHistoryReport, "generatedAt" | "status" | "healthScore" | "url">> & { findings: QaFinding[] }> {
+  if (!fs.existsSync(dirPath)) return [];
+  return fs.readdirSync(dirPath)
+    .filter((name) => name.endsWith(".json") && name !== "latest.json" && name !== "trends.json")
+    .map((name) => {
+      const data = JSON.parse(fs.readFileSync(path.join(dirPath, name), "utf8")) as QaHistoryReport;
+      return {
+        generatedAt: String(data.generatedAt || "1970-01-01T00:00:00.000Z"),
+        status: String(data.status || "unknown"),
+        healthScore: Number(data.healthScore ?? 0),
+        url: String(data.url || ""),
+        findings: Array.isArray(data.findings) ? data.findings : [],
+      };
+    })
+    .sort((a, b) => a.generatedAt.localeCompare(b.generatedAt));
+}
+
+function computeStatusStreak(timeline: TrendTimelineEntry[]): { status: ReportStatus | "unknown"; length: number } {
+  if (!timeline.length) return { status: "unknown", length: 0 };
+  const latestStatus = timeline[timeline.length - 1]?.status || "unknown";
+  let length = 0;
+  for (let index = timeline.length - 1; index >= 0; index -= 1) {
+    if (timeline[index]?.status !== latestStatus) break;
+    length += 1;
+  }
+  return { status: latestStatus, length };
+}
+
+function buildTrendReport(dirPath: string, limit: number): QaTrendReport {
+  const reports = loadReports(dirPath);
+  const timeline: TrendTimelineEntry[] = reports.slice(-limit).map((report) => ({
+    generatedAt: report.generatedAt,
+    status: report.status,
+    healthScore: report.healthScore,
+    url: report.url,
+    findings: report.findings.length,
+  }));
+
+  const latestReport = reports[reports.length - 1] || null;
+  const previousReport = reports.length > 1 ? reports[reports.length - 2] : null;
+  const latestMap = new Map((latestReport?.findings || []).map((finding) => [findingSignature(finding), normalizeFinding(finding)]));
+  const previousMap = new Map((previousReport?.findings || []).map((finding) => [findingSignature(finding), normalizeFinding(finding)]));
+  const occurrenceMap = new Map<string, TrendFinding>();
+
+  for (const report of reports) {
+    for (const finding of report.findings) {
+      const signature = findingSignature(finding);
+      const existing = occurrenceMap.get(signature);
+      if (existing) {
+        existing.occurrences += 1;
+      } else {
+        occurrenceMap.set(signature, normalizeFinding(finding));
+      }
+    }
+  }
+
+  const newFindings = [...latestMap.entries()]
+    .filter(([signature]) => !previousMap.has(signature))
+    .map(([, finding]) => finding);
+  const fixedFindings = [...previousMap.entries()]
+    .filter(([signature]) => !latestMap.has(signature))
+    .map(([, finding]) => finding);
+  const recurringFindings = [...latestMap.entries()]
+    .filter(([signature]) => previousMap.has(signature))
+    .map(([signature, finding]) => ({ ...finding, occurrences: occurrenceMap.get(signature)?.occurrences || 1 }));
+  const recurringHotspots = [...occurrenceMap.values()]
+    .filter((finding) => finding.occurrences > 1)
+    .sort((left, right) => right.occurrences - left.occurrences || left.title.localeCompare(right.title))
+    .slice(0, 10);
+
+  const statusCounts: Record<string, number> = {};
+  for (const report of reports) {
+    statusCounts[report.status] = (statusCounts[report.status] || 0) + 1;
+  }
+
+  return {
+    generatedAt: new Date().toISOString(),
+    sourceDir: path.relative(process.cwd(), dirPath) || ".",
+    totalRuns: reports.length,
+    latest: latestReport
+      ? {
+          generatedAt: latestReport.generatedAt,
+          status: latestReport.status,
+          healthScore: latestReport.healthScore,
+          url: latestReport.url,
+          findings: latestReport.findings.length,
+        }
+      : null,
+    previous: previousReport
+      ? {
+          generatedAt: previousReport.generatedAt,
+          status: previousReport.status,
+          healthScore: previousReport.healthScore,
+          url: previousReport.url,
+          findings: previousReport.findings.length,
+        }
+      : null,
+    deltaHealthScore: latestReport && previousReport ? latestReport.healthScore - previousReport.healthScore : 0,
+    currentStatusStreak: computeStatusStreak(timeline),
+    statusCounts,
+    timeline,
+    newFindings,
+    fixedFindings,
+    recurringFindings,
+    recurringHotspots,
+  };
+}
+
+function renderFindingList(title: string, findings: TrendFinding[]): string {
+  if (!findings.length) return `## ${title}\n\nNone.\n`;
+  const lines = findings.map((finding) => `- **${finding.severity.toUpperCase()}** ${finding.title} (${finding.category})${finding.occurrences > 1 ? ` x${finding.occurrences}` : ""}`);
+  return `## ${title}\n\n${lines.join("\n")}\n`;
+}
+
+function buildMarkdown(report: QaTrendReport): string {
+  const timelineLines = report.timeline.length
+    ? report.timeline
+        .map((entry) => `- ${entry.generatedAt}: ${entry.status} | health ${entry.healthScore} | findings ${entry.findings}${entry.url ? ` | ${entry.url}` : ""}`)
+        .join("\n")
+    : "No QA runs found.";
+
+  return `# QA Trends
+
+- Generated: ${report.generatedAt}
+- Source dir: ${report.sourceDir}
+- Total runs: ${report.totalRuns}
+- Latest status: ${report.latest?.status || "n/a"}
+- Latest health score: ${report.latest?.healthScore ?? "n/a"}
+- Health delta vs previous: ${report.deltaHealthScore}
+- Current status streak: ${report.currentStatusStreak.status} x${report.currentStatusStreak.length}
+
+## Timeline
+
+${timelineLines}
+
+${renderFindingList("New Findings", report.newFindings)}
+${renderFindingList("Fixed Findings", report.fixedFindings)}
+${renderFindingList("Recurring Findings", report.recurringFindings)}
+${renderFindingList("Recurring Hotspots", report.recurringHotspots)}
+`;
+}
+
+export function writeQaTrendArtifacts(args: Partial<QaTrendArgs> = {}): { report: QaTrendReport; jsonPath: string; markdownPath: string } {
+  const dir = path.resolve(process.cwd(), args.dir || DEFAULT_QA_DIR);
+  const jsonPath = path.resolve(process.cwd(), args.jsonOut || path.join(dir, "trends.json"));
+  const markdownPath = path.resolve(process.cwd(), args.markdownOut || path.join(dir, "trends.md"));
+  const report = buildTrendReport(dir, args.limit || 20);
+  ensureDir(path.dirname(jsonPath));
+  ensureDir(path.dirname(markdownPath));
+  fs.writeFileSync(jsonPath, JSON.stringify(report, null, 2));
+  fs.writeFileSync(markdownPath, buildMarkdown(report));
+  return { report, jsonPath, markdownPath };
+}
+
+if (import.meta.main) {
+  const args = parseArgs(process.argv.slice(2));
+  const result = writeQaTrendArtifacts(args);
+  if (args.json) {
+    console.log(JSON.stringify(result.report, null, 2));
+  } else {
+    console.log(`wrote ${path.relative(process.cwd(), result.jsonPath)} and ${path.relative(process.cwd(), result.markdownPath)}`);
+  }
+}

--- a/skills/qa/SKILL.md
+++ b/skills/qa/SKILL.md
@@ -22,8 +22,9 @@ Run repeatable browser verification, collect evidence, and turn it into a ship/n
 4. Capture or compare a snapshot when visual/text drift matters.
 5. Score the result with categorized findings, severity, evidence, and a recommendation.
 6. Save the QA report under `.codex-stack/qa/`, including annotated screenshot evidence when snapshot failures occur.
-7. Publish tracked copies into `docs/qa/` when the shipping workflow needs GitHub-linkable evidence.
-8. Render `docs/qa/` through `scripts/render-qa-pages.ts` when the operator needs a static review site.
+7. Refresh `.codex-stack/qa/trends.json` and `.codex-stack/qa/trends.md` so the operator can compare the latest run against prior QA history.
+8. Publish tracked copies into `docs/qa/` when the shipping workflow needs GitHub-linkable evidence.
+9. Render `docs/qa/` through `scripts/render-qa-pages.ts` when the operator needs a static review site.
 
 ## CLI
 
@@ -32,6 +33,7 @@ bun src/cli.ts qa http://127.0.0.1:4173/dashboard --flow portal-dashboard --snap
 bun src/cli.ts qa http://127.0.0.1:4173/login --flow portal-full-demo --snapshot portal-login --session demo
 bun src/cli.ts qa https://preview.example.com --mode diff-aware --base-ref origin/main --session preview --json
 bun scripts/qa-run.ts --fixture ./tmp/qa-fixture.json --json
+bun scripts/qa-trends.ts --dir .codex-stack/qa --json
 ```
 
 ## Output format
@@ -43,6 +45,7 @@ bun scripts/qa-run.ts --fixture ./tmp/qa-fixture.json --json
 - Snapshot evidence
 - Flow pass/fail summary
 - Recommendation
+- Trend delta vs previous runs via `.codex-stack/qa/trends.json`
 
 ## Guardrails
 


### PR DESCRIPTION
## Summary
- add reusable QA trend report generation from saved run history
- refresh trend artifacts automatically after `qa-run` writes reports
- add regression coverage and docs for the new history view

## Validation
- bun src/cli.ts review --json
- bun run typecheck
- bun run smoke

Closes #35