### PR TITLE
feat: add visual PR QA packs

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -79,6 +79,7 @@ jobs:
           owner="${GITHUB_REPOSITORY%/*}"
           repo="${GITHUB_REPOSITORY#*/}"
           preview_url="https://${owner}.github.io/${repo}/pr-preview/pr-${PR_NUMBER}/"
+          echo "CODEX_STACK_PREVIEW_PAGES_ROOT=${preview_url}__codex/" >> "$GITHUB_ENV"
           args=(
             "--repo" "${GITHUB_REPOSITORY}"
             "--branch" "${GITHUB_HEAD_REF}"
@@ -136,8 +137,31 @@ jobs:
           )
           if [ -f preview.json ]; then
             args+=("--preview-input" "preview.json")
+            if [ -n "${CODEX_STACK_PREVIEW_PAGES_ROOT:-}" ]; then
+              args+=("--preview-pages-root" "${CODEX_STACK_PREVIEW_PAGES_ROOT}")
+            fi
           fi
           bun scripts/render-pr-review.ts "${args[@]}"
+
+      - name: Attach PR review evidence to preview site
+        if: github.event.pull_request.head.repo.full_name == github.repository && hashFiles('preview.json') != ''
+        run: |
+          set -euo pipefail
+          mkdir -p .preview-site/__codex
+          cp -R preview-artifacts/. .preview-site/__codex/
+          cp preview.md preview.json preview-comment.md review.md review.json review-summary.json .preview-site/__codex/
+
+      - name: Republish PR preview with review evidence
+        if: github.event.pull_request.head.repo.full_name == github.repository && hashFiles('preview.json') != ''
+        uses: JamesIves/github-pages-deploy-action@v4.8.0
+        with:
+          branch: gh-pages
+          folder: .preview-site
+          target-folder: pr-preview/pr-${{ github.event.pull_request.number }}
+          clean: true
+          force: false
+          single-commit: true
+          attempt-limit: 3
 
       - name: Add step summary
         run: cat review.md >> "$GITHUB_STEP_SUMMARY"

--- a/README.md
+++ b/README.md
@@ -48,11 +48,11 @@ Use the repo in this order:
 - Persistent named browser sessions
 - Portable session import/export with cookie and storage-state bundles
 - Checked-in and local browser flows with import/export for JSON, YAML, and Markdown
-- Page snapshots and snapshot comparison artifacts
-- QA reports with typed categories, severity, health score, diff-aware route inference, saved evidence, and annotated screenshots for snapshot failures
+- Page snapshots and snapshot comparison artifacts with self-contained visual packs
+- QA reports with typed categories, severity, health score, diff-aware route inference, saved evidence, annotated screenshots, and published visual packs for snapshot failures
 - Historical QA trend artifacts under `.codex-stack/qa/trends.json` and `.codex-stack/qa/trends.md`
 - Preview verification with URL template resolution, readiness polling, deploy/page verification, QA execution, and PR comment output for preview deployments
-- Deploy verification with page and device matrices, screenshot manifests, console capture, and tracked evidence
+- Deploy verification with page and device matrices, screenshot manifests, console capture, tracked evidence, and `visual/index.html` review packs
 - Shipping automation with PR body generation, labels, reviewers, assignees, projects, and optional deploy verification
 - PR comments with deploy verification summaries and artifact references after `ship --pr`
 - Tracked QA evidence published under `docs/qa/<branch>/` during shipping so PR comments can link to real files
@@ -152,7 +152,8 @@ What happens next:
 
 - `pr-review.yml` runs `codex-stack` review on the PR diff
 - for same-repo PRs, the review workflow publishes a GitHub Pages preview at `https://<owner>.github.io/<repo>/pr-preview/pr-<number>/` and verifies that live preview before merging
-- the workflow posts or updates a PR comment with structural findings plus any preview deploy evidence
+- the same workflow republishes review evidence under `https://<owner>.github.io/<repo>/pr-preview/pr-<number>/__codex/`
+- the workflow posts or updates a PR comment with structural findings plus hosted preview visual evidence
 - the job fails if critical findings are detected in either structural review or preview verification
 - if the PR has the `automerge` label, `pr-automerge.yml` enables GitHub auto-merge
 
@@ -343,6 +344,8 @@ On GitHub, `.github/workflows/qa-pages.yml` deploys the merged `docs/qa/` report
 - branch artifact links that work immediately on the PR branch
 - stable Pages links that activate after the branch is merged to `main`
 
+When a published QA report includes snapshot evidence, the Pages site now surfaces `visual/index.html` as the primary review-evidence entrypoint alongside the raw markdown, JSON, annotation, and screenshot files.
+
 The same `gh-pages` branch also hosts PR previews under `pr-preview/pr-<number>/`. Configure these repo variables if you want richer automatic preview coverage in `pr-review.yml`:
 
 - `CODEX_STACK_PREVIEW_PATHS=/login,/dashboard`
@@ -354,6 +357,8 @@ The same `gh-pages` branch also hosts PR previews under `pr-preview/pr-<number>/
 Optional authenticated preview secret:
 
 - `CODEX_STACK_PREVIEW_SESSION_BUNDLE_B64=<base64 of browse export-session output>`
+
+For same-repo PRs, `pr-review.yml` republishes the preview subtree with hosted review evidence under `pr-preview/pr-<number>/__codex/`, including the deploy visual pack at `__codex/visual/index.html`.
 
 When a PR closes, `.github/workflows/preview-cleanup.yml` removes only `gh-pages/pr-preview/pr-<number>/` and keeps the root QA site plus other active PR previews intact.
 

--- a/browse/src/cli.ts
+++ b/browse/src/cli.ts
@@ -127,6 +127,17 @@ interface SnapshotComparison {
   screenshotChanged: boolean;
 }
 
+interface SnapshotVisualPack {
+  dir: string;
+  index: string;
+  manifest: string;
+  annotation: string;
+  baselineJson: string;
+  currentJson: string;
+  baselineScreenshot: string;
+  currentScreenshot: string;
+}
+
 interface PlaywrightResponse {
   status(): number;
   ok(): boolean;
@@ -324,6 +335,261 @@ function textHash(text: unknown): string {
 function fileHash(filePath: string): string {
   if (!fs.existsSync(filePath)) return "";
   return createHash("sha256").update(fs.readFileSync(filePath)).digest("hex");
+}
+
+function escapeHtml(value: unknown): string {
+  return String(value || "")
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+function escapeXml(value: unknown): string {
+  return escapeHtml(value);
+}
+
+function relativePath(filePath: string): string {
+  return path.relative(process.cwd(), filePath).replace(/\\/g, "/");
+}
+
+function pngDimensions(filePath: string): { width: number; height: number } {
+  const buffer = fs.readFileSync(filePath);
+  if (buffer.length < 24 || buffer.toString("ascii", 1, 4) !== "PNG") {
+    throw new Error(`Unsupported PNG artifact: ${filePath}`);
+  }
+  return {
+    width: buffer.readUInt32BE(16),
+    height: buffer.readUInt32BE(20),
+  };
+}
+
+function screenshotDataUri(filePath: string): string {
+  return `data:image/png;base64,${fs.readFileSync(filePath).toString("base64")}`;
+}
+
+function normalizeSnapshotBounds(bounds: Partial<SnapshotBounds> | undefined): SnapshotBounds | null {
+  if (!bounds) return null;
+  return {
+    x: Number(bounds.x || 0),
+    y: Number(bounds.y || 0),
+    width: Number(bounds.width || 0),
+    height: Number(bounds.height || 0),
+  };
+}
+
+function selectorBounds(snapshot: Partial<SnapshotPayload> | null, selector: string): SnapshotBounds | null {
+  const elements = Array.isArray(snapshot?.elements) ? snapshot.elements : [];
+  const match = elements.find((item) => item?.selector === selector);
+  return normalizeSnapshotBounds(match?.bounds);
+}
+
+function snapshotAnnotationMarkers(
+  comparison: SnapshotComparison,
+  baselineSnapshot: Partial<SnapshotPayload> | null,
+  currentSnapshot: Partial<SnapshotPayload> | null,
+): Array<{ selector: string; label: string; color: string; bounds: SnapshotBounds }> {
+  const markers: Array<{ selector: string; label: string; color: string; bounds: SnapshotBounds }> = [];
+
+  for (const selector of comparison.missingSelectors) {
+    const bounds = selectorBounds(baselineSnapshot, selector);
+    if (!bounds) continue;
+    markers.push({ selector, label: `Missing: ${selector}`, color: "#d73a49", bounds });
+  }
+
+  for (const item of comparison.changedSelectors) {
+    const selector = item.selector;
+    const bounds = selectorBounds(currentSnapshot, selector) || selectorBounds(baselineSnapshot, selector);
+    if (!selector || !bounds) continue;
+    markers.push({ selector, label: `Changed: ${selector}`, color: "#fb8500", bounds });
+  }
+
+  for (const selector of comparison.newSelectors) {
+    const bounds = selectorBounds(currentSnapshot, selector);
+    if (!bounds) continue;
+    markers.push({ selector, label: `New: ${selector}`, color: "#2563eb", bounds });
+  }
+
+  return markers;
+}
+
+function renderSnapshotAnnotationSvg({
+  screenshotPath,
+  markers,
+  title,
+}: {
+  screenshotPath: string;
+  markers: Array<{ selector: string; label: string; color: string; bounds: SnapshotBounds }>;
+  title: string;
+}): string {
+  if (!fs.existsSync(screenshotPath)) return "";
+  const { width, height } = pngDimensions(screenshotPath);
+  const imageHref = screenshotDataUri(screenshotPath);
+  const topPadding = 56;
+  const markerSvg = markers.map((marker, index) => {
+    const x = marker.bounds.x;
+    const y = marker.bounds.y + topPadding;
+    const w = Math.max(4, marker.bounds.width);
+    const h = Math.max(4, marker.bounds.height);
+    const labelY = Math.max(20, y - 6);
+    return [
+      `<rect x="${x}" y="${y}" width="${w}" height="${h}" fill="none" stroke="${marker.color}" stroke-width="3"/>`,
+      `<rect x="${x}" y="${Math.max(4, labelY - 18)}" width="${Math.min(width - x, Math.max(80, marker.label.length * 7))}" height="18" fill="${marker.color}" opacity="0.92"/>`,
+      `<text x="${x + 6}" y="${labelY - 5}" font-family="monospace" font-size="11" fill="#ffffff">${escapeXml(`${index + 1}. ${marker.label}`)}</text>`,
+    ].join("");
+  }).join("\n");
+
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height + topPadding}" viewBox="0 0 ${width} ${height + topPadding}">
+  <rect width="${width}" height="${height + topPadding}" fill="#0f172a"/>
+  <text x="16" y="24" font-family="monospace" font-size="14" fill="#ffffff">${escapeXml(title)}</text>
+  <text x="16" y="44" font-family="monospace" font-size="11" fill="#cbd5e1">${escapeXml(markers.length ? `${markers.length} annotated issue(s)` : "No element-level annotations available")}</text>
+  <image href="${imageHref}" x="0" y="${topPadding}" width="${width}" height="${height}"/>
+  ${markerSvg}
+</svg>
+`;
+}
+
+function copyIfExists(sourcePath: string, targetPath: string): string {
+  if (!sourcePath || !fs.existsSync(sourcePath)) return "";
+  ensureDir(path.dirname(targetPath));
+  fs.copyFileSync(sourcePath, targetPath);
+  return targetPath;
+}
+
+function renderSnapshotVisualPackHtml(manifest: Record<string, unknown>): string {
+  const summary = manifest.summary as Record<string, unknown>;
+  const assets = manifest.assets as Record<string, string>;
+  const markers = Array.isArray(manifest.markers) ? manifest.markers as Array<Record<string, unknown>> : [];
+  return `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>${escapeHtml(manifest.title || manifest.name || "Snapshot visual pack")}</title>
+  <style>
+    :root { color-scheme: light dark; font-family: ui-sans-serif, system-ui, sans-serif; }
+    body { margin: 0; background: #0f172a; color: #e2e8f0; }
+    main { max-width: 1200px; margin: 0 auto; padding: 24px; }
+    h1, h2 { margin: 0 0 12px; }
+    .meta, .summary { display: grid; gap: 8px; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); margin: 18px 0 24px; }
+    .card { background: rgba(15, 23, 42, 0.92); border: 1px solid rgba(148, 163, 184, 0.18); border-radius: 16px; padding: 16px; }
+    .grid { display: grid; gap: 18px; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); }
+    img, object { width: 100%; border-radius: 12px; border: 1px solid rgba(148, 163, 184, 0.18); background: #020617; }
+    ul { padding-left: 20px; }
+    a { color: #93c5fd; }
+    .pill { display: inline-block; padding: 4px 10px; border-radius: 999px; background: rgba(59, 130, 246, 0.18); margin-right: 8px; }
+  </style>
+</head>
+<body>
+  <main>
+    <h1>${escapeHtml(manifest.title || manifest.name || "Snapshot visual pack")}</h1>
+    <div class="meta">
+      <div class="card"><strong>Status</strong><div>${escapeHtml(manifest.status || "unknown")}</div></div>
+      <div class="card"><strong>Snapshot</strong><div>${escapeHtml(manifest.name || "snapshot")}</div></div>
+      <div class="card"><strong>Generated</strong><div>${escapeHtml(manifest.generatedAt || "n/a")}</div></div>
+    </div>
+    <div class="summary">
+      <div class="card"><strong>Missing selectors</strong><div>${escapeHtml(summary?.missingSelectors ?? 0)}</div></div>
+      <div class="card"><strong>Changed selectors</strong><div>${escapeHtml(summary?.changedSelectors ?? 0)}</div></div>
+      <div class="card"><strong>New selectors</strong><div>${escapeHtml(summary?.newSelectors ?? 0)}</div></div>
+      <div class="card"><strong>Body/title drift</strong><div>${escapeHtml(`${Boolean(summary?.bodyTextChanged) || Boolean(summary?.titleChanged)}`)}</div></div>
+    </div>
+    <section class="grid">
+      <article class="card">
+        <h2>Baseline</h2>
+        ${assets?.baselineScreenshot ? `<img src="${escapeHtml(assets.baselineScreenshot)}" alt="Baseline screenshot">` : "<p>Missing baseline screenshot.</p>"}
+        <p><a href="${escapeHtml(assets.baselineJson || "")}">Baseline JSON</a></p>
+      </article>
+      <article class="card">
+        <h2>Current</h2>
+        ${assets?.currentScreenshot ? `<img src="${escapeHtml(assets.currentScreenshot)}" alt="Current screenshot">` : "<p>Missing current screenshot.</p>"}
+        <p><a href="${escapeHtml(assets.currentJson || "")}">Current JSON</a></p>
+      </article>
+      <article class="card">
+        <h2>Annotation</h2>
+        ${assets?.annotation ? `<object data="${escapeHtml(assets.annotation)}" type="image/svg+xml" aria-label="Annotated snapshot"></object>` : "<p>No annotation available.</p>"}
+      </article>
+    </section>
+    <section class="card" style="margin-top: 20px;">
+      <h2>Annotated selectors</h2>
+      <ul>
+        ${markers.length ? markers.map((item) => `<li>${escapeHtml(item.label || item.selector || "marker")}</li>`).join("") : "<li>No selector-level markers recorded.</li>"}
+      </ul>
+      <p><a href="manifest.json">Manifest JSON</a></p>
+    </section>
+  </main>
+</body>
+</html>`;
+}
+
+export function createSnapshotVisualPack({
+  name,
+  stamp,
+  baselineJsonPath,
+  currentJsonPath,
+  baselineScreenshotPath,
+  currentScreenshotPath,
+  comparison,
+}: {
+  name: string;
+  stamp: string;
+  baselineJsonPath: string;
+  currentJsonPath: string;
+  baselineScreenshotPath: string;
+  currentScreenshotPath: string;
+  comparison: SnapshotComparison;
+}): SnapshotVisualPack {
+  const outputDir = path.join(ARTIFACT_DIR, `${name}-${stamp}-visual`);
+  ensureDir(outputDir);
+  const baselineJson = copyIfExists(baselineJsonPath, path.join(outputDir, "baseline.json"));
+  const currentJson = copyIfExists(currentJsonPath, path.join(outputDir, "current.json"));
+  const baselineScreenshot = copyIfExists(baselineScreenshotPath, path.join(outputDir, "baseline.png"));
+  const currentScreenshot = copyIfExists(currentScreenshotPath, path.join(outputDir, "current.png"));
+  const baselineSnapshot = readJson<SnapshotPayload | null>(baselineJsonPath, null);
+  const currentSnapshot = readJson<SnapshotPayload | null>(currentJsonPath, null);
+  const markers = snapshotAnnotationMarkers(comparison, baselineSnapshot, currentSnapshot);
+  const annotationPath = path.join(outputDir, "annotation.svg");
+  const annotationSvg = currentScreenshot
+    ? renderSnapshotAnnotationSvg({
+        screenshotPath: currentScreenshot,
+        markers,
+        title: `Snapshot visual pack • ${name}`,
+      })
+    : "";
+  if (annotationSvg) {
+    fs.writeFileSync(annotationPath, annotationSvg);
+  }
+  const manifestPath = path.join(outputDir, "manifest.json");
+  const indexPath = path.join(outputDir, "index.html");
+  const manifest = {
+    generatedAt: new Date().toISOString(),
+    name,
+    title: `Snapshot visual pack • ${name}`,
+    status: comparison.status,
+    summary: comparison.summary,
+    markers: markers.map((item) => ({ selector: item.selector, label: item.label })),
+    assets: {
+      baselineJson: path.basename(baselineJson),
+      currentJson: path.basename(currentJson),
+      baselineScreenshot: path.basename(baselineScreenshot),
+      currentScreenshot: path.basename(currentScreenshot),
+      annotation: annotationSvg ? path.basename(annotationPath) : "",
+    },
+  };
+  writeJson(manifestPath, manifest);
+  fs.writeFileSync(indexPath, renderSnapshotVisualPackHtml(manifest));
+  return {
+    dir: relativePath(outputDir),
+    index: relativePath(indexPath),
+    manifest: relativePath(manifestPath),
+    annotation: annotationSvg ? relativePath(annotationPath) : "",
+    baselineJson: relativePath(baselineJson),
+    currentJson: relativePath(currentJson),
+    baselineScreenshot: relativePath(baselineScreenshot),
+    currentScreenshot: relativePath(currentScreenshot),
+  };
 }
 
 function assertFlowName(name: string): void {
@@ -655,7 +921,7 @@ async function captureSnapshotPayload(page: PlaywrightPage): Promise<SnapshotPay
   };
 }
 
-function compareSnapshotData(
+export function compareSnapshotData(
   baseline: Partial<SnapshotPayload> | null,
   current: Partial<SnapshotPayload>,
   { baselineScreenshotHash = "", currentScreenshotHash = "" }: { baselineScreenshotHash?: string; currentScreenshotHash?: string } = {},
@@ -1750,6 +2016,15 @@ async function main(): Promise<void> {
       baselineScreenshotHash: baselineSnapshot.screenshotHash || fileHash(snapshotScreenshotPath(snapshotName)),
       currentScreenshotHash: currentSnapshot.screenshotHash,
     });
+    const visualPack = createSnapshotVisualPack({
+      name: snapshotName,
+      stamp,
+      baselineJsonPath: baselineJson,
+      currentJsonPath: artifactJson,
+      baselineScreenshotPath: snapshotScreenshotPath(snapshotName),
+      currentScreenshotPath: artifactScreenshot,
+      comparison,
+    });
     recordSession(session, {
       lastCommand: "compare-snapshot",
       lastUrl: url,
@@ -1762,6 +2037,7 @@ async function main(): Promise<void> {
       current: path.relative(process.cwd(), artifactJson),
       screenshot: path.relative(process.cwd(), artifactScreenshot),
       comparison,
+      visualPack,
     });
     return;
   }
@@ -2193,10 +2469,12 @@ async function main(): Promise<void> {
   usage();
 }
 
-main().catch((error: unknown) => {
-  console.error(cleanError(error));
-  process.exit(1);
-});
+if (import.meta.main) {
+  main().catch((error: unknown) => {
+    console.error(cleanError(error));
+    process.exit(1);
+  });
+}
 
 function cleanError(error: unknown): string {
   return error instanceof Error ? error.message : String(error);

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -87,7 +87,7 @@ bun scripts/render-pr-review.ts --input review.json --preview-input preview.json
 Notes:
 
 - `pr-review.yml` uses `review-diff.ts` plus `render-pr-review.ts` to comment on every PR.
-- For same-repo PRs, `pr-review.yml` also publishes a GitHub Pages preview under `pr-preview/pr-<number>/`, runs `preview-verify.ts` against that live URL, and merges the preview deploy evidence into the review comment.
+- For same-repo PRs, `pr-review.yml` also publishes a GitHub Pages preview under `pr-preview/pr-<number>/`, runs `preview-verify.ts` against that live URL, republishes review evidence under `pr-preview/pr-<number>/__codex/`, and merges that hosted visual pack into the review comment.
 - The review workflow fails when critical findings are present in either structural review or preview verification.
 
 ## Issue workflow
@@ -140,6 +140,7 @@ Notes:
 - It upgrades raw browser evidence into categorized findings, severity, health score, and recommendation.
 - `--mode diff-aware` inspects the git diff, infers changed routes for common app/page layouts, and probes those URLs from the supplied base URL.
 - Snapshot-based failures also emit annotated SVG evidence under `.codex-stack/qa/annotations/`.
+- `compare-snapshot` now emits a self-contained visual pack, and `qa --publish-dir ...` copies that pack into `visual/index.html` and `visual/manifest.json`.
 - Every `qa-run` also refreshes `.codex-stack/qa/trends.json` and `.codex-stack/qa/trends.md` so you can compare the latest run against prior QA history.
 - Use `--publish-dir docs/qa/<name>` when you want tracked copies of the QA report and evidence.
 - Use `--update-snapshot` when the UI change is intentional and the baseline should move.
@@ -173,6 +174,7 @@ Notes:
 - The script polls preview readiness before it delegates to `deploy-verify.ts`.
 - `--session-bundle <path>` imports an exported browser session into the named preview session before live checks run.
 - `preview-verify.yml` is the manual rerun path. `pr-review.yml` is the automatic PR-time path and publishes the GitHub Pages preview before verification.
+- For same-repo PRs, preview evidence is republished into the same Pages subtree under `__codex/visual/index.html`.
 - Both preview workflows can consume the repo secret `CODEX_STACK_PREVIEW_SESSION_BUNDLE_B64` and decode it to a temp bundle file without exposing the contents in logs.
 - The workflow uploads `preview.md`, `preview.json`, `preview-comment.md`, and the published deploy artifacts as a workflow artifact, then updates a stable PR comment.
 
@@ -190,7 +192,7 @@ Notes:
 - It waits for readiness, verifies every requested `path x device` combination, and captures screenshots plus console evidence.
 - Flow and snapshot checks are delegated to the existing QA runtime so the deploy report reuses the same finding model and artifacts.
 - `--session-bundle <path>` validates the bundle up front, imports it into the named deploy session when live browser checks need it, and passes it through to `qa-run.ts`.
-- The script writes `report.md`, `report.json`, `comment.md`, and `screenshots.json` under the publish directory even when you do not pass explicit output paths.
+- The script writes `report.md`, `report.json`, `comment.md`, `screenshots.json`, and a visual review pack under `visual/index.html` and `visual/manifest.json`.
 
 ## Retro workflow
 
@@ -258,6 +260,7 @@ Notes:
 - Local flows live under `.codex-stack/browse/flows/` and override same-named repo flows.
 - Session bundles capture cookies plus origin storage so authenticated QA setups can move between named sessions.
 - `import-browser-cookies` is the local macOS path for Chrome, Arc, Brave, and Edge profiles when you need to bootstrap an authenticated session without replaying login flows manually.
+- `compare-snapshot` creates a portable visual pack with baseline/current screenshots, annotation SVG, manifest JSON, and an HTML index page.
 - `upload`, `dialog`, and the expanded assertion set are available both as direct commands and as flow actions.
 - `wait` supports `load:<state>` plus `state:<visible|hidden|attached|detached>:<selector>` for richer synchronization.
 - Selector arguments accept semantic prefixes as well as CSS: `role:<role>[:<name>]`, `label:<text>`, `placeholder:<text>`, `text:<text>`, and `testid:<value>`.

--- a/scripts/browse-snapshot-visual-pack.spec.ts
+++ b/scripts/browse-snapshot-visual-pack.spec.ts
@@ -1,0 +1,85 @@
+#!/usr/bin/env bun
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import process from "node:process";
+import { pathToFileURL } from "node:url";
+
+const repoRoot = process.cwd();
+const fixtureRoot = fs.mkdtempSync(path.join(os.tmpdir(), "codex-stack-snapshot-pack-"));
+
+async function main(): Promise<void> {
+  process.chdir(fixtureRoot);
+  const png = Buffer.from("iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAusB9Y9l9i8AAAAASUVORK5CYII=", "base64");
+  const baselineJsonPath = path.join(fixtureRoot, "baseline.json");
+  const currentJsonPath = path.join(fixtureRoot, "current.json");
+  const baselineScreenshotPath = path.join(fixtureRoot, "baseline.png");
+  const currentScreenshotPath = path.join(fixtureRoot, "current.png");
+
+  fs.writeFileSync(baselineScreenshotPath, png);
+  fs.writeFileSync(currentScreenshotPath, png);
+  fs.writeFileSync(baselineJsonPath, JSON.stringify({
+    name: "landing-home",
+    title: "Landing",
+    bodyText: "Welcome",
+    elements: [{ selector: "h1", text: "Welcome", bounds: { x: 0, y: 0, width: 1, height: 1 } }],
+  }, null, 2));
+  fs.writeFileSync(currentJsonPath, JSON.stringify({
+    name: "landing-home",
+    title: "Landing",
+    bodyText: "Welcome back",
+    elements: [],
+  }, null, 2));
+
+  const browseCli = await import(pathToFileURL(path.join(repoRoot, "browse", "src", "cli.ts")).href);
+  const comparison = browseCli.compareSnapshotData(
+    JSON.parse(fs.readFileSync(baselineJsonPath, "utf8")),
+    JSON.parse(fs.readFileSync(currentJsonPath, "utf8")),
+    { baselineScreenshotHash: "a", currentScreenshotHash: "b" },
+  );
+  const visualPack = browseCli.createSnapshotVisualPack({
+    name: "landing-home",
+    stamp: "fixture",
+    baselineJsonPath,
+    currentJsonPath,
+    baselineScreenshotPath,
+    currentScreenshotPath,
+    comparison,
+  }) as {
+    dir: string;
+    index: string;
+    manifest: string;
+    annotation?: string;
+  };
+
+  assert.ok(fs.existsSync(path.join(fixtureRoot, visualPack.index)));
+  assert.ok(fs.existsSync(path.join(fixtureRoot, visualPack.manifest)));
+  assert.ok(fs.existsSync(path.join(fixtureRoot, visualPack.dir, "baseline.png")));
+  assert.ok(fs.existsSync(path.join(fixtureRoot, visualPack.dir, "current.png")));
+  assert.ok(fs.existsSync(path.join(fixtureRoot, visualPack.annotation || "")));
+
+  const manifest = JSON.parse(fs.readFileSync(path.join(fixtureRoot, visualPack.manifest), "utf8")) as {
+    assets?: Record<string, string>;
+    summary?: Record<string, number | boolean>;
+  };
+  const html = fs.readFileSync(path.join(fixtureRoot, visualPack.index), "utf8");
+
+  assert.equal(manifest.assets?.baselineScreenshot, "baseline.png");
+  assert.equal(manifest.assets?.currentScreenshot, "current.png");
+  assert.equal(manifest.assets?.annotation, "annotation.svg");
+  assert.equal(manifest.summary?.missingSelectors, 1);
+  assert.match(html, /Snapshot visual pack/);
+  assert.match(html, /Manifest JSON/);
+  assert.match(html, /baseline\.png/);
+  assert.match(html, /current\.png/);
+
+  console.log("browse-snapshot-visual-pack spec passed");
+}
+
+try {
+  await main();
+} finally {
+  process.chdir(repoRoot);
+  fs.rmSync(fixtureRoot, { recursive: true, force: true });
+}

--- a/scripts/ci-check.sh
+++ b/scripts/ci-check.sh
@@ -88,6 +88,7 @@ run_ts scripts/qa-trends.spec.ts >/tmp/codex-stack-qa-trends-spec.log
 run_ts scripts/qa-diff-mode.spec.ts >/tmp/codex-stack-qa-diff-mode-spec.log
 run_ts scripts/browse-session.spec.ts >/tmp/codex-stack-browse-session-spec.log
 run_ts scripts/browse-browser-profile.spec.ts >/tmp/codex-stack-browse-browser-profile-spec.log
+run_ts scripts/browse-snapshot-visual-pack.spec.ts >/tmp/codex-stack-browse-snapshot-pack-spec.log
 run_ts scripts/preview-verify.ts --help >/tmp/codex-stack-preview-help.log
 run_ts scripts/deploy-verify.ts --help >/tmp/codex-stack-deploy-help.log
 run_ts scripts/build-preview-site.ts --help >/tmp/codex-stack-build-preview-help.log
@@ -106,7 +107,10 @@ grep -q '"offline": true' /tmp/codex-stack-upgrade.json
 run_ts scripts/retro-report.ts --since "1 day ago" --artifact-dir /tmp/codex-stack-retros --no-github >/tmp/codex-stack-retro.log
 run_ts scripts/weekly-digest.ts --since "1 day ago" --out /tmp/codex-stack-weekly.md --json-out /tmp/codex-stack-weekly.json --publish-dir /tmp/codex-stack-weekly-publish --no-github >/tmp/codex-stack-weekly.log
 mkdir -p .codex-stack/browse/snapshots .codex-stack/browse/artifacts
+mkdir -p .codex-stack/browse/artifacts/example-visual
 run_eval "process.stdout.write(Buffer.from('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAusB9Y9l9i8AAAAASUVORK5CYII=','base64'))" > .codex-stack/browse/artifacts/example-1.png
+run_eval "process.stdout.write(Buffer.from('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAusB9Y9l9i8AAAAASUVORK5CYII=','base64'))" > .codex-stack/browse/artifacts/example-visual/baseline.png
+run_eval "process.stdout.write(Buffer.from('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAusB9Y9l9i8AAAAASUVORK5CYII=','base64'))" > .codex-stack/browse/artifacts/example-visual/current.png
 cat > .codex-stack/browse/snapshots/example.json <<'JSON'
 {
   "name": "example",
@@ -124,6 +128,17 @@ cat > .codex-stack/browse/artifacts/example-1.json <<'JSON'
   "elements": []
 }
 JSON
+cat > .codex-stack/browse/artifacts/example-visual/index.html <<'HTML'
+<html><body>visual pack</body></html>
+HTML
+cat > .codex-stack/browse/artifacts/example-visual/manifest.json <<'JSON'
+{
+  "status": "changed"
+}
+JSON
+cat > .codex-stack/browse/artifacts/example-visual/annotation.svg <<'SVG'
+<svg xmlns="http://www.w3.org/2000/svg"></svg>
+SVG
 cat > /tmp/codex-stack-qa-fixture.json <<'JSON'
 {
   "url": "https://example.com/demo",
@@ -134,6 +149,14 @@ cat > /tmp/codex-stack-qa-fixture.json <<'JSON'
       "baseline": ".codex-stack/browse/snapshots/example.json",
       "current": ".codex-stack/browse/artifacts/example-1.json",
       "screenshot": ".codex-stack/browse/artifacts/example-1.png",
+      "visualPack": {
+        "dir": ".codex-stack/browse/artifacts/example-visual",
+        "index": ".codex-stack/browse/artifacts/example-visual/index.html",
+        "manifest": ".codex-stack/browse/artifacts/example-visual/manifest.json",
+        "annotation": ".codex-stack/browse/artifacts/example-visual/annotation.svg",
+        "baselineScreenshot": ".codex-stack/browse/artifacts/example-visual/baseline.png",
+        "currentScreenshot": ".codex-stack/browse/artifacts/example-visual/current.png"
+      },
       "comparison": {
         "missingSelectors": ["h1"],
         "changedSelectors": [],
@@ -164,6 +187,8 @@ test -f docs/qa/smoke-fixture/report.md
 test -f docs/qa/smoke-fixture/report.json
 test -f docs/qa/smoke-fixture/annotation.svg
 test -f docs/qa/smoke-fixture/screenshot.png
+test -f docs/qa/smoke-fixture/visual/index.html
+test -f docs/qa/smoke-fixture/visual/manifest.json
 run_ts scripts/render-qa-pages.ts --out .site >/tmp/codex-stack-qa-pages.log
 test -f .site/index.html
 test -f .site/qa/index.html
@@ -171,6 +196,7 @@ test -f .site/qa/smoke-fixture/index.html
 test -f .site/manifest.json
 test -f .site/.nojekyll
 grep -q 'codex-stack QA Reports' .site/index.html
+grep -q 'Visual pack' .site/index.html
 grep -q 'smoke-fixture' .site/manifest.json
 grep -q 'github.io' .site/manifest.json
 bun run build >/tmp/codex-stack-preview-build.log

--- a/scripts/deploy-verify.spec.ts
+++ b/scripts/deploy-verify.spec.ts
@@ -16,6 +16,7 @@ const readinessFixturePath = path.join(fixtureRoot, "readiness-fixture.json");
 const baselinePath = path.join(fixtureRoot, "baseline.json");
 const currentPath = path.join(fixtureRoot, "current.json");
 const screenshotPath = path.join(fixtureRoot, "snapshot-screenshot.png");
+const visualDir = path.join(fixtureRoot, "visual-pack");
 const pageScreenshotA = path.join(fixtureRoot, "page-a.png");
 const pageScreenshotB = path.join(fixtureRoot, "page-b.png");
 const sessionBundlePath = path.join(fixtureRoot, "session-bundle.json");
@@ -29,6 +30,12 @@ async function main(): Promise<void> {
   fs.writeFileSync(screenshotPath, png);
   fs.writeFileSync(pageScreenshotA, png);
   fs.writeFileSync(pageScreenshotB, png);
+  fs.mkdirSync(visualDir, { recursive: true });
+  fs.writeFileSync(path.join(visualDir, "index.html"), "<html><body>visual pack</body></html>");
+  fs.writeFileSync(path.join(visualDir, "manifest.json"), JSON.stringify({ status: "changed" }, null, 2));
+  fs.writeFileSync(path.join(visualDir, "annotation.svg"), "<svg xmlns=\"http://www.w3.org/2000/svg\"></svg>");
+  fs.writeFileSync(path.join(visualDir, "baseline.png"), png);
+  fs.writeFileSync(path.join(visualDir, "current.png"), png);
   fs.writeFileSync(sessionBundlePath, JSON.stringify({
     version: 1,
     exportedAt: new Date().toISOString(),
@@ -94,6 +101,12 @@ async function main(): Promise<void> {
         baseline: baselinePath,
         current: currentPath,
         screenshot: screenshotPath,
+        visualPack: {
+          dir: visualDir,
+          index: path.join(visualDir, "index.html"),
+          manifest: path.join(visualDir, "manifest.json"),
+          annotation: path.join(visualDir, "annotation.svg"),
+        },
         comparison: {
           missingSelectors: ["h1"],
           changedSelectors: [],
@@ -176,6 +189,7 @@ async function main(): Promise<void> {
     checks?: { paths?: string[]; devices?: string[]; strictHttp?: boolean };
     pathResults?: Array<{ path?: string; device?: string; status?: string; httpStatus?: number | null; screenshot?: string; console?: { errors?: string[]; warnings?: string[] } }>;
     qa?: { status?: string; flowResults?: Array<{ name?: string }>; snapshotResults?: Array<{ name?: string; status?: string; annotation?: string }>; findings?: Array<{ title?: string }> };
+    visualPack?: { index?: string; manifest?: string };
     screenshotManifest?: string;
   };
 
@@ -196,6 +210,8 @@ async function main(): Promise<void> {
   assert.ok(report.qa?.snapshotResults?.some((entry) => entry.name === "portal-dashboard" && entry.status === "changed"));
   assert.ok(report.qa?.findings?.some((entry) => String(entry.title).includes("Expected UI selectors")));
   assert.ok(report.screenshotManifest);
+  assert.ok(String(report.visualPack?.index).includes("visual/index.html"));
+  assert.ok(String(report.visualPack?.manifest).includes("visual/manifest.json"));
 
   assert.ok(fs.existsSync(markdownOut));
   assert.ok(fs.existsSync(jsonOut));
@@ -204,6 +220,10 @@ async function main(): Promise<void> {
   assert.ok(fs.existsSync(path.join(publishDir, "report.json")));
   assert.ok(fs.existsSync(path.join(publishDir, "comment.md")));
   assert.ok(fs.existsSync(path.join(publishDir, "screenshots.json")));
+  assert.ok(fs.existsSync(path.join(publishDir, "visual", "index.html")));
+  assert.ok(fs.existsSync(path.join(publishDir, "visual", "manifest.json")));
+  const visualSnapshotDirs = fs.readdirSync(path.join(publishDir, "visual", "snapshots"));
+  assert.ok(visualSnapshotDirs.some((entry) => fs.existsSync(path.join(publishDir, "visual", "snapshots", entry, "index.html"))));
   assert.ok(fs.existsSync(path.join(publishDir, "screenshots", "root-desktop.png")));
   assert.ok(fs.existsSync(path.join(publishDir, "screenshots", "dashboard-mobile.png")));
 
@@ -214,6 +234,7 @@ async function main(): Promise<void> {
   assert.match(markdown, /root-desktop\.png/);
   assert.match(markdown, /dashboard-mobile\.png/);
   assert.match(markdown, /portal-dashboard/);
+  assert.match(markdown, /Visual pack/);
   assert.match(comment, /Deploy URL: https:\/\/preview-77\.example\.com/);
 
   console.log("deploy-verify spec passed");

--- a/scripts/deploy-verify.ts
+++ b/scripts/deploy-verify.ts
@@ -99,11 +99,23 @@ interface QaFlowResult {
   steps?: number;
 }
 
+interface VisualPackRef {
+  dir?: string;
+  index?: string;
+  manifest?: string;
+  annotation?: string;
+  baselineJson?: string;
+  currentJson?: string;
+  baselineScreenshot?: string;
+  currentScreenshot?: string;
+}
+
 interface QaPublishedArtifacts {
   markdown?: string;
   json?: string;
   annotation?: string;
   screenshot?: string;
+  visualPack?: VisualPackRef | null;
 }
 
 interface QaArtifacts {
@@ -111,6 +123,7 @@ interface QaArtifacts {
   json?: string;
   annotation?: string;
   screenshot?: string;
+  visualPack?: VisualPackRef | null;
   published?: QaPublishedArtifacts;
 }
 
@@ -119,6 +132,7 @@ interface QaSnapshotReport {
   status?: string;
   annotation?: string;
   screenshot?: string;
+  visualPack?: VisualPackRef | null;
 }
 
 interface QaRunReport {
@@ -139,6 +153,7 @@ export interface DeploySnapshotResult {
   report: string;
   annotation: string;
   screenshot: string;
+  visualPack?: VisualPackRef | null;
 }
 
 export interface DeployQaSummary {
@@ -157,6 +172,12 @@ interface ScreenshotManifestEntry {
   url: string;
   status: DeployStatus;
   screenshot: string;
+}
+
+interface DeployVisualPack {
+  dir: string;
+  index: string;
+  manifest: string;
 }
 
 export interface DeployReport {
@@ -179,6 +200,7 @@ export interface DeployReport {
   qa: DeployQaSummary;
   artifactRoot: string;
   screenshotManifest: string;
+  visualPack?: DeployVisualPack | null;
   runUrl: string;
   recommendation: string;
 }
@@ -575,6 +597,105 @@ function copyFileIfPresent(source: string, destination: string): string {
   ensureDir(path.dirname(destination));
   fs.copyFileSync(resolved, destination);
   return relative(destination);
+}
+
+function copyTree(sourceDir: string, targetDir: string): void {
+  const resolved = path.isAbsolute(sourceDir) ? sourceDir : path.resolve(process.cwd(), sourceDir);
+  if (!fs.existsSync(resolved)) return;
+  ensureDir(targetDir);
+  for (const entry of fs.readdirSync(resolved, { withFileTypes: true })) {
+    const sourcePath = path.join(resolved, entry.name);
+    const targetPath = path.join(targetDir, entry.name);
+    if (entry.isDirectory()) copyTree(sourcePath, targetPath);
+    else fs.copyFileSync(sourcePath, targetPath);
+  }
+}
+
+function escapeHtml(value: unknown): string {
+  return String(value || "")
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+function relFrom(root: string, targetPath: string): string {
+  return path.relative(root, targetPath).replace(/\\/g, "/");
+}
+
+function renderDeployVisualIndex(manifest: {
+  title: string;
+  generatedAt: string;
+  status: DeployStatus;
+  previewUrl: string;
+  screenshotManifest: string;
+  screenshots: Array<Record<string, unknown>>;
+  snapshots: Array<Record<string, unknown>>;
+}): string {
+  const screenshotCards = manifest.screenshots.length
+    ? manifest.screenshots.map((item) => `
+      <article class="card">
+        <h2>${escapeHtml(`${item.path || "/"} @ ${item.device || "desktop"}`)}</h2>
+        <p>Status: <strong>${escapeHtml(item.status || "unknown")}</strong> • HTTP: ${escapeHtml(item.httpStatus ?? "n/a")}</p>
+        ${(item.consoleErrors || 0) || (item.consoleWarnings || 0) ? `<p>Console: ${escapeHtml(`${item.consoleErrors || 0} errors, ${item.consoleWarnings || 0} warnings`)}</p>` : ""}
+        ${item.screenshot ? `<img src="${escapeHtml(String(item.screenshot))}" alt="${escapeHtml(`${item.path || "/"} ${item.device || "desktop"}`)}">` : "<p>No screenshot recorded.</p>"}
+      </article>
+    `).join("\n")
+    : "<p>No deploy screenshots recorded.</p>";
+
+  const snapshotCards = manifest.snapshots.length
+    ? manifest.snapshots.map((item) => `
+      <article class="card">
+        <h2>${escapeHtml(String(item.name || "snapshot"))}</h2>
+        <p>Status: <strong>${escapeHtml(item.status || "unknown")}</strong> • ${escapeHtml(`${item.targetPath || "/"} @ ${item.device || "desktop"}`)}</p>
+        ${item.index ? `<p><a href="${escapeHtml(String(item.index))}">Open visual pack</a></p>` : ""}
+        ${item.manifest ? `<p><a href="${escapeHtml(String(item.manifest))}">Manifest JSON</a></p>` : ""}
+        ${item.annotation ? `<object data="${escapeHtml(String(item.annotation))}" type="image/svg+xml" aria-label="Snapshot annotation"></object>` : item.screenshot ? `<img src="${escapeHtml(String(item.screenshot))}" alt="${escapeHtml(String(item.name || "snapshot"))}">` : "<p>No visual evidence recorded.</p>"}
+      </article>
+    `).join("\n")
+    : "<p>No snapshot visual packs recorded.</p>";
+
+  return `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>${escapeHtml(manifest.title)}</title>
+  <style>
+    :root { color-scheme: light dark; font-family: ui-sans-serif, system-ui, sans-serif; }
+    body { margin: 0; background: #08111f; color: #e5edf8; }
+    main { max-width: 1240px; margin: 0 auto; padding: 28px 20px 56px; }
+    h1, h2 { margin: 0 0 12px; }
+    p, li { line-height: 1.55; }
+    a { color: #93c5fd; }
+    .meta, .grid { display: grid; gap: 16px; }
+    .meta { grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); margin: 20px 0 28px; }
+    .grid { grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); }
+    .card { background: rgba(15, 23, 42, 0.92); border: 1px solid rgba(148, 163, 184, 0.18); border-radius: 18px; padding: 18px; }
+    img, object { width: 100%; border-radius: 12px; border: 1px solid rgba(148, 163, 184, 0.18); background: #020617; }
+  </style>
+</head>
+<body>
+  <main>
+    <h1>${escapeHtml(manifest.title)}</h1>
+    <div class="meta">
+      <div class="card"><strong>Status</strong><div>${escapeHtml(manifest.status)}</div></div>
+      <div class="card"><strong>Generated</strong><div>${escapeHtml(manifest.generatedAt)}</div></div>
+      <div class="card"><strong>Preview URL</strong><div>${manifest.previewUrl ? `<a href="${escapeHtml(manifest.previewUrl)}">${escapeHtml(manifest.previewUrl)}</a>` : "n/a"}</div></div>
+      <div class="card"><strong>Screenshot manifest</strong><div>${manifest.screenshotManifest ? `<a href="${escapeHtml(manifest.screenshotManifest)}">Open JSON</a>` : "n/a"}</div></div>
+    </div>
+    <section>
+      <h2>Page/device checks</h2>
+      <div class="grid">${screenshotCards}</div>
+    </section>
+    <section style="margin-top: 28px;">
+      <h2>Snapshot regressions</h2>
+      <div class="grid">${snapshotCards}</div>
+    </section>
+  </main>
+</body>
+</html>`;
 }
 
 function asObject(value: unknown): Record<string, unknown> | null {
@@ -989,6 +1110,7 @@ function aggregateQa({
       report: cleanSubject(entry.report.artifacts?.published?.markdown || entry.report.artifacts?.markdown || ""),
       annotation: cleanSubject(entry.report.snapshotResult?.annotation || entry.report.artifacts?.published?.annotation || entry.report.artifacts?.annotation || ""),
       screenshot: cleanSubject(entry.report.snapshotResult?.screenshot || entry.report.artifacts?.published?.screenshot || entry.report.artifacts?.screenshot || ""),
+      visualPack: entry.report.snapshotResult?.visualPack || entry.report.artifacts?.published?.visualPack || entry.report.artifacts?.visualPack || null,
     }));
   const healthScore = reports.reduce((lowest, entry) => {
     const next = typeof entry.report.healthScore === "number" ? entry.report.healthScore : 100;
@@ -1121,6 +1243,8 @@ export function renderDeployMarkdown(report: DeployReport): string {
     "",
     `- Artifact root: \`${relative(report.artifactRoot)}\``,
     report.screenshotManifest ? `- Screenshot manifest: \`${report.screenshotManifest}\`` : "",
+    report.visualPack?.index ? `- Visual pack: \`${report.visualPack.index}\`` : "",
+    report.visualPack?.manifest ? `- Visual manifest: \`${report.visualPack.manifest}\`` : "",
     primaryQaArtifacts.markdown ? `- QA report: \`${primaryQaArtifacts.markdown}\`` : "",
     primaryQaArtifacts.json ? `- QA json: \`${primaryQaArtifacts.json}\`` : "",
     primaryQaArtifacts.annotation ? `- QA annotation: \`${primaryQaArtifacts.annotation}\`` : "",
@@ -1160,6 +1284,82 @@ function writeScreenshotManifest(targetPath: string, results: DeployPathResult[]
     }));
   writeFile(targetPath, JSON.stringify(manifest, null, 2));
   return relative(targetPath);
+}
+
+function writeVisualPack({
+  publishDir,
+  resolvedUrl,
+  pathResults,
+  snapshotResults,
+  screenshotManifest,
+  status,
+}: {
+  publishDir: string;
+  resolvedUrl: string;
+  pathResults: DeployPathResult[];
+  snapshotResults: DeploySnapshotResult[];
+  screenshotManifest: string;
+  status: DeployStatus;
+}): DeployVisualPack {
+  const visualDir = path.join(publishDir, "visual");
+  const screenshotDir = path.join(visualDir, "screenshots");
+  const snapshotRoot = path.join(visualDir, "snapshots");
+  ensureDir(screenshotDir);
+  ensureDir(snapshotRoot);
+
+  const screenshotEntries = pathResults.map((entry) => {
+    const destination = entry.screenshot ? path.join(screenshotDir, path.basename(entry.screenshot)) : "";
+    const copiedScreenshot = entry.screenshot ? copyFileIfPresent(entry.screenshot, destination) : "";
+    return {
+      path: entry.path,
+      device: entry.device,
+      url: entry.url,
+      status: entry.status,
+      httpStatus: entry.httpStatus,
+      consoleErrors: entry.console.errors.length,
+      consoleWarnings: entry.console.warnings.length,
+      screenshot: copiedScreenshot ? relFrom(visualDir, path.resolve(process.cwd(), copiedScreenshot)) : "",
+    };
+  });
+
+  const snapshotEntries = snapshotResults.map((entry) => {
+    const slug = slugify(`${entry.name}-${entry.targetPath}-${entry.device}`);
+    const targetDir = path.join(snapshotRoot, slug);
+    if (entry.visualPack?.dir) {
+      copyTree(entry.visualPack.dir, targetDir);
+    }
+    const copiedAnnotation = entry.annotation ? copyFileIfPresent(entry.annotation, path.join(targetDir, "annotation.svg")) : "";
+    const copiedScreenshot = entry.screenshot ? copyFileIfPresent(entry.screenshot, path.join(targetDir, "screenshot.png")) : "";
+    const indexPath = path.join(targetDir, "index.html");
+    const manifestPath = path.join(targetDir, "manifest.json");
+    return {
+      name: entry.name,
+      targetPath: entry.targetPath,
+      device: entry.device,
+      status: entry.status,
+      index: fs.existsSync(indexPath) ? relFrom(visualDir, indexPath) : "",
+      manifest: fs.existsSync(manifestPath) ? relFrom(visualDir, manifestPath) : "",
+      annotation: copiedAnnotation ? relFrom(visualDir, path.resolve(process.cwd(), copiedAnnotation)) : (fs.existsSync(path.join(targetDir, "annotation.svg")) ? relFrom(visualDir, path.join(targetDir, "annotation.svg")) : ""),
+      screenshot: copiedScreenshot ? relFrom(visualDir, path.resolve(process.cwd(), copiedScreenshot)) : (fs.existsSync(path.join(targetDir, "current.png")) ? relFrom(visualDir, path.join(targetDir, "current.png")) : ""),
+    };
+  });
+
+  const manifest = {
+    generatedAt: new Date().toISOString(),
+    title: "codex-stack visual review pack",
+    status,
+    previewUrl: resolvedUrl,
+    screenshotManifest: screenshotManifest ? relFrom(visualDir, path.resolve(process.cwd(), screenshotManifest)) : "",
+    screenshots: screenshotEntries,
+    snapshots: snapshotEntries,
+  };
+  writeFile(path.join(visualDir, "manifest.json"), JSON.stringify(manifest, null, 2));
+  writeFile(path.join(visualDir, "index.html"), renderDeployVisualIndex(manifest));
+  return {
+    dir: relative(visualDir),
+    index: relative(path.join(visualDir, "index.html")),
+    manifest: relative(path.join(visualDir, "manifest.json")),
+  };
 }
 
 export async function runDeployVerification(args: DeployArgs): Promise<DeployReport> {
@@ -1229,11 +1429,20 @@ export async function runDeployVerification(args: DeployArgs): Promise<DeployRep
     qa,
     artifactRoot: publishDir,
     screenshotManifest: "",
+    visualPack: null,
     runUrl: actionsRunUrl(context),
     recommendation: "",
   };
 
   report.screenshotManifest = writeScreenshotManifest(path.join(publishDir, "screenshots.json"), pathResults);
+  report.visualPack = writeVisualPack({
+    publishDir,
+    resolvedUrl: resolved.url,
+    pathResults,
+    snapshotResults: report.qa.snapshotResults,
+    screenshotManifest: report.screenshotManifest,
+    status: report.status,
+  });
   report.recommendation = recommendation(report);
 
   const markdown = renderDeployMarkdown(report);

--- a/scripts/preview-verify.spec.ts
+++ b/scripts/preview-verify.spec.ts
@@ -16,6 +16,7 @@ const readinessFixturePath = path.join(fixtureRoot, "readiness-fixture.json");
 const baselinePath = path.join(fixtureRoot, "baseline.json");
 const currentPath = path.join(fixtureRoot, "current.json");
 const screenshotPath = path.join(fixtureRoot, "screenshot.png");
+const visualDir = path.join(fixtureRoot, "visual-pack");
 const pageScreenshot = path.join(fixtureRoot, "page.png");
 const sessionBundlePath = path.join(fixtureRoot, "session-bundle.json");
 const markdownOut = path.join(fixtureRoot, "preview.md");
@@ -27,6 +28,12 @@ async function main(): Promise<void> {
   const png = Buffer.from("iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAusB9Y9l9i8AAAAASUVORK5CYII=", "base64");
   fs.writeFileSync(screenshotPath, png);
   fs.writeFileSync(pageScreenshot, png);
+  fs.mkdirSync(visualDir, { recursive: true });
+  fs.writeFileSync(path.join(visualDir, "index.html"), "<html><body>visual pack</body></html>");
+  fs.writeFileSync(path.join(visualDir, "manifest.json"), JSON.stringify({ status: "changed" }, null, 2));
+  fs.writeFileSync(path.join(visualDir, "annotation.svg"), "<svg xmlns=\"http://www.w3.org/2000/svg\"></svg>");
+  fs.writeFileSync(path.join(visualDir, "baseline.png"), png);
+  fs.writeFileSync(path.join(visualDir, "current.png"), png);
   fs.writeFileSync(sessionBundlePath, JSON.stringify({
     version: 1,
     exportedAt: new Date().toISOString(),
@@ -80,6 +87,12 @@ async function main(): Promise<void> {
         baseline: baselinePath,
         current: currentPath,
         screenshot: screenshotPath,
+        visualPack: {
+          dir: visualDir,
+          index: path.join(visualDir, "index.html"),
+          manifest: path.join(visualDir, "manifest.json"),
+          annotation: path.join(visualDir, "annotation.svg"),
+        },
         comparison: {
           missingSelectors: ["h1"],
           changedSelectors: [],
@@ -149,8 +162,9 @@ async function main(): Promise<void> {
     recommendation?: string;
     readiness?: { status?: string; attempts?: number };
     context?: { branchSlug?: string; shortSha?: string };
-    deploy?: { screenshotManifest?: string; pathResults?: Array<{ status?: string; screenshot?: string }> };
+    deploy?: { screenshotManifest?: string; visualPack?: { index?: string; manifest?: string }; pathResults?: Array<{ status?: string; screenshot?: string }> };
     qa?: { snapshotResult?: { status?: string; annotation?: string }; findings?: Array<{ title?: string }> };
+    visualPack?: { index?: string; manifest?: string };
   };
 
   assert.equal(report.url, "https://preview-42.example.com");
@@ -162,6 +176,8 @@ async function main(): Promise<void> {
   assert.equal(report.context?.branchSlug, "feat-42-preview-ready");
   assert.equal(report.context?.shortSha, "abcdef1");
   assert.ok(report.deploy?.screenshotManifest);
+  assert.ok(String(report.deploy?.visualPack?.index).includes("visual/index.html"));
+  assert.ok(String(report.visualPack?.index).includes("visual/index.html"));
   assert.ok(report.deploy?.pathResults?.some((entry) => entry.status === "warning" && String(entry.screenshot).includes("root-desktop")));
   assert.equal(report.qa?.snapshotResult?.status, "changed");
   assert.ok(report.qa?.findings?.some((entry) => String(entry.title).includes("Expected UI selectors")));
@@ -180,6 +196,7 @@ async function main(): Promise<void> {
   assert.match(markdown, /Workflow run: https:\/\/github.com\/anup4khandelwal\/codex-stack\/actions\/runs\/123456/);
   assert.match(markdown, /## Deploy checks/);
   assert.match(markdown, /root-desktop\.png/);
+  assert.match(markdown, /Visual pack/);
   assert.match(comment, /Expected UI selectors are missing/);
 
   console.log("preview-verify spec passed");

--- a/scripts/preview-verify.ts
+++ b/scripts/preview-verify.ts
@@ -49,6 +49,7 @@ interface PreviewReport {
   readiness: ReadinessResult;
   qa: PreviewQaCompat;
   artifactRoot: string;
+  visualPack?: DeployReport["visualPack"];
   runUrl: string;
   recommendation: string;
   deploy: DeployReport;
@@ -185,6 +186,8 @@ function renderMarkdown(report: PreviewReport): string {
     "",
     `- Artifact root: \`${relative(report.artifactRoot)}\``,
     report.deploy.screenshotManifest ? `- Screenshot manifest: \`${report.deploy.screenshotManifest}\`` : "",
+    report.visualPack?.index ? `- Visual pack: \`${report.visualPack.index}\`` : "",
+    report.visualPack?.manifest ? `- Visual manifest: \`${report.visualPack.manifest}\`` : "",
     published.markdown ? `- QA report: \`${published.markdown}\`` : "",
     published.json ? `- QA json: \`${published.json}\`` : "",
     published.annotation ? `- Annotation: \`${published.annotation}\`` : "",
@@ -221,6 +224,7 @@ async function main(): Promise<void> {
     readiness: deploy.readiness,
     qa: buildCompatQa(deploy),
     artifactRoot: deploy.artifactRoot,
+    visualPack: deploy.visualPack,
     runUrl: deploy.runUrl,
     recommendation: deploy.recommendation,
     deploy,

--- a/scripts/qa-run.spec.ts
+++ b/scripts/qa-run.spec.ts
@@ -17,6 +17,7 @@ async function main(): Promise<void> {
 const baselinePath = path.join(fixtureRoot, "baseline.json");
 const currentPath = path.join(fixtureRoot, "current.json");
 const screenshotPath = path.join(fixtureRoot, "screenshot.png");
+const visualDir = path.join(fixtureRoot, "visual");
 const bundlePath = path.join(fixtureRoot, "session-bundle.json");
 const importMarker = path.join(fixtureRoot, "imported-session.json");
 
@@ -80,6 +81,10 @@ const importMarker = path.join(fixtureRoot, "imported-session.json");
       2,
     ),
   );
+  fs.mkdirSync(visualDir, { recursive: true });
+  fs.writeFileSync(path.join(visualDir, "index.html"), "<html><body>visual pack</body></html>");
+  fs.writeFileSync(path.join(visualDir, "manifest.json"), JSON.stringify({ status: "changed" }, null, 2));
+  fs.writeFileSync(path.join(visualDir, "annotation.svg"), "<svg xmlns=\"http://www.w3.org/2000/svg\"></svg>");
 
   fs.writeFileSync(
     path.join(browseDir, "cli.ts"),
@@ -102,6 +107,12 @@ if (command === "compare-snapshot") {
     baseline: ${JSON.stringify(baselinePath)},
     current: ${JSON.stringify(currentPath)},
     screenshot: ${JSON.stringify(screenshotPath)},
+    visualPack: {
+      dir: ${JSON.stringify(visualDir)},
+      index: ${JSON.stringify(path.join(visualDir, "index.html"))},
+      manifest: ${JSON.stringify(path.join(visualDir, "manifest.json"))},
+      annotation: ${JSON.stringify(path.join(visualDir, "annotation.svg"))}
+    },
     comparison: {
       missingSelectors: ["h1"],
       changedSelectors: [],
@@ -141,9 +152,9 @@ process.exit(1);
     status?: string;
     healthScore?: number;
     flowResults?: Array<{ name?: string; status?: string; steps?: number }>;
-    snapshotResult?: { name?: string; status?: string; annotation?: string; screenshot?: string };
+    snapshotResult?: { name?: string; status?: string; annotation?: string; screenshot?: string; visualPack?: { index?: string; manifest?: string } | null };
     findings?: Array<{ severity?: string; category?: string; title?: string; evidence?: { annotation?: string } }>;
-    artifacts?: { annotation?: string };
+    artifacts?: { annotation?: string; visualPack?: { index?: string; manifest?: string } | null };
   };
 
   assert.equal(report.status, "critical");
@@ -155,10 +166,13 @@ process.exit(1);
   assert.equal(report.snapshotResult?.status, "changed");
   assert.ok(String(report.snapshotResult?.annotation).includes(".codex-stack/qa/annotations/"));
   assert.ok(String(report.snapshotResult?.screenshot).includes("screenshot.png"));
+  assert.ok(String(report.snapshotResult?.visualPack?.index).includes("visual/index.html"));
+  assert.ok(String(report.snapshotResult?.visualPack?.manifest).includes("visual/manifest.json"));
   assert.ok(report.findings?.some((item) => item.severity === "critical" && item.category === "visual" && item.title === "Expected UI selectors are missing"));
   assert.ok(report.findings?.some((item) => item.severity === "medium" && item.category === "visual" && item.title === "Snapshot drift detected"));
   assert.ok(report.findings?.some((item) => item.evidence?.annotation));
   assert.ok(report.artifacts?.annotation);
+  assert.ok(report.artifacts?.visualPack?.index);
   assert.ok(fs.existsSync(path.join(fixtureRoot, String(report.artifacts?.annotation))));
   const imported = JSON.parse(fs.readFileSync(importMarker, "utf8")) as { sourcePath?: string; sessionFlag?: string; sessionName?: string };
   assert.equal(imported.sourcePath, bundlePath);

--- a/scripts/qa-run.ts
+++ b/scripts/qa-run.ts
@@ -58,6 +58,17 @@ interface SnapshotComparison {
   screenshotChanged?: boolean;
 }
 
+interface VisualPackRef {
+  dir: string;
+  index: string;
+  manifest: string;
+  annotation?: string;
+  baselineJson?: string;
+  currentJson?: string;
+  baselineScreenshot?: string;
+  currentScreenshot?: string;
+}
+
 interface SnapshotCommandResult {
   status?: string;
   baseline?: string;
@@ -65,6 +76,7 @@ interface SnapshotCommandResult {
   current?: string;
   screenshot?: string;
   comparison?: SnapshotComparison;
+  visualPack?: VisualPackRef;
 }
 
 interface SnapshotEvidence {
@@ -118,6 +130,7 @@ interface QaSnapshotSummary {
   current: string;
   screenshot: string;
   annotation: string;
+  visualPack?: VisualPackRef | null;
 }
 
 interface PublishedArtifacts {
@@ -128,6 +141,7 @@ interface PublishedArtifacts {
   screenshot: string;
   current: string;
   baseline: string;
+  visualPack?: VisualPackRef | null;
 }
 
 interface QaArtifacts {
@@ -136,6 +150,7 @@ interface QaArtifacts {
   latestJson?: string;
   latestMarkdown?: string;
   annotation?: string;
+  visualPack?: VisualPackRef | null;
   trendsJson?: string;
   trendsMarkdown?: string;
   published?: PublishedArtifacts;
@@ -362,6 +377,25 @@ function asSnapshotComparison(value: unknown): SnapshotComparison {
   };
 }
 
+function asVisualPackRef(value: unknown): VisualPackRef | undefined {
+  const obj = asObject(value);
+  if (!obj) return undefined;
+  const dir = asString(obj.dir);
+  const index = asString(obj.index);
+  const manifest = asString(obj.manifest);
+  if (!dir && !index && !manifest) return undefined;
+  return {
+    dir,
+    index,
+    manifest,
+    annotation: asString(obj.annotation),
+    baselineJson: asString(obj.baselineJson),
+    currentJson: asString(obj.currentJson),
+    baselineScreenshot: asString(obj.baselineScreenshot),
+    currentScreenshot: asString(obj.currentScreenshot),
+  };
+}
+
 function asSnapshotCommandResult(value: unknown): SnapshotCommandResult {
   const obj = asObject(value);
   return {
@@ -371,6 +405,7 @@ function asSnapshotCommandResult(value: unknown): SnapshotCommandResult {
     current: asString(obj?.current),
     screenshot: asString(obj?.screenshot),
     comparison: obj?.comparison ? asSnapshotComparison(obj.comparison) : undefined,
+    visualPack: obj?.visualPack ? asVisualPackRef(obj.visualPack) : undefined,
   };
 }
 
@@ -521,6 +556,8 @@ function buildMarkdown(report: QaReport): string {
         `- Snapshot: ${report.snapshotResult.status} (${report.snapshotResult.name})`,
         report.snapshotResult.screenshot ? `- Screenshot: ${report.snapshotResult.screenshot}` : "",
         report.snapshotResult.annotation ? `- Annotation: ${report.snapshotResult.annotation}` : "",
+        report.snapshotResult.visualPack?.index ? `- Visual pack: ${report.snapshotResult.visualPack.index}` : "",
+        report.snapshotResult.visualPack?.manifest ? `- Visual manifest: ${report.snapshotResult.visualPack.manifest}` : "",
       ]
         .filter(Boolean)
         .join("\n")
@@ -1001,9 +1038,10 @@ function buildReport({
           current: snapshotEvidence.result.current || "",
           screenshot: snapshotEvidence.result.screenshot || "",
           annotation: "",
+          visualPack: snapshotEvidence.result.visualPack || null,
         }
       : null,
-    artifacts: {},
+    artifacts: snapshotEvidence?.result.visualPack ? { visualPack: snapshotEvidence.result.visualPack } : {},
   };
 }
 
@@ -1018,6 +1056,9 @@ function attachSnapshotAnnotation(report: QaReport, snapshotEvidence: SnapshotEv
     if (item.evidence.snapshot) {
       item.evidence.annotation = artifact.annotation;
       item.evidence.screenshot = item.evidence.screenshot || artifact.screenshot;
+      if (report.snapshotResult?.visualPack?.index) {
+        item.evidence.visualPack = report.snapshotResult.visualPack.index;
+      }
     }
   }
   report.artifacts.annotation = artifact.annotation;
@@ -1036,12 +1077,45 @@ function copyIfExists(sourcePath: string, targetPath: string): string {
   return targetPath;
 }
 
+function copyTree(sourceDir: string, targetDir: string): void {
+  const resolvedSource = resolveMaybeRelative(sourceDir);
+  if (!resolvedSource || !fs.existsSync(resolvedSource)) return;
+  ensureDir(targetDir);
+  for (const entry of fs.readdirSync(resolvedSource, { withFileTypes: true })) {
+    const sourcePath = path.join(resolvedSource, entry.name);
+    const targetPath = path.join(targetDir, entry.name);
+    if (entry.isDirectory()) copyTree(sourcePath, targetPath);
+    else fs.copyFileSync(sourcePath, targetPath);
+  }
+}
+
 function rewriteEvidencePaths(report: QaReport, pathMap: Record<string, string>): void {
   if (report.snapshotResult) {
     if (pathMap[report.snapshotResult.baseline]) report.snapshotResult.baseline = pathMap[report.snapshotResult.baseline];
     if (pathMap[report.snapshotResult.current]) report.snapshotResult.current = pathMap[report.snapshotResult.current];
     if (pathMap[report.snapshotResult.screenshot]) report.snapshotResult.screenshot = pathMap[report.snapshotResult.screenshot];
     if (pathMap[report.snapshotResult.annotation]) report.snapshotResult.annotation = pathMap[report.snapshotResult.annotation];
+    if (report.snapshotResult.visualPack) {
+      if (pathMap[report.snapshotResult.visualPack.dir]) report.snapshotResult.visualPack.dir = pathMap[report.snapshotResult.visualPack.dir];
+      if (pathMap[report.snapshotResult.visualPack.index]) report.snapshotResult.visualPack.index = pathMap[report.snapshotResult.visualPack.index];
+      if (pathMap[report.snapshotResult.visualPack.manifest]) report.snapshotResult.visualPack.manifest = pathMap[report.snapshotResult.visualPack.manifest];
+      if (report.snapshotResult.visualPack.annotation && pathMap[report.snapshotResult.visualPack.annotation]) report.snapshotResult.visualPack.annotation = pathMap[report.snapshotResult.visualPack.annotation];
+      if (report.snapshotResult.visualPack.baselineJson && pathMap[report.snapshotResult.visualPack.baselineJson]) report.snapshotResult.visualPack.baselineJson = pathMap[report.snapshotResult.visualPack.baselineJson];
+      if (report.snapshotResult.visualPack.currentJson && pathMap[report.snapshotResult.visualPack.currentJson]) report.snapshotResult.visualPack.currentJson = pathMap[report.snapshotResult.visualPack.currentJson];
+      if (report.snapshotResult.visualPack.baselineScreenshot && pathMap[report.snapshotResult.visualPack.baselineScreenshot]) report.snapshotResult.visualPack.baselineScreenshot = pathMap[report.snapshotResult.visualPack.baselineScreenshot];
+      if (report.snapshotResult.visualPack.currentScreenshot && pathMap[report.snapshotResult.visualPack.currentScreenshot]) report.snapshotResult.visualPack.currentScreenshot = pathMap[report.snapshotResult.visualPack.currentScreenshot];
+    }
+  }
+
+  if (report.artifacts.visualPack) {
+    if (pathMap[report.artifacts.visualPack.dir]) report.artifacts.visualPack.dir = pathMap[report.artifacts.visualPack.dir];
+    if (pathMap[report.artifacts.visualPack.index]) report.artifacts.visualPack.index = pathMap[report.artifacts.visualPack.index];
+    if (pathMap[report.artifacts.visualPack.manifest]) report.artifacts.visualPack.manifest = pathMap[report.artifacts.visualPack.manifest];
+    if (report.artifacts.visualPack.annotation && pathMap[report.artifacts.visualPack.annotation]) report.artifacts.visualPack.annotation = pathMap[report.artifacts.visualPack.annotation];
+    if (report.artifacts.visualPack.baselineJson && pathMap[report.artifacts.visualPack.baselineJson]) report.artifacts.visualPack.baselineJson = pathMap[report.artifacts.visualPack.baselineJson];
+    if (report.artifacts.visualPack.currentJson && pathMap[report.artifacts.visualPack.currentJson]) report.artifacts.visualPack.currentJson = pathMap[report.artifacts.visualPack.currentJson];
+    if (report.artifacts.visualPack.baselineScreenshot && pathMap[report.artifacts.visualPack.baselineScreenshot]) report.artifacts.visualPack.baselineScreenshot = pathMap[report.artifacts.visualPack.baselineScreenshot];
+    if (report.artifacts.visualPack.currentScreenshot && pathMap[report.artifacts.visualPack.currentScreenshot]) report.artifacts.visualPack.currentScreenshot = pathMap[report.artifacts.visualPack.currentScreenshot];
   }
 
   for (const item of report.findings) {
@@ -1077,6 +1151,31 @@ function publishArtifacts(report: QaReport, publishDir: string): QaReport {
     }
   }
 
+  const sourceVisualPack = report.snapshotResult?.visualPack || report.artifacts.visualPack || null;
+  let publishedVisualPack: VisualPackRef | null = null;
+  if (sourceVisualPack?.dir) {
+    const visualDir = path.join(outputDir, "visual");
+    copyTree(sourceVisualPack.dir, visualDir);
+    publishedVisualPack = {
+      dir: relative(visualDir),
+      index: fs.existsSync(path.join(visualDir, "index.html")) ? relative(path.join(visualDir, "index.html")) : "",
+      manifest: fs.existsSync(path.join(visualDir, "manifest.json")) ? relative(path.join(visualDir, "manifest.json")) : "",
+      annotation: fs.existsSync(path.join(visualDir, "annotation.svg")) ? relative(path.join(visualDir, "annotation.svg")) : "",
+      baselineJson: fs.existsSync(path.join(visualDir, "baseline.json")) ? relative(path.join(visualDir, "baseline.json")) : "",
+      currentJson: fs.existsSync(path.join(visualDir, "current.json")) ? relative(path.join(visualDir, "current.json")) : "",
+      baselineScreenshot: fs.existsSync(path.join(visualDir, "baseline.png")) ? relative(path.join(visualDir, "baseline.png")) : "",
+      currentScreenshot: fs.existsSync(path.join(visualDir, "current.png")) ? relative(path.join(visualDir, "current.png")) : "",
+    };
+    pathMap[sourceVisualPack.dir] = publishedVisualPack.dir;
+    pathMap[sourceVisualPack.index] = publishedVisualPack.index;
+    pathMap[sourceVisualPack.manifest] = publishedVisualPack.manifest;
+    if (sourceVisualPack.annotation && publishedVisualPack.annotation) pathMap[sourceVisualPack.annotation] = publishedVisualPack.annotation;
+    if (sourceVisualPack.baselineJson && publishedVisualPack.baselineJson) pathMap[sourceVisualPack.baselineJson] = publishedVisualPack.baselineJson;
+    if (sourceVisualPack.currentJson && publishedVisualPack.currentJson) pathMap[sourceVisualPack.currentJson] = publishedVisualPack.currentJson;
+    if (sourceVisualPack.baselineScreenshot && publishedVisualPack.baselineScreenshot) pathMap[sourceVisualPack.baselineScreenshot] = publishedVisualPack.baselineScreenshot;
+    if (sourceVisualPack.currentScreenshot && publishedVisualPack.currentScreenshot) pathMap[sourceVisualPack.currentScreenshot] = publishedVisualPack.currentScreenshot;
+  }
+
   rewriteEvidencePaths(published, pathMap);
   const publishedJsonPath = path.join(outputDir, "report.json");
   const publishedMarkdownPath = path.join(outputDir, "report.md");
@@ -1090,6 +1189,7 @@ function publishArtifacts(report: QaReport, publishDir: string): QaReport {
       screenshot: pathMap[report.snapshotResult?.screenshot || ""] || "",
       current: pathMap[report.snapshotResult?.current || ""] || "",
       baseline: pathMap[report.snapshotResult?.baseline || ""] || "",
+      visualPack: publishedVisualPack,
     },
   };
 

--- a/scripts/render-pr-review.spec.ts
+++ b/scripts/render-pr-review.spec.ts
@@ -56,6 +56,10 @@ async function main(): Promise<void> {
           markdown: "preview-artifacts/report.md",
           annotation: "preview-artifacts/annotation.svg",
           screenshot: "preview-artifacts/screenshot.png",
+          visualPack: {
+            index: "preview-artifacts/visual/index.html",
+            manifest: "preview-artifacts/visual/manifest.json",
+          },
         },
       },
       snapshotResult: {
@@ -67,6 +71,10 @@ async function main(): Promise<void> {
     },
     deploy: {
       screenshotManifest: "preview-artifacts/screenshots.json",
+      visualPack: {
+        index: "preview-artifacts/visual/index.html",
+        manifest: "preview-artifacts/visual/manifest.json",
+      },
       pathResults: [
         {
           path: "/",
@@ -104,6 +112,8 @@ async function main(): Promise<void> {
       reviewPath,
       "--preview-input",
       previewPath,
+      "--preview-pages-root",
+      "https://anup4khandelwal.github.io/codex-stack/pr-preview/pr-23/__codex/",
       "--markdown-out",
       markdownOut,
       "--summary-out",
@@ -119,6 +129,7 @@ async function main(): Promise<void> {
   assert.match(stdout, /## Preview QA/);
   assert.match(stdout, /Preview URL: https:\/\/preview-23\.example\.com/);
   assert.match(stdout, /Workflow run: https:\/\/github\.com\/anup4khandelwal\/codex-stack\/actions\/runs\/123456/);
+  assert.match(stdout, /Hosted visual pack: https:\/\/anup4khandelwal\.github\.io\/codex-stack\/pr-preview\/pr-23\/__codex\/visual\/index\.html/);
   assert.match(stdout, /CRITICAL\/VISUAL/);
   assert.match(stdout, /annotation\.svg/);
   assert.match(stdout, /### Deploy checks/);
@@ -146,6 +157,8 @@ async function main(): Promise<void> {
       reviewPath,
       "--preview-input",
       previewPath,
+      "--preview-pages-root",
+      "https://anup4khandelwal.github.io/codex-stack/pr-preview/pr-23/__codex/",
       "--fail-on-critical",
     ],
     {

--- a/scripts/render-pr-review.ts
+++ b/scripts/render-pr-review.ts
@@ -42,6 +42,10 @@ interface PreviewQaReport {
       json?: string;
       annotation?: string;
       screenshot?: string;
+      visualPack?: {
+        index?: string;
+        manifest?: string;
+      } | null;
     };
   };
 }
@@ -59,6 +63,10 @@ interface PreviewReport {
   qa?: PreviewQaReport;
   deploy?: {
     screenshotManifest?: string;
+    visualPack?: {
+      index?: string;
+      manifest?: string;
+    } | null;
     pathResults?: Array<{
       path?: string;
       device?: string;
@@ -70,17 +78,21 @@ interface PreviewReport {
         warnings?: string[];
       };
     }>;
-    qa?: {
-      snapshotResults?: Array<{
-        name?: string;
-        targetPath?: string;
-        device?: string;
-        status?: string;
-        report?: string;
-        annotation?: string;
-        screenshot?: string;
-      }>;
-    };
+      qa?: {
+        snapshotResults?: Array<{
+          name?: string;
+          targetPath?: string;
+          device?: string;
+          status?: string;
+          report?: string;
+          annotation?: string;
+          screenshot?: string;
+          visualPack?: {
+            index?: string;
+            manifest?: string;
+          } | null;
+        }>;
+      };
   };
 }
 
@@ -101,6 +113,7 @@ interface ReviewSummary {
 interface ParsedArgs {
   input: string;
   previewInput: string;
+  previewPagesRoot: string;
   markdownOut: string;
   summaryOut: string;
   failOnCritical: boolean;
@@ -111,7 +124,7 @@ function usage(): never {
   console.log(`render-pr-review
 
 Usage:
-  bun scripts/render-pr-review.ts --input <review.json> [--preview-input <preview.json>] [--markdown-out <path>] [--summary-out <path>] [--fail-on-critical] [--json]
+  bun scripts/render-pr-review.ts --input <review.json> [--preview-input <preview.json>] [--preview-pages-root <url>] [--markdown-out <path>] [--summary-out <path>] [--fail-on-critical] [--json]
 `);
   process.exit(0);
 }
@@ -120,6 +133,7 @@ function parseArgs(argv: string[]): ParsedArgs {
   const out: ParsedArgs = {
     input: "",
     previewInput: "",
+    previewPagesRoot: "",
     markdownOut: "",
     summaryOut: "",
     failOnCritical: false,
@@ -132,6 +146,9 @@ function parseArgs(argv: string[]): ParsedArgs {
       i += 1;
     } else if (arg === "--preview-input") {
       out.previewInput = argv[i + 1] || "";
+      i += 1;
+    } else if (arg === "--preview-pages-root") {
+      out.previewPagesRoot = argv[i + 1] || "";
       i += 1;
     } else if (arg === "--markdown-out") {
       out.markdownOut = argv[i + 1] || "";
@@ -167,6 +184,15 @@ function readPreviewJson(filePath: string): PreviewReport {
 
 function countBySeverity(findings: ReviewFinding[], severity: string): number {
   return findings.filter((item) => item.severity === severity).length;
+}
+
+function withTrailingSlash(value: string): string {
+  return value.endsWith("/") ? value : `${value}/`;
+}
+
+function absoluteLink(root: string, relativePath: string): string {
+  if (!root || !relativePath) return "";
+  return new URL(relativePath.replace(/^\/+/, ""), withTrailingSlash(root)).toString();
 }
 
 function findingLines(findings: ReviewFinding[]): string[] {
@@ -216,11 +242,14 @@ function deploySnapshotLines(preview: PreviewReport | null): string[] {
   });
 }
 
-function renderPreviewSection(preview: PreviewReport | null, summary: ReviewSummary): string {
+function renderPreviewSection(preview: PreviewReport | null, summary: ReviewSummary, previewPagesRoot: string): string {
   if (!preview) return "";
   const findings = Array.isArray(preview.qa?.findings) ? preview.qa?.findings : [];
   const published = preview.qa?.artifacts?.published || {};
   const snapshot = preview.qa?.snapshotResult;
+  const hostedVisualPack = absoluteLink(previewPagesRoot, "visual/index.html");
+  const hostedVisualManifest = absoluteLink(previewPagesRoot, "visual/manifest.json");
+  const hostedScreenshotManifest = absoluteLink(previewPagesRoot, "screenshots.json");
   return `
 ## Preview QA
 
@@ -232,10 +261,14 @@ function renderPreviewSection(preview: PreviewReport | null, summary: ReviewSumm
 - Recommendation: ${preview.recommendation || preview.qa?.recommendation || "n/a"}
 ${preview.url ? `- Preview URL: ${preview.url}` : ""}
 ${preview.runUrl ? `- Workflow run: ${preview.runUrl}` : ""}
+${hostedVisualPack ? `- Hosted visual pack: ${hostedVisualPack}` : ""}
+${hostedVisualManifest ? `- Hosted visual manifest: ${hostedVisualManifest}` : ""}
 ${published.markdown ? `- QA report: \`${published.markdown}\`` : ""}
 ${published.annotation ? `- Annotation: \`${published.annotation}\`` : ""}
 ${published.screenshot ? `- Screenshot: \`${published.screenshot}\`` : ""}
 ${preview.deploy?.screenshotManifest ? `- Screenshot manifest: \`${preview.deploy.screenshotManifest}\`` : ""}
+${hostedScreenshotManifest ? `- Hosted screenshot manifest: ${hostedScreenshotManifest}` : ""}
+${preview.deploy?.visualPack?.index ? `- Local visual pack: \`${preview.deploy.visualPack.index}\`` : ""}
 ${snapshot?.status ? `- Snapshot: ${snapshot.status}${snapshot.name ? ` (${snapshot.name})` : ""}` : ""}
 
 ### Preview findings
@@ -252,7 +285,7 @@ ${deploySnapshotLines(preview).join("\n")}
 `;
 }
 
-function renderMarkdown(review: ReviewReport, summary: ReviewSummary, preview: PreviewReport | null): string {
+function renderMarkdown(review: ReviewReport, summary: ReviewSummary, preview: PreviewReport | null, previewPagesRoot: string): string {
   return `<!-- codex-stack:pr-review -->
 # codex-stack PR review
 
@@ -267,7 +300,7 @@ function renderMarkdown(review: ReviewReport, summary: ReviewSummary, preview: P
 ## Findings
 
 ${findingLines(review.findings ?? []).join("\n")}
-${renderPreviewSection(preview, summary)}`;
+${renderPreviewSection(preview, summary, previewPagesRoot)}`;
 }
 
 const args = parseArgs(process.argv.slice(2));
@@ -287,7 +320,7 @@ summary.previewIncluded = Boolean(preview);
 summary.previewStatus = preview?.status || "";
 summary.previewBlocking = ["critical", "error"].includes(String(preview?.status || "").toLowerCase());
 summary.blocking = summary.criticalCount > 0 || summary.previewBlocking;
-const markdown = renderMarkdown(review, summary, preview);
+const markdown = renderMarkdown(review, summary, preview, args.previewPagesRoot);
 
 if (args.markdownOut) {
   const target = path.resolve(process.cwd(), args.markdownOut);

--- a/scripts/render-qa-pages.ts
+++ b/scripts/render-qa-pages.ts
@@ -57,9 +57,12 @@ interface CollectedReport {
   jsonPath: string;
   annotationPath: string;
   screenshotPath: string;
+  visualIndexPath: string;
+  visualManifestPath: string;
   stableUrl: string;
   stableAnnotationUrl: string;
   stableScreenshotUrl: string;
+  stableVisualUrl: string;
 }
 
 interface LayoutProps {
@@ -452,6 +455,7 @@ function renderIndex({ reports, baseUrl }: { reports: CollectedReport[]; baseUrl
         </div>
         <div class="links">
           <a href="${escapeHtml(`qa/${report.slug}/`)}">Open report</a>
+          ${report.visualIndexPath ? `<a href="${escapeHtml(report.visualIndexPath)}">Visual pack</a>` : ""}
           ${report.mdPath ? `<a href="${escapeHtml(report.mdPath)}">Markdown</a>` : ""}
           ${report.jsonPath ? `<a href="${escapeHtml(report.jsonPath)}">JSON</a>` : ""}
           ${report.annotationPath ? `<a href="${escapeHtml(report.annotationPath)}">Annotation</a>` : ""}
@@ -472,6 +476,8 @@ function renderIndex({ reports, baseUrl }: { reports: CollectedReport[]; baseUrl
 function renderReport(report: CollectedReport, baseUrl: string): string {
   const snapshot = report.data.snapshotResult || {};
   const detailLinks: string[] = [];
+  if (report.visualIndexPath) detailLinks.push(`<a href="visual/index.html">Visual pack</a>`);
+  if (report.visualManifestPath) detailLinks.push(`<a href="visual/manifest.json">Visual manifest</a>`);
   if (report.mdPath) detailLinks.push(`<a href="report.md">Markdown</a>`);
   if (report.jsonPath) detailLinks.push(`<a href="report.json">JSON</a>`);
   if (report.annotationPath) detailLinks.push(`<a href="annotation.svg">Annotation</a>`);
@@ -549,13 +555,17 @@ function collectReports(sourceDir: string, baseUrl: string): CollectedReport[] {
         jsonPath: fs.existsSync(reportJson) ? `qa/${entry.name}/report.json` : "",
         annotationPath: fs.existsSync(path.join(reportDir, "annotation.svg")) ? `qa/${entry.name}/annotation.svg` : "",
         screenshotPath: fs.existsSync(path.join(reportDir, "screenshot.png")) ? `qa/${entry.name}/screenshot.png` : "",
+        visualIndexPath: fs.existsSync(path.join(reportDir, "visual", "index.html")) ? `qa/${entry.name}/visual/index.html` : "",
+        visualManifestPath: fs.existsSync(path.join(reportDir, "visual", "manifest.json")) ? `qa/${entry.name}/visual/manifest.json` : "",
         stableUrl: "",
         stableAnnotationUrl: "",
         stableScreenshotUrl: "",
+        stableVisualUrl: "",
       };
       report.stableUrl = reportLink(baseUrl, report);
       report.stableAnnotationUrl = report.annotationPath ? assetLink(baseUrl, report, "annotation.svg") : "";
       report.stableScreenshotUrl = report.screenshotPath ? assetLink(baseUrl, report, "screenshot.png") : "";
+      report.stableVisualUrl = report.visualIndexPath ? assetLink(baseUrl, report, "visual/index.html") : "";
       return report;
     })
     .filter((report): report is CollectedReport => Boolean(report))
@@ -604,6 +614,7 @@ function main(): void {
       stableUrl: report.stableUrl,
       stableAnnotationUrl: report.stableAnnotationUrl,
       stableScreenshotUrl: report.stableScreenshotUrl,
+      stableVisualUrl: report.stableVisualUrl,
     })),
   };
   fs.writeFileSync(path.join(args.out, "manifest.json"), JSON.stringify(manifest, null, 2));


### PR DESCRIPTION
## Summary
- add self-contained visual packs for snapshot comparisons and thread them through QA, deploy, preview, PR review, and QA Pages
- publish hosted PR review evidence under `pr-preview/pr-<number>/__codex/` and link it from the existing PR review comment
- add regression coverage and smoke checks for visual-pack generation and publishing

## Validation
- bun run typecheck
- bun run smoke
