### PR TITLE
feat: add visual diff scoring and digest rollups

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,17 +48,17 @@ Use the repo in this order:
 - Persistent named browser sessions
 - Portable session import/export with cookie and storage-state bundles
 - Checked-in and local browser flows with import/export for JSON, YAML, and Markdown
-- Page snapshots and snapshot comparison artifacts with self-contained visual packs
+- Page snapshots and snapshot comparison artifacts with self-contained visual packs, diff heatmaps, and image-diff scores
 - QA reports with typed categories, severity, health score, diff-aware route inference, saved evidence, annotated screenshots, and published visual packs for snapshot failures
 - Historical QA trend artifacts under `.codex-stack/qa/trends.json` and `.codex-stack/qa/trends.md`
 - Preview verification with URL template resolution, readiness polling, deploy/page verification, QA execution, and PR comment output for preview deployments
-- Deploy verification with page and device matrices, screenshot manifests, console capture, tracked evidence, and `visual/index.html` review packs
+- Deploy verification with page and device matrices, screenshot manifests, console capture, tracked evidence, and `visual/index.html` review packs with ranked regressions
 - Shipping automation with PR body generation, labels, reviewers, assignees, projects, and optional deploy verification
 - PR comments with deploy verification summaries and artifact references after `ship --pr`
 - Tracked QA evidence published under `docs/qa/<branch>/` during shipping so PR comments can link to real files
 - GitHub Pages publishing for `docs/qa/` so merged QA reports keep a stable URL after branch cleanup
 - Issue-first workflow automation with PR review comments and opt-in auto-merge
-- Retrospective analytics plus weekly digest publishing outputs for markdown, Slack, and email
+- Retrospective analytics plus weekly digest publishing outputs for markdown, Slack, and email, including visual regression rollups from published QA evidence
 - Upgrade auditing via CLI plus a daily scheduled update-check workflow that syncs a stable issue
 
 ## Quick start
@@ -345,6 +345,7 @@ On GitHub, `.github/workflows/qa-pages.yml` deploys the merged `docs/qa/` report
 - stable Pages links that activate after the branch is merged to `main`
 
 When a published QA report includes snapshot evidence, the Pages site now surfaces `visual/index.html` as the primary review-evidence entrypoint alongside the raw markdown, JSON, annotation, and screenshot files.
+Those visual packs now include a diff heatmap and an image-diff score so regressions can be ranked instead of treated as binary drift only.
 
 The same `gh-pages` branch also hosts PR previews under `pr-preview/pr-<number>/`. Configure these repo variables if you want richer automatic preview coverage in `pr-review.yml`:
 
@@ -359,6 +360,7 @@ Optional authenticated preview secret:
 - `CODEX_STACK_PREVIEW_SESSION_BUNDLE_B64=<base64 of browse export-session output>`
 
 For same-repo PRs, `pr-review.yml` republishes the preview subtree with hosted review evidence under `pr-preview/pr-<number>/__codex/`, including the deploy visual pack at `__codex/visual/index.html`.
+The PR review comment uses that hosted pack to show direct visual-summary links and inline screenshots for the highest-signal regressions.
 
 When a PR closes, `.github/workflows/preview-cleanup.yml` removes only `gh-pages/pr-preview/pr-<number>/` and keeps the root QA site plus other active PR previews intact.
 

--- a/browse/src/cli.ts
+++ b/browse/src/cli.ts
@@ -4,6 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import process from "node:process";
 import { createHash } from "node:crypto";
+import { PNG } from "pngjs";
 import {
   importBrowserCookies,
   browserProfileSpec,
@@ -136,6 +137,18 @@ interface SnapshotVisualPack {
   currentJson: string;
   baselineScreenshot: string;
   currentScreenshot: string;
+  diffImage: string;
+  imageDiff: ImageDiffMetrics | null;
+}
+
+interface ImageDiffMetrics {
+  comparedPixels: number;
+  changedPixels: number;
+  diffRatio: number;
+  score: number;
+  dimensionsMatch: boolean;
+  baseline: { width: number; height: number };
+  current: { width: number; height: number };
 }
 
 interface PlaywrightResponse {
@@ -458,10 +471,81 @@ function copyIfExists(sourcePath: string, targetPath: string): string {
   return targetPath;
 }
 
+function roundMetric(value: number): number {
+  return Number.isFinite(value) ? Math.round(value * 1000) / 1000 : 0;
+}
+
+function computeImageDiff({
+  baselinePath,
+  currentPath,
+  diffPath,
+}: {
+  baselinePath: string;
+  currentPath: string;
+  diffPath: string;
+}): ImageDiffMetrics | null {
+  if (!baselinePath || !currentPath || !fs.existsSync(baselinePath) || !fs.existsSync(currentPath)) return null;
+  let baseline: PNG;
+  let current: PNG;
+  try {
+    baseline = PNG.sync.read(fs.readFileSync(baselinePath));
+    current = PNG.sync.read(fs.readFileSync(currentPath));
+  } catch {
+    return null;
+  }
+  const width = Math.max(baseline.width, current.width);
+  const height = Math.max(baseline.height, current.height);
+  const diff = new PNG({ width, height });
+  let changedPixels = 0;
+  const comparedPixels = width * height;
+
+  const pixelAt = (image: PNG, x: number, y: number): [number, number, number, number] => {
+    if (x >= image.width || y >= image.height) return [255, 0, 255, 255];
+    const idx = ((image.width * y) + x) << 2;
+    return [image.data[idx], image.data[idx + 1], image.data[idx + 2], image.data[idx + 3]];
+  };
+
+  for (let y = 0; y < height; y += 1) {
+    for (let x = 0; x < width; x += 1) {
+      const [br, bg, bb, ba] = pixelAt(baseline, x, y);
+      const [cr, cg, cb, ca] = pixelAt(current, x, y);
+      const targetIdx = ((width * y) + x) << 2;
+      const delta = Math.abs(br - cr) + Math.abs(bg - cg) + Math.abs(bb - cb) + Math.abs(ba - ca);
+      if (delta > 0) {
+        changedPixels += 1;
+        diff.data[targetIdx] = 220;
+        diff.data[targetIdx + 1] = Math.min(255, 30 + delta);
+        diff.data[targetIdx + 2] = 70;
+        diff.data[targetIdx + 3] = 255;
+      } else {
+        const gray = Math.round((cr + cg + cb) / 3);
+        diff.data[targetIdx] = gray;
+        diff.data[targetIdx + 1] = gray;
+        diff.data[targetIdx + 2] = gray;
+        diff.data[targetIdx + 3] = 90;
+      }
+    }
+  }
+
+  ensureDir(path.dirname(diffPath));
+  fs.writeFileSync(diffPath, PNG.sync.write(diff));
+  const diffRatio = comparedPixels ? changedPixels / comparedPixels : 0;
+  return {
+    comparedPixels,
+    changedPixels,
+    diffRatio: roundMetric(diffRatio),
+    score: roundMetric(Math.max(0, 100 - (diffRatio * 100))),
+    dimensionsMatch: baseline.width === current.width && baseline.height === current.height,
+    baseline: { width: baseline.width, height: baseline.height },
+    current: { width: current.width, height: current.height },
+  };
+}
+
 function renderSnapshotVisualPackHtml(manifest: Record<string, unknown>): string {
   const summary = manifest.summary as Record<string, unknown>;
   const assets = manifest.assets as Record<string, string>;
   const markers = Array.isArray(manifest.markers) ? manifest.markers as Array<Record<string, unknown>> : [];
+  const imageDiff = (manifest.imageDiff || {}) as Record<string, unknown>;
   return `<!doctype html>
 <html lang="en">
 <head>
@@ -495,6 +579,8 @@ function renderSnapshotVisualPackHtml(manifest: Record<string, unknown>): string
       <div class="card"><strong>Changed selectors</strong><div>${escapeHtml(summary?.changedSelectors ?? 0)}</div></div>
       <div class="card"><strong>New selectors</strong><div>${escapeHtml(summary?.newSelectors ?? 0)}</div></div>
       <div class="card"><strong>Body/title drift</strong><div>${escapeHtml(`${Boolean(summary?.bodyTextChanged) || Boolean(summary?.titleChanged)}`)}</div></div>
+      <div class="card"><strong>Image diff score</strong><div>${escapeHtml(imageDiff?.score ?? "n/a")}</div></div>
+      <div class="card"><strong>Image diff ratio</strong><div>${escapeHtml(imageDiff?.diffRatio ?? "n/a")}</div></div>
     </div>
     <section class="grid">
       <article class="card">
@@ -510,6 +596,11 @@ function renderSnapshotVisualPackHtml(manifest: Record<string, unknown>): string
       <article class="card">
         <h2>Annotation</h2>
         ${assets?.annotation ? `<object data="${escapeHtml(assets.annotation)}" type="image/svg+xml" aria-label="Annotated snapshot"></object>` : "<p>No annotation available.</p>"}
+      </article>
+      <article class="card">
+        <h2>Diff heatmap</h2>
+        ${assets?.diffImage ? `<img src="${escapeHtml(assets.diffImage)}" alt="Diff heatmap">` : "<p>No diff image available.</p>"}
+        <p>${imageDiff?.dimensionsMatch === false ? "Images had different dimensions; missing regions are highlighted." : "Images matched dimensions."}</p>
       </article>
     </section>
     <section class="card" style="margin-top: 20px;">
@@ -547,6 +638,7 @@ export function createSnapshotVisualPack({
   const currentJson = copyIfExists(currentJsonPath, path.join(outputDir, "current.json"));
   const baselineScreenshot = copyIfExists(baselineScreenshotPath, path.join(outputDir, "baseline.png"));
   const currentScreenshot = copyIfExists(currentScreenshotPath, path.join(outputDir, "current.png"));
+  const diffImagePath = path.join(outputDir, "diff.png");
   const baselineSnapshot = readJson<SnapshotPayload | null>(baselineJsonPath, null);
   const currentSnapshot = readJson<SnapshotPayload | null>(currentJsonPath, null);
   const markers = snapshotAnnotationMarkers(comparison, baselineSnapshot, currentSnapshot);
@@ -561,6 +653,13 @@ export function createSnapshotVisualPack({
   if (annotationSvg) {
     fs.writeFileSync(annotationPath, annotationSvg);
   }
+  const imageDiff = baselineScreenshot && currentScreenshot
+    ? computeImageDiff({
+        baselinePath: baselineScreenshot,
+        currentPath: currentScreenshot,
+        diffPath: diffImagePath,
+      })
+    : null;
   const manifestPath = path.join(outputDir, "manifest.json");
   const indexPath = path.join(outputDir, "index.html");
   const manifest = {
@@ -569,6 +668,7 @@ export function createSnapshotVisualPack({
     title: `Snapshot visual pack • ${name}`,
     status: comparison.status,
     summary: comparison.summary,
+    imageDiff,
     markers: markers.map((item) => ({ selector: item.selector, label: item.label })),
     assets: {
       baselineJson: path.basename(baselineJson),
@@ -576,6 +676,7 @@ export function createSnapshotVisualPack({
       baselineScreenshot: path.basename(baselineScreenshot),
       currentScreenshot: path.basename(currentScreenshot),
       annotation: annotationSvg ? path.basename(annotationPath) : "",
+      diffImage: imageDiff ? path.basename(diffImagePath) : "",
     },
   };
   writeJson(manifestPath, manifest);
@@ -589,6 +690,8 @@ export function createSnapshotVisualPack({
     currentJson: relativePath(currentJson),
     baselineScreenshot: relativePath(baselineScreenshot),
     currentScreenshot: relativePath(currentScreenshot),
+    diffImage: imageDiff ? relativePath(diffImagePath) : "",
+    imageDiff,
   };
 }
 

--- a/bun.lock
+++ b/bun.lock
@@ -6,9 +6,11 @@
       "name": "codex-stack",
       "dependencies": {
         "playwright": "^1.53.2",
+        "pngjs": "^7.0.0",
       },
       "devDependencies": {
         "@types/node": "^25.5.0",
+        "@types/pngjs": "^6.0.5",
         "typescript": "^5.9.3",
       },
     },
@@ -16,11 +18,15 @@
   "packages": {
     "@types/node": ["@types/node@25.5.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw=="],
 
+    "@types/pngjs": ["@types/pngjs@6.0.5", "", { "dependencies": { "@types/node": "*" } }, "sha512-0k5eKfrA83JOZPppLtS2C7OUtyNAl2wKNxfyYl9Q5g9lPkgBl/9hNyAu6HuEH2J4XmIv2znEpkDd0SaZVxW6iQ=="],
+
     "fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
 
     "playwright": ["playwright@1.58.2", "", { "dependencies": { "playwright-core": "1.58.2" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A=="],
 
     "playwright-core": ["playwright-core@1.58.2", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg=="],
+
+    "pngjs": ["pngjs@7.0.0", "", {}, "sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow=="],
 
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -216,6 +216,7 @@ Notes:
 
 - By default, every retro run writes `latest.md`, `latest.json`, and timestamped snapshots under `.codex-stack/retros/`.
 - When GitHub data is available, `retro` adds PR throughput, merge time, first-review latency, backlog, and reviewer load metrics.
+- `retro` now also scans published visual-pack manifests under `docs/qa/`, `.codex-stack/qa/`, and `.codex-stack/browse/artifacts/` to rank the highest-regression screenshots.
 - `weekly-digest.ts` also writes publication-ready artifacts under `docs/weekly-digest-publish/`: `summary.txt`, `slack.md`, `slack.json`, `email.md`, and `manifest.json`.
 
 ## Upgrade workflow
@@ -260,7 +261,7 @@ Notes:
 - Local flows live under `.codex-stack/browse/flows/` and override same-named repo flows.
 - Session bundles capture cookies plus origin storage so authenticated QA setups can move between named sessions.
 - `import-browser-cookies` is the local macOS path for Chrome, Arc, Brave, and Edge profiles when you need to bootstrap an authenticated session without replaying login flows manually.
-- `compare-snapshot` creates a portable visual pack with baseline/current screenshots, annotation SVG, manifest JSON, and an HTML index page.
+- `compare-snapshot` creates a portable visual pack with baseline/current screenshots, diff heatmap, image-diff score, annotation SVG, manifest JSON, and an HTML index page.
 - `upload`, `dialog`, and the expanded assertion set are available both as direct commands and as flow actions.
 - `wait` supports `load:<state>` plus `state:<visible|hidden|attached|detached>:<selector>` for richer synchronization.
 - Selector arguments accept semantic prefixes as well as CSS: `role:<role>[:<name>]`, `label:<text>`, `placeholder:<text>`, `text:<text>`, and `testid:<value>`.

--- a/package.json
+++ b/package.json
@@ -36,10 +36,12 @@
     "browse:screenshot": "bun browse/src/cli.ts screenshot"
   },
   "dependencies": {
-    "playwright": "^1.53.2"
+    "playwright": "^1.53.2",
+    "pngjs": "^7.0.0"
   },
   "devDependencies": {
     "@types/node": "^25.5.0",
+    "@types/pngjs": "^6.0.5",
     "typescript": "^5.9.3"
   },
   "engines": {

--- a/scripts/browse-snapshot-visual-pack.spec.ts
+++ b/scripts/browse-snapshot-visual-pack.spec.ts
@@ -5,20 +5,30 @@ import os from "node:os";
 import path from "node:path";
 import process from "node:process";
 import { pathToFileURL } from "node:url";
+import { PNG } from "pngjs";
 
 const repoRoot = process.cwd();
 const fixtureRoot = fs.mkdtempSync(path.join(os.tmpdir(), "codex-stack-snapshot-pack-"));
 
 async function main(): Promise<void> {
   process.chdir(fixtureRoot);
-  const png = Buffer.from("iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAusB9Y9l9i8AAAAASUVORK5CYII=", "base64");
+  const makePng = (rgba: [number, number, number, number]): Buffer => {
+    const image = new PNG({ width: 2, height: 2 });
+    for (let index = 0; index < image.data.length; index += 4) {
+      image.data[index] = rgba[0];
+      image.data[index + 1] = rgba[1];
+      image.data[index + 2] = rgba[2];
+      image.data[index + 3] = rgba[3];
+    }
+    return PNG.sync.write(image);
+  };
   const baselineJsonPath = path.join(fixtureRoot, "baseline.json");
   const currentJsonPath = path.join(fixtureRoot, "current.json");
   const baselineScreenshotPath = path.join(fixtureRoot, "baseline.png");
   const currentScreenshotPath = path.join(fixtureRoot, "current.png");
 
-  fs.writeFileSync(baselineScreenshotPath, png);
-  fs.writeFileSync(currentScreenshotPath, png);
+  fs.writeFileSync(baselineScreenshotPath, makePng([10, 20, 30, 255]));
+  fs.writeFileSync(currentScreenshotPath, makePng([40, 50, 60, 255]));
   fs.writeFileSync(baselineJsonPath, JSON.stringify({
     name: "landing-home",
     title: "Landing",
@@ -51,25 +61,34 @@ async function main(): Promise<void> {
     index: string;
     manifest: string;
     annotation?: string;
+    imageDiff?: { score?: number };
   };
 
   assert.ok(fs.existsSync(path.join(fixtureRoot, visualPack.index)));
   assert.ok(fs.existsSync(path.join(fixtureRoot, visualPack.manifest)));
   assert.ok(fs.existsSync(path.join(fixtureRoot, visualPack.dir, "baseline.png")));
   assert.ok(fs.existsSync(path.join(fixtureRoot, visualPack.dir, "current.png")));
+  assert.ok(fs.existsSync(path.join(fixtureRoot, visualPack.dir, "diff.png")));
   assert.ok(fs.existsSync(path.join(fixtureRoot, visualPack.annotation || "")));
 
   const manifest = JSON.parse(fs.readFileSync(path.join(fixtureRoot, visualPack.manifest), "utf8")) as {
     assets?: Record<string, string>;
     summary?: Record<string, number | boolean>;
+    imageDiff?: { score?: number; diffRatio?: number; changedPixels?: number };
   };
   const html = fs.readFileSync(path.join(fixtureRoot, visualPack.index), "utf8");
 
   assert.equal(manifest.assets?.baselineScreenshot, "baseline.png");
   assert.equal(manifest.assets?.currentScreenshot, "current.png");
   assert.equal(manifest.assets?.annotation, "annotation.svg");
+  assert.equal(manifest.assets?.diffImage, "diff.png");
   assert.equal(manifest.summary?.missingSelectors, 1);
+  assert.equal(typeof manifest.imageDiff?.score, "number");
+  assert.equal(typeof visualPack.imageDiff?.score, "number");
+  assert.ok((manifest.imageDiff?.changedPixels || 0) > 0);
   assert.match(html, /Snapshot visual pack/);
+  assert.match(html, /Image diff score/);
+  assert.match(html, /Diff heatmap/);
   assert.match(html, /Manifest JSON/);
   assert.match(html, /baseline\.png/);
   assert.match(html, /current\.png/);

--- a/scripts/ci-check.sh
+++ b/scripts/ci-check.sh
@@ -98,6 +98,7 @@ run_ts scripts/cleanup-preview-site.spec.ts >/tmp/codex-stack-preview-cleanup-sp
 run_ts scripts/preview-workflow-auth.spec.ts >/tmp/codex-stack-preview-workflow-auth-spec.log
 run_ts scripts/ship-branch.ts --help >/tmp/codex-stack-ship-help.log
 run_ts scripts/retro-report.ts --help >/tmp/codex-stack-retro-help.log
+run_ts scripts/retro-report.spec.ts >/tmp/codex-stack-retro-spec.log
 run_ts scripts/upgrade-check.ts --offline --json >/tmp/codex-stack-upgrade.json
 run_ts scripts/upgrade-check.spec.ts >/tmp/codex-stack-upgrade-spec.log
 run_ts scripts/preview-verify.spec.ts >/tmp/codex-stack-preview-spec.log

--- a/scripts/deploy-verify.spec.ts
+++ b/scripts/deploy-verify.spec.ts
@@ -32,10 +32,11 @@ async function main(): Promise<void> {
   fs.writeFileSync(pageScreenshotB, png);
   fs.mkdirSync(visualDir, { recursive: true });
   fs.writeFileSync(path.join(visualDir, "index.html"), "<html><body>visual pack</body></html>");
-  fs.writeFileSync(path.join(visualDir, "manifest.json"), JSON.stringify({ status: "changed" }, null, 2));
+  fs.writeFileSync(path.join(visualDir, "manifest.json"), JSON.stringify({ status: "changed", imageDiff: { score: 68.2, diffRatio: 0.318 } }, null, 2));
   fs.writeFileSync(path.join(visualDir, "annotation.svg"), "<svg xmlns=\"http://www.w3.org/2000/svg\"></svg>");
   fs.writeFileSync(path.join(visualDir, "baseline.png"), png);
   fs.writeFileSync(path.join(visualDir, "current.png"), png);
+  fs.writeFileSync(path.join(visualDir, "diff.png"), png);
   fs.writeFileSync(sessionBundlePath, JSON.stringify({
     version: 1,
     exportedAt: new Date().toISOString(),
@@ -106,6 +107,16 @@ async function main(): Promise<void> {
           index: path.join(visualDir, "index.html"),
           manifest: path.join(visualDir, "manifest.json"),
           annotation: path.join(visualDir, "annotation.svg"),
+          diffImage: path.join(visualDir, "diff.png"),
+          imageDiff: {
+            score: 68.2,
+            diffRatio: 0.318,
+            changedPixels: 11,
+            comparedPixels: 16,
+            dimensionsMatch: true,
+            baseline: { width: 1, height: 1 },
+            current: { width: 1, height: 1 },
+          },
         },
         comparison: {
           missingSelectors: ["h1"],
@@ -212,6 +223,11 @@ async function main(): Promise<void> {
   assert.ok(report.screenshotManifest);
   assert.ok(String(report.visualPack?.index).includes("visual/index.html"));
   assert.ok(String(report.visualPack?.manifest).includes("visual/manifest.json"));
+  const visualManifest = JSON.parse(fs.readFileSync(path.join(publishDir, "visual", "manifest.json"), "utf8")) as {
+    snapshots?: Array<{ imageDiffScore?: number; diffImage?: string }>;
+  };
+  assert.ok(visualManifest.snapshots?.some((entry) => entry.imageDiffScore === 68.2));
+  assert.ok(visualManifest.snapshots?.some((entry) => String(entry.diffImage).includes("diff.png")));
 
   assert.ok(fs.existsSync(markdownOut));
   assert.ok(fs.existsSync(jsonOut));
@@ -224,6 +240,7 @@ async function main(): Promise<void> {
   assert.ok(fs.existsSync(path.join(publishDir, "visual", "manifest.json")));
   const visualSnapshotDirs = fs.readdirSync(path.join(publishDir, "visual", "snapshots"));
   assert.ok(visualSnapshotDirs.some((entry) => fs.existsSync(path.join(publishDir, "visual", "snapshots", entry, "index.html"))));
+  assert.ok(visualSnapshotDirs.some((entry) => fs.existsSync(path.join(publishDir, "visual", "snapshots", entry, "diff.png"))));
   assert.ok(fs.existsSync(path.join(publishDir, "screenshots", "root-desktop.png")));
   assert.ok(fs.existsSync(path.join(publishDir, "screenshots", "dashboard-mobile.png")));
 

--- a/scripts/deploy-verify.ts
+++ b/scripts/deploy-verify.ts
@@ -108,6 +108,16 @@ interface VisualPackRef {
   currentJson?: string;
   baselineScreenshot?: string;
   currentScreenshot?: string;
+  diffImage?: string;
+  imageDiff?: {
+    comparedPixels: number;
+    changedPixels: number;
+    diffRatio: number;
+    score: number;
+    dimensionsMatch: boolean;
+    baseline: { width: number; height: number };
+    current: { width: number; height: number };
+  } | null;
 }
 
 interface QaPublishedArtifacts {
@@ -649,9 +659,10 @@ function renderDeployVisualIndex(manifest: {
       <article class="card">
         <h2>${escapeHtml(String(item.name || "snapshot"))}</h2>
         <p>Status: <strong>${escapeHtml(item.status || "unknown")}</strong> • ${escapeHtml(`${item.targetPath || "/"} @ ${item.device || "desktop"}`)}</p>
+        ${typeof item.imageDiffScore === "number" ? `<p>Image diff score: <strong>${escapeHtml(item.imageDiffScore)}</strong> • ratio ${escapeHtml(item.imageDiffRatio ?? "n/a")}</p>` : ""}
         ${item.index ? `<p><a href="${escapeHtml(String(item.index))}">Open visual pack</a></p>` : ""}
         ${item.manifest ? `<p><a href="${escapeHtml(String(item.manifest))}">Manifest JSON</a></p>` : ""}
-        ${item.annotation ? `<object data="${escapeHtml(String(item.annotation))}" type="image/svg+xml" aria-label="Snapshot annotation"></object>` : item.screenshot ? `<img src="${escapeHtml(String(item.screenshot))}" alt="${escapeHtml(String(item.name || "snapshot"))}">` : "<p>No visual evidence recorded.</p>"}
+        ${item.diffImage ? `<img src="${escapeHtml(String(item.diffImage))}" alt="${escapeHtml(String(item.name || "snapshot"))} diff heatmap">` : item.annotation ? `<object data="${escapeHtml(String(item.annotation))}" type="image/svg+xml" aria-label="Snapshot annotation"></object>` : item.screenshot ? `<img src="${escapeHtml(String(item.screenshot))}" alt="${escapeHtml(String(item.name || "snapshot"))}">` : "<p>No visual evidence recorded.</p>"}
       </article>
     `).join("\n")
     : "<p>No snapshot visual packs recorded.</p>";
@@ -1192,6 +1203,7 @@ function renderSnapshotLines(snapshotResults: DeploySnapshotResult[]): string[] 
     const refs = [
       `${item.name} @ ${item.targetPath} (${item.device})`,
       `status=${item.status}`,
+      item.visualPack?.imageDiff ? `imageScore=${item.visualPack.imageDiff.score}` : "",
       item.report ? `report=${item.report}` : "",
       item.annotation ? `annotation=${item.annotation}` : "",
       item.screenshot ? `screenshot=${item.screenshot}` : "",
@@ -1330,6 +1342,7 @@ function writeVisualPack({
     }
     const copiedAnnotation = entry.annotation ? copyFileIfPresent(entry.annotation, path.join(targetDir, "annotation.svg")) : "";
     const copiedScreenshot = entry.screenshot ? copyFileIfPresent(entry.screenshot, path.join(targetDir, "screenshot.png")) : "";
+    const copiedDiff = entry.visualPack?.diffImage ? copyFileIfPresent(entry.visualPack.diffImage, path.join(targetDir, "diff.png")) : "";
     const indexPath = path.join(targetDir, "index.html");
     const manifestPath = path.join(targetDir, "manifest.json");
     return {
@@ -1341,6 +1354,9 @@ function writeVisualPack({
       manifest: fs.existsSync(manifestPath) ? relFrom(visualDir, manifestPath) : "",
       annotation: copiedAnnotation ? relFrom(visualDir, path.resolve(process.cwd(), copiedAnnotation)) : (fs.existsSync(path.join(targetDir, "annotation.svg")) ? relFrom(visualDir, path.join(targetDir, "annotation.svg")) : ""),
       screenshot: copiedScreenshot ? relFrom(visualDir, path.resolve(process.cwd(), copiedScreenshot)) : (fs.existsSync(path.join(targetDir, "current.png")) ? relFrom(visualDir, path.join(targetDir, "current.png")) : ""),
+      diffImage: copiedDiff ? relFrom(visualDir, path.resolve(process.cwd(), copiedDiff)) : (fs.existsSync(path.join(targetDir, "diff.png")) ? relFrom(visualDir, path.join(targetDir, "diff.png")) : ""),
+      imageDiffScore: entry.visualPack?.imageDiff?.score ?? null,
+      imageDiffRatio: entry.visualPack?.imageDiff?.diffRatio ?? null,
     };
   });
 

--- a/scripts/preview-verify.spec.ts
+++ b/scripts/preview-verify.spec.ts
@@ -30,10 +30,11 @@ async function main(): Promise<void> {
   fs.writeFileSync(pageScreenshot, png);
   fs.mkdirSync(visualDir, { recursive: true });
   fs.writeFileSync(path.join(visualDir, "index.html"), "<html><body>visual pack</body></html>");
-  fs.writeFileSync(path.join(visualDir, "manifest.json"), JSON.stringify({ status: "changed" }, null, 2));
+  fs.writeFileSync(path.join(visualDir, "manifest.json"), JSON.stringify({ status: "changed", imageDiff: { score: 81.1, diffRatio: 0.189 } }, null, 2));
   fs.writeFileSync(path.join(visualDir, "annotation.svg"), "<svg xmlns=\"http://www.w3.org/2000/svg\"></svg>");
   fs.writeFileSync(path.join(visualDir, "baseline.png"), png);
   fs.writeFileSync(path.join(visualDir, "current.png"), png);
+  fs.writeFileSync(path.join(visualDir, "diff.png"), png);
   fs.writeFileSync(sessionBundlePath, JSON.stringify({
     version: 1,
     exportedAt: new Date().toISOString(),
@@ -92,6 +93,16 @@ async function main(): Promise<void> {
           index: path.join(visualDir, "index.html"),
           manifest: path.join(visualDir, "manifest.json"),
           annotation: path.join(visualDir, "annotation.svg"),
+          diffImage: path.join(visualDir, "diff.png"),
+          imageDiff: {
+            score: 81.1,
+            diffRatio: 0.189,
+            changedPixels: 8,
+            comparedPixels: 16,
+            dimensionsMatch: true,
+            baseline: { width: 1, height: 1 },
+            current: { width: 1, height: 1 },
+          },
         },
         comparison: {
           missingSelectors: ["h1"],
@@ -197,6 +208,7 @@ async function main(): Promise<void> {
   assert.match(markdown, /## Deploy checks/);
   assert.match(markdown, /root-desktop\.png/);
   assert.match(markdown, /Visual pack/);
+  assert.match(markdown, /visual\/manifest\.json/);
   assert.match(comment, /Expected UI selectors are missing/);
 
   console.log("preview-verify spec passed");

--- a/scripts/qa-run.spec.ts
+++ b/scripts/qa-run.spec.ts
@@ -83,8 +83,9 @@ const importMarker = path.join(fixtureRoot, "imported-session.json");
   );
   fs.mkdirSync(visualDir, { recursive: true });
   fs.writeFileSync(path.join(visualDir, "index.html"), "<html><body>visual pack</body></html>");
-  fs.writeFileSync(path.join(visualDir, "manifest.json"), JSON.stringify({ status: "changed" }, null, 2));
+  fs.writeFileSync(path.join(visualDir, "manifest.json"), JSON.stringify({ status: "changed", imageDiff: { score: 72.4, diffRatio: 0.276, changedPixels: 12 } }, null, 2));
   fs.writeFileSync(path.join(visualDir, "annotation.svg"), "<svg xmlns=\"http://www.w3.org/2000/svg\"></svg>");
+  fs.writeFileSync(path.join(visualDir, "diff.png"), fs.readFileSync(screenshotPath));
 
   fs.writeFileSync(
     path.join(browseDir, "cli.ts"),
@@ -111,7 +112,9 @@ if (command === "compare-snapshot") {
       dir: ${JSON.stringify(visualDir)},
       index: ${JSON.stringify(path.join(visualDir, "index.html"))},
       manifest: ${JSON.stringify(path.join(visualDir, "manifest.json"))},
-      annotation: ${JSON.stringify(path.join(visualDir, "annotation.svg"))}
+      annotation: ${JSON.stringify(path.join(visualDir, "annotation.svg"))},
+      diffImage: ${JSON.stringify(path.join(visualDir, "diff.png"))},
+      imageDiff: { score: 72.4, diffRatio: 0.276, changedPixels: 12, comparedPixels: 16, dimensionsMatch: true, baseline: { width: 1, height: 1 }, current: { width: 1, height: 1 } }
     },
     comparison: {
       missingSelectors: ["h1"],
@@ -152,7 +155,7 @@ process.exit(1);
     status?: string;
     healthScore?: number;
     flowResults?: Array<{ name?: string; status?: string; steps?: number }>;
-    snapshotResult?: { name?: string; status?: string; annotation?: string; screenshot?: string; visualPack?: { index?: string; manifest?: string } | null };
+    snapshotResult?: { name?: string; status?: string; annotation?: string; screenshot?: string; visualPack?: { index?: string; manifest?: string; diffImage?: string; imageDiff?: { score?: number } } | null };
     findings?: Array<{ severity?: string; category?: string; title?: string; evidence?: { annotation?: string } }>;
     artifacts?: { annotation?: string; visualPack?: { index?: string; manifest?: string } | null };
   };
@@ -168,6 +171,8 @@ process.exit(1);
   assert.ok(String(report.snapshotResult?.screenshot).includes("screenshot.png"));
   assert.ok(String(report.snapshotResult?.visualPack?.index).includes("visual/index.html"));
   assert.ok(String(report.snapshotResult?.visualPack?.manifest).includes("visual/manifest.json"));
+  assert.ok(String(report.snapshotResult?.visualPack?.diffImage).includes("visual/diff.png"));
+  assert.equal(report.snapshotResult?.visualPack?.imageDiff?.score, 72.4);
   assert.ok(report.findings?.some((item) => item.severity === "critical" && item.category === "visual" && item.title === "Expected UI selectors are missing"));
   assert.ok(report.findings?.some((item) => item.severity === "medium" && item.category === "visual" && item.title === "Snapshot drift detected"));
   assert.ok(report.findings?.some((item) => item.evidence?.annotation));

--- a/scripts/qa-run.ts
+++ b/scripts/qa-run.ts
@@ -67,6 +67,16 @@ interface VisualPackRef {
   currentJson?: string;
   baselineScreenshot?: string;
   currentScreenshot?: string;
+  diffImage?: string;
+  imageDiff?: {
+    comparedPixels: number;
+    changedPixels: number;
+    diffRatio: number;
+    score: number;
+    dimensionsMatch: boolean;
+    baseline: { width: number; height: number };
+    current: { width: number; height: number };
+  } | null;
 }
 
 interface SnapshotCommandResult {
@@ -393,6 +403,22 @@ function asVisualPackRef(value: unknown): VisualPackRef | undefined {
     currentJson: asString(obj.currentJson),
     baselineScreenshot: asString(obj.baselineScreenshot),
     currentScreenshot: asString(obj.currentScreenshot),
+    diffImage: asString(obj.diffImage),
+    imageDiff: asObject(obj.imageDiff) ? {
+      comparedPixels: asNumber(asObject(obj.imageDiff)?.comparedPixels),
+      changedPixels: asNumber(asObject(obj.imageDiff)?.changedPixels),
+      diffRatio: asNumber(asObject(obj.imageDiff)?.diffRatio),
+      score: asNumber(asObject(obj.imageDiff)?.score),
+      dimensionsMatch: Boolean(asObject(obj.imageDiff)?.dimensionsMatch),
+      baseline: {
+        width: asNumber(asObject(asObject(obj.imageDiff)?.baseline)?.width),
+        height: asNumber(asObject(asObject(obj.imageDiff)?.baseline)?.height),
+      },
+      current: {
+        width: asNumber(asObject(asObject(obj.imageDiff)?.current)?.width),
+        height: asNumber(asObject(asObject(obj.imageDiff)?.current)?.height),
+      },
+    } : null,
   };
 }
 
@@ -558,6 +584,7 @@ function buildMarkdown(report: QaReport): string {
         report.snapshotResult.annotation ? `- Annotation: ${report.snapshotResult.annotation}` : "",
         report.snapshotResult.visualPack?.index ? `- Visual pack: ${report.snapshotResult.visualPack.index}` : "",
         report.snapshotResult.visualPack?.manifest ? `- Visual manifest: ${report.snapshotResult.visualPack.manifest}` : "",
+        report.snapshotResult.visualPack?.imageDiff ? `- Image diff score: ${report.snapshotResult.visualPack.imageDiff.score}` : "",
       ]
         .filter(Boolean)
         .join("\n")
@@ -1059,6 +1086,9 @@ function attachSnapshotAnnotation(report: QaReport, snapshotEvidence: SnapshotEv
       if (report.snapshotResult?.visualPack?.index) {
         item.evidence.visualPack = report.snapshotResult.visualPack.index;
       }
+      if (report.snapshotResult?.visualPack?.diffImage) {
+        item.evidence.diffImage = report.snapshotResult.visualPack.diffImage;
+      }
     }
   }
   report.artifacts.annotation = artifact.annotation;
@@ -1104,6 +1134,7 @@ function rewriteEvidencePaths(report: QaReport, pathMap: Record<string, string>)
       if (report.snapshotResult.visualPack.currentJson && pathMap[report.snapshotResult.visualPack.currentJson]) report.snapshotResult.visualPack.currentJson = pathMap[report.snapshotResult.visualPack.currentJson];
       if (report.snapshotResult.visualPack.baselineScreenshot && pathMap[report.snapshotResult.visualPack.baselineScreenshot]) report.snapshotResult.visualPack.baselineScreenshot = pathMap[report.snapshotResult.visualPack.baselineScreenshot];
       if (report.snapshotResult.visualPack.currentScreenshot && pathMap[report.snapshotResult.visualPack.currentScreenshot]) report.snapshotResult.visualPack.currentScreenshot = pathMap[report.snapshotResult.visualPack.currentScreenshot];
+      if (report.snapshotResult.visualPack.diffImage && pathMap[report.snapshotResult.visualPack.diffImage]) report.snapshotResult.visualPack.diffImage = pathMap[report.snapshotResult.visualPack.diffImage];
     }
   }
 
@@ -1116,6 +1147,7 @@ function rewriteEvidencePaths(report: QaReport, pathMap: Record<string, string>)
     if (report.artifacts.visualPack.currentJson && pathMap[report.artifacts.visualPack.currentJson]) report.artifacts.visualPack.currentJson = pathMap[report.artifacts.visualPack.currentJson];
     if (report.artifacts.visualPack.baselineScreenshot && pathMap[report.artifacts.visualPack.baselineScreenshot]) report.artifacts.visualPack.baselineScreenshot = pathMap[report.artifacts.visualPack.baselineScreenshot];
     if (report.artifacts.visualPack.currentScreenshot && pathMap[report.artifacts.visualPack.currentScreenshot]) report.artifacts.visualPack.currentScreenshot = pathMap[report.artifacts.visualPack.currentScreenshot];
+    if (report.artifacts.visualPack.diffImage && pathMap[report.artifacts.visualPack.diffImage]) report.artifacts.visualPack.diffImage = pathMap[report.artifacts.visualPack.diffImage];
   }
 
   for (const item of report.findings) {
@@ -1165,6 +1197,8 @@ function publishArtifacts(report: QaReport, publishDir: string): QaReport {
       currentJson: fs.existsSync(path.join(visualDir, "current.json")) ? relative(path.join(visualDir, "current.json")) : "",
       baselineScreenshot: fs.existsSync(path.join(visualDir, "baseline.png")) ? relative(path.join(visualDir, "baseline.png")) : "",
       currentScreenshot: fs.existsSync(path.join(visualDir, "current.png")) ? relative(path.join(visualDir, "current.png")) : "",
+      diffImage: fs.existsSync(path.join(visualDir, "diff.png")) ? relative(path.join(visualDir, "diff.png")) : "",
+      imageDiff: sourceVisualPack.imageDiff || null,
     };
     pathMap[sourceVisualPack.dir] = publishedVisualPack.dir;
     pathMap[sourceVisualPack.index] = publishedVisualPack.index;
@@ -1174,6 +1208,7 @@ function publishArtifacts(report: QaReport, publishDir: string): QaReport {
     if (sourceVisualPack.currentJson && publishedVisualPack.currentJson) pathMap[sourceVisualPack.currentJson] = publishedVisualPack.currentJson;
     if (sourceVisualPack.baselineScreenshot && publishedVisualPack.baselineScreenshot) pathMap[sourceVisualPack.baselineScreenshot] = publishedVisualPack.baselineScreenshot;
     if (sourceVisualPack.currentScreenshot && publishedVisualPack.currentScreenshot) pathMap[sourceVisualPack.currentScreenshot] = publishedVisualPack.currentScreenshot;
+    if (sourceVisualPack.diffImage && publishedVisualPack.diffImage) pathMap[sourceVisualPack.diffImage] = publishedVisualPack.diffImage;
   }
 
   rewriteEvidencePaths(published, pathMap);

--- a/scripts/render-pr-review.spec.ts
+++ b/scripts/render-pr-review.spec.ts
@@ -15,6 +15,35 @@ async function main(): Promise<void> {
   const previewPath = path.join(fixtureRoot, "preview.json");
   const markdownOut = path.join(fixtureRoot, "review.md");
   const summaryOut = path.join(fixtureRoot, "summary.json");
+  const visualRoot = path.join(fixtureRoot, "preview-artifacts", "visual");
+  fs.mkdirSync(path.join(visualRoot, "screenshots"), { recursive: true });
+  fs.mkdirSync(path.join(visualRoot, "snapshots", "dashboard-root-desktop"), { recursive: true });
+  fs.writeFileSync(path.join(visualRoot, "manifest.json"), JSON.stringify({
+    screenshots: [
+      {
+        path: "/",
+        device: "desktop",
+        status: "warning",
+        httpStatus: 200,
+        screenshot: "screenshots/root-desktop.png",
+        consoleWarnings: 1,
+        consoleErrors: 0,
+      },
+    ],
+    snapshots: [
+      {
+        name: "dashboard",
+        targetPath: "/",
+        device: "desktop",
+        status: "changed",
+        index: "snapshots/dashboard-root-desktop/index.html",
+        manifest: "snapshots/dashboard-root-desktop/manifest.json",
+        diffImage: "snapshots/dashboard-root-desktop/diff.png",
+        imageDiffScore: 68.2,
+        imageDiffRatio: 0.318,
+      },
+    ],
+  }, null, 2));
 
   fs.writeFileSync(reviewPath, JSON.stringify({
     status: "ok",
@@ -58,7 +87,7 @@ async function main(): Promise<void> {
           screenshot: "preview-artifacts/screenshot.png",
           visualPack: {
             index: "preview-artifacts/visual/index.html",
-            manifest: "preview-artifacts/visual/manifest.json",
+            manifest: path.join(visualRoot, "manifest.json"),
           },
         },
       },
@@ -73,7 +102,7 @@ async function main(): Promise<void> {
       screenshotManifest: "preview-artifacts/screenshots.json",
       visualPack: {
         index: "preview-artifacts/visual/index.html",
-        manifest: "preview-artifacts/visual/manifest.json",
+        manifest: path.join(visualRoot, "manifest.json"),
       },
       pathResults: [
         {
@@ -130,9 +159,11 @@ async function main(): Promise<void> {
   assert.match(stdout, /Preview URL: https:\/\/preview-23\.example\.com/);
   assert.match(stdout, /Workflow run: https:\/\/github\.com\/anup4khandelwal\/codex-stack\/actions\/runs\/123456/);
   assert.match(stdout, /Hosted visual pack: https:\/\/anup4khandelwal\.github\.io\/codex-stack\/pr-preview\/pr-23\/__codex\/visual\/index\.html/);
+  assert.match(stdout, /`changed` `score 68\.2` `ratio 0\.318` dashboard @ \//);
   assert.match(stdout, /CRITICAL\/VISUAL/);
   assert.match(stdout, /annotation\.svg/);
   assert.match(stdout, /### Deploy checks/);
+  assert.match(stdout, /!\[dashboard desktop\]\(https:\/\/anup4khandelwal\.github\.io\/codex-stack\/pr-preview\/pr-23\/__codex\/visual\/snapshots\/dashboard-root-desktop\/diff\.png\)/);
   assert.match(stdout, /consoleWarnings=1/);
   assert.match(stdout, /screenshots\.json/);
   assert.ok(fs.existsSync(markdownOut));

--- a/scripts/render-pr-review.ts
+++ b/scripts/render-pr-review.ts
@@ -96,6 +96,31 @@ interface PreviewReport {
   };
 }
 
+interface LocalVisualManifest {
+  screenshots?: Array<{
+    path?: string;
+    device?: string;
+    status?: string;
+    httpStatus?: number | null;
+    screenshot?: string;
+    consoleErrors?: number;
+    consoleWarnings?: number;
+  }>;
+  snapshots?: Array<{
+    name?: string;
+    targetPath?: string;
+    device?: string;
+    status?: string;
+    index?: string;
+    manifest?: string;
+    annotation?: string;
+    screenshot?: string;
+    diffImage?: string;
+    imageDiffScore?: number | null;
+    imageDiffRatio?: number | null;
+  }>;
+}
+
 interface ReviewSummary {
   status: string;
   branch: string;
@@ -195,6 +220,18 @@ function absoluteLink(root: string, relativePath: string): string {
   return new URL(relativePath.replace(/^\/+/, ""), withTrailingSlash(root)).toString();
 }
 
+function readLocalVisualManifest(preview: PreviewReport | null): LocalVisualManifest | null {
+  const manifestPath = preview?.deploy?.visualPack?.manifest;
+  if (!manifestPath) return null;
+  const resolved = path.resolve(process.cwd(), manifestPath);
+  if (!fs.existsSync(resolved)) return null;
+  try {
+    return JSON.parse(fs.readFileSync(resolved, "utf8")) as LocalVisualManifest;
+  } catch {
+    return null;
+  }
+}
+
 function findingLines(findings: ReviewFinding[]): string[] {
   if (!findings.length) return ["- No findings."];
   return findings.map((item) => {
@@ -242,6 +279,66 @@ function deploySnapshotLines(preview: PreviewReport | null): string[] {
   });
 }
 
+function visualBadgeLines(preview: PreviewReport | null, previewPagesRoot: string): string[] {
+  const manifest = readLocalVisualManifest(preview);
+  if (!manifest) return ["- No hosted visual summary available."];
+  const visualPagesRoot = absoluteLink(previewPagesRoot, "visual/");
+
+  const snapshotLines = (manifest.snapshots || [])
+    .filter((item) => typeof item.imageDiffScore === "number" || item.status)
+    .sort((left, right) => (Number(left.imageDiffScore ?? -1) - Number(right.imageDiffScore ?? -1)))
+    .slice(0, 3)
+    .map((item) => {
+      const hosted = item.index ? absoluteLink(visualPagesRoot, item.index) : "";
+      const badgeBits = [
+        `\`${item.status || "unknown"}\``,
+        typeof item.imageDiffScore === "number" ? `\`score ${item.imageDiffScore}\`` : "",
+        typeof item.imageDiffRatio === "number" ? `\`ratio ${item.imageDiffRatio}\`` : "",
+      ].filter(Boolean).join(" ");
+      return `- ${badgeBits} ${item.name || "snapshot"} @ ${item.targetPath || "/"} (${item.device || "desktop"})${hosted ? ` → ${hosted}` : ""}`;
+    });
+
+  const screenshotLines = (manifest.screenshots || [])
+    .filter((item) => item.status && item.status !== "pass" && item.screenshot)
+    .slice(0, 2)
+    .map((item) => {
+      const hostedScreenshot = absoluteLink(visualPagesRoot, item.screenshot || "");
+      return `- \`${item.status}\` ${item.path || "/"} @ ${item.device || "desktop"}${hostedScreenshot ? ` → ${hostedScreenshot}` : ""}`;
+    });
+
+  return [...snapshotLines, ...screenshotLines].slice(0, 5).length
+    ? [...snapshotLines, ...screenshotLines].slice(0, 5)
+    : ["- No failing visual checks were captured."];
+}
+
+function visualImageEmbeds(preview: PreviewReport | null, previewPagesRoot: string): string[] {
+  const manifest = readLocalVisualManifest(preview);
+  if (!manifest) return [];
+  const visualPagesRoot = absoluteLink(previewPagesRoot, "visual/");
+  const images: string[] = [];
+
+  for (const item of (manifest.snapshots || [])) {
+    const target = item.diffImage || item.screenshot || item.annotation || "";
+    if (!target) continue;
+    const hosted = absoluteLink(visualPagesRoot, target);
+    if (!hosted) continue;
+    images.push(`![${item.name || "snapshot"} ${item.device || "desktop"}](${hosted})`);
+    if (images.length >= 2) break;
+  }
+
+  if (images.length < 2) {
+    for (const item of (manifest.screenshots || [])) {
+      if (item.status === "pass" || !item.screenshot) continue;
+      const hosted = absoluteLink(visualPagesRoot, item.screenshot);
+      if (!hosted) continue;
+      images.push(`![${item.path || "/"} ${item.device || "desktop"}](${hosted})`);
+      if (images.length >= 2) break;
+    }
+  }
+
+  return images;
+}
+
 function renderPreviewSection(preview: PreviewReport | null, summary: ReviewSummary, previewPagesRoot: string): string {
   if (!preview) return "";
   const findings = Array.isArray(preview.qa?.findings) ? preview.qa?.findings : [];
@@ -282,6 +379,12 @@ ${deployCheckLines(preview).join("\n")}
 ### Deploy snapshots
 
 ${deploySnapshotLines(preview).join("\n")}
+
+### Visual summary
+
+${visualBadgeLines(preview, previewPagesRoot).join("\n")}
+
+${visualImageEmbeds(preview, previewPagesRoot).join("\n\n")}
 `;
 }
 

--- a/scripts/retro-report.spec.ts
+++ b/scripts/retro-report.spec.ts
@@ -1,0 +1,93 @@
+#!/usr/bin/env bun
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import process from "node:process";
+import { execFileSync } from "node:child_process";
+
+const rootDir = process.cwd();
+const bun = process.execPath || "bun";
+const fixtureRoot = fs.mkdtempSync(path.join(os.tmpdir(), "codex-stack-retro-"));
+
+async function main(): Promise<void> {
+  const repoDir = path.join(fixtureRoot, "repo");
+  fs.mkdirSync(repoDir, { recursive: true });
+  execFileSync("git", ["init", "-b", "main"], { cwd: repoDir, encoding: "utf8" });
+  execFileSync("git", ["config", "user.email", "spec@example.com"], { cwd: repoDir, encoding: "utf8" });
+  execFileSync("git", ["config", "user.name", "Spec User"], { cwd: repoDir, encoding: "utf8" });
+  fs.writeFileSync(path.join(repoDir, "README.md"), "# demo\n");
+  execFileSync("git", ["add", "README.md"], { cwd: repoDir, encoding: "utf8" });
+  execFileSync("git", ["commit", "-m", "feat: add demo"], { cwd: repoDir, encoding: "utf8" });
+
+  const visualDir = path.join(repoDir, "docs", "qa", "sample", "visual");
+  fs.mkdirSync(visualDir, { recursive: true });
+  fs.writeFileSync(path.join(visualDir, "manifest.json"), JSON.stringify({
+    snapshots: [
+      {
+        name: "dashboard",
+        status: "changed",
+        targetPath: "/dashboard",
+        device: "desktop",
+        imageDiffScore: 71.4,
+        imageDiffRatio: 0.286,
+      },
+      {
+        name: "login",
+        status: "changed",
+        targetPath: "/login",
+        device: "mobile",
+        imageDiffScore: 83.2,
+        imageDiffRatio: 0.168,
+      },
+    ],
+  }, null, 2));
+
+  const markdown = execFileSync(
+    bun,
+    [path.join(rootDir, "scripts", "retro-report.ts"), "--since", "30 days ago", "--no-github"],
+    {
+      cwd: repoDir,
+      encoding: "utf8",
+    },
+  );
+
+  const rawJson = execFileSync(
+    bun,
+    [path.join(rootDir, "scripts", "retro-report.ts"), "--since", "30 days ago", "--no-github", "--json"],
+    {
+      cwd: repoDir,
+      encoding: "utf8",
+    },
+  );
+
+  const summary = JSON.parse(rawJson) as {
+    visual?: {
+      available?: boolean;
+      snapshotCount?: number;
+      failingSnapshotCount?: number;
+      avgImageDiffScore?: number;
+      topRegressions?: Array<{ name?: string; score?: number }>;
+    };
+    recommendation?: string;
+  };
+
+  assert.equal(summary.visual?.available, true);
+  assert.equal(summary.visual?.snapshotCount, 2);
+  assert.equal(summary.visual?.failingSnapshotCount, 2);
+  assert.equal(summary.visual?.avgImageDiffScore, 77.3);
+  assert.equal(summary.visual?.topRegressions?.[0]?.name, "dashboard");
+  assert.match(String(summary.recommendation), /Visual QA surfaced|Delivery looked steady|Low visible throughput/);
+  assert.match(markdown, /## Visual QA evidence/);
+  assert.match(markdown, /dashboard @ \/dashboard/);
+  assert.match(markdown, /Avg image diff score: 77\.3/);
+
+  console.log("retro-report spec passed");
+}
+
+try {
+  await main();
+} finally {
+  process.chdir(rootDir);
+  fs.rmSync(fixtureRoot, { recursive: true, force: true });
+}

--- a/scripts/retro-report.ts
+++ b/scripts/retro-report.ts
@@ -3,6 +3,7 @@ import fs from "node:fs";
 import path from "node:path";
 import process from "node:process";
 import { execSync, type ExecSyncOptionsWithStringEncoding } from "node:child_process";
+import { collectVisualAnalytics, type VisualAnalytics } from "./visual-pack-summary.ts";
 
 interface RunOptions extends Partial<ExecSyncOptionsWithStringEncoding> {
   allowFailure?: boolean;
@@ -74,6 +75,7 @@ interface RetroSummary {
   recentSubjects: RecentSubject[];
   recommendation: string;
   github: GithubAnalytics;
+  visual: VisualAnalytics;
   artifacts: RetroArtifacts | Record<string, never>;
 }
 
@@ -428,6 +430,9 @@ function fetchGithubAnalytics({ repo, since, limit }: { repo: string; since: str
 }
 
 function recommendation(summary: RetroSummary): string {
+  if (summary.visual.available && summary.visual.failingSnapshotCount >= 3 && summary.visual.avgImageDiffScore < 90) {
+    return `Visual QA surfaced ${summary.visual.failingSnapshotCount} regressions with an average image score of ${summary.visual.avgImageDiffScore}. Tighten preview review before shipping more UI work.`;
+  }
   if (summary.github.enabled && (summary.github.pendingReviewCount || 0) >= 3) {
     return `${summary.github.pendingReviewCount || 0} open PRs have been waiting at least 24 hours for a first review. Rebalance reviewer load before opening new work.`;
   }
@@ -482,6 +487,24 @@ function toMarkdown(summary: RetroSummary): string {
 - Status: unavailable (${summary.github.reason})
 `;
 
+  const visualSection = summary.visual.available
+    ? `## Visual QA evidence
+
+- Visual manifests scanned: ${summary.visual.manifestCount}
+- Snapshots scored: ${summary.visual.snapshotCount}
+- Regressions found: ${summary.visual.failingSnapshotCount}
+- Avg image diff score: ${summary.visual.avgImageDiffScore}
+- Avg image diff ratio: ${summary.visual.avgImageDiffRatio}
+
+### Top visual regressions
+
+${summary.visual.topRegressions.length ? summary.visual.topRegressions.map((item) => `- ${item.name} @ ${item.targetPath} (${item.device}) • status=${item.status} • score=${item.score} • ratio=${item.diffRatio}`).join("\n") : "- none"}
+`
+    : `## Visual QA evidence
+
+- Status: no published visual packs found
+`;
+
   return `# Retro Report
 
 - Since: ${summary.since}
@@ -507,7 +530,9 @@ ${areaLines}
 
 ${subjectLines}
 
-${githubSection}`;
+${githubSection}
+
+${visualSection}`;
 }
 
 function writeArtifacts(summary: RetroSummary, markdown: string, artifactDir: string): RetroArtifacts {
@@ -542,6 +567,7 @@ const repo = args.repo || inferGithubRepo();
 const github = args.noGithub
   ? { enabled: false, reason: "disabled", repo }
   : fetchGithubAnalytics({ repo, since: args.since, limit: args.githubLimit });
+const visual = collectVisualAnalytics();
 
 const summary: RetroSummary = {
   since: args.since,
@@ -553,6 +579,7 @@ const summary: RetroSummary = {
   recentSubjects: commits.slice(0, 10).map((commit) => ({ subject: commit.subject, author: commit.author })),
   recommendation: "",
   github,
+  visual,
   artifacts: {},
 };
 summary.recommendation = recommendation(summary);

--- a/scripts/visual-pack-summary.ts
+++ b/scripts/visual-pack-summary.ts
@@ -1,0 +1,131 @@
+#!/usr/bin/env bun
+import fs from "node:fs";
+import path from "node:path";
+import process from "node:process";
+
+export interface VisualSnapshotRegression {
+  name: string;
+  status: string;
+  targetPath: string;
+  device: string;
+  score: number;
+  diffRatio: number;
+  manifestPath: string;
+}
+
+export interface VisualAnalytics {
+  available: boolean;
+  manifestCount: number;
+  snapshotCount: number;
+  failingSnapshotCount: number;
+  avgImageDiffScore: number;
+  avgImageDiffRatio: number;
+  topRegressions: VisualSnapshotRegression[];
+  rootsScanned: string[];
+}
+
+interface SnapshotManifest {
+  name?: string;
+  status?: string;
+  imageDiff?: {
+    score?: number;
+    diffRatio?: number;
+  };
+}
+
+interface DeployVisualManifest {
+  snapshots?: Array<{
+    name?: string;
+    status?: string;
+    targetPath?: string;
+    device?: string;
+    imageDiffScore?: number | null;
+    imageDiffRatio?: number | null;
+  }>;
+}
+
+function round(value: number): number {
+  return Number.isFinite(value) ? Math.round(value * 10) / 10 : 0;
+}
+
+function cleanSubject(value: unknown): string {
+  return String(value || "").replace(/\s+/g, " ").trim();
+}
+
+function walk(dirPath: string, out: string[]): void {
+  if (!fs.existsSync(dirPath)) return;
+  for (const entry of fs.readdirSync(dirPath, { withFileTypes: true })) {
+    const target = path.join(dirPath, entry.name);
+    if (entry.isDirectory()) walk(target, out);
+    else if (entry.isFile() && entry.name === "manifest.json") out.push(target);
+  }
+}
+
+export function collectVisualAnalytics(roots = [
+  path.resolve(process.cwd(), "docs", "qa"),
+  path.resolve(process.cwd(), ".codex-stack", "qa"),
+  path.resolve(process.cwd(), ".codex-stack", "browse", "artifacts"),
+]): VisualAnalytics {
+  const manifests: string[] = [];
+  for (const root of roots) {
+    walk(root, manifests);
+  }
+
+  const regressions: VisualSnapshotRegression[] = [];
+
+  for (const manifestPath of manifests) {
+    let parsed: SnapshotManifest | DeployVisualManifest | null = null;
+    try {
+      parsed = JSON.parse(fs.readFileSync(manifestPath, "utf8")) as SnapshotManifest | DeployVisualManifest;
+    } catch {
+      parsed = null;
+    }
+    if (!parsed) continue;
+
+    if (Array.isArray((parsed as DeployVisualManifest).snapshots)) {
+      for (const item of (parsed as DeployVisualManifest).snapshots || []) {
+        if (typeof item?.imageDiffScore !== "number") continue;
+        regressions.push({
+          name: cleanSubject(item.name || "snapshot"),
+          status: cleanSubject(item.status || "unknown"),
+          targetPath: cleanSubject(item.targetPath || "/"),
+          device: cleanSubject(item.device || "desktop"),
+          score: Number(item.imageDiffScore || 0),
+          diffRatio: Number(item.imageDiffRatio || 0),
+          manifestPath: path.relative(process.cwd(), manifestPath),
+        });
+      }
+      continue;
+    }
+
+    if (manifestPath.includes(`${path.sep}visual${path.sep}snapshots${path.sep}`)) {
+      continue;
+    }
+
+    const snapshot = parsed as SnapshotManifest;
+    if (typeof snapshot.imageDiff?.score !== "number") continue;
+    regressions.push({
+      name: cleanSubject(snapshot.name || "snapshot"),
+      status: cleanSubject(snapshot.status || "unknown"),
+      targetPath: "/",
+      device: "desktop",
+      score: Number(snapshot.imageDiff.score || 0),
+      diffRatio: Number(snapshot.imageDiff.diffRatio || 0),
+      manifestPath: path.relative(process.cwd(), manifestPath),
+    });
+  }
+
+  const scored = regressions.filter((item) => Number.isFinite(item.score));
+  return {
+    available: scored.length > 0,
+    manifestCount: manifests.length,
+    snapshotCount: scored.length,
+    failingSnapshotCount: scored.filter((item) => item.status !== "match" && item.status !== "pass").length,
+    avgImageDiffScore: scored.length ? round(scored.reduce((sum, item) => sum + item.score, 0) / scored.length) : 0,
+    avgImageDiffRatio: scored.length ? round(scored.reduce((sum, item) => sum + item.diffRatio, 0) / scored.length) : 0,
+    topRegressions: [...scored]
+      .sort((left, right) => left.score - right.score || right.diffRatio - left.diffRatio || left.name.localeCompare(right.name))
+      .slice(0, 5),
+    rootsScanned: roots.map((item) => path.relative(process.cwd(), item)),
+  };
+}

--- a/scripts/weekly-digest.spec.ts
+++ b/scripts/weekly-digest.spec.ts
@@ -29,6 +29,18 @@ console.log(JSON.stringify({
   topAuthors: [{ name: "anup", count: 7 }, { name: "codex", count: 5 }],
   recentSubjects: [{ subject: "feat: improve preview flow" }, { subject: "fix: tighten issue-flow quoting" }],
   recommendation: "Keep shipping. Review latency is under control.",
+  visual: {
+    available: true,
+    manifestCount: 2,
+    snapshotCount: 3,
+    failingSnapshotCount: 2,
+    avgImageDiffScore: 81.4,
+    avgImageDiffRatio: 0.186,
+    topRegressions: [
+      { name: "dashboard", status: "changed", targetPath: "/dashboard", device: "desktop", score: 71.4, diffRatio: 0.286 },
+      { name: "login", status: "changed", targetPath: "/login", device: "mobile", score: 83.2, diffRatio: 0.168 }
+    ]
+  },
   github: {
     enabled: true,
     reason: "",
@@ -67,15 +79,18 @@ console.log(JSON.stringify({
   assert.match(markdown, /Weekly Digest/);
   assert.match(markdown, /Repo: anup4khandelwal\/codex-stack/);
   assert.match(markdown, /Recommendation: Keep shipping/);
+  assert.match(markdown, /## Visual QA/);
+  assert.match(markdown, /Avg image diff score: 81\.4/);
 
   const report = JSON.parse(fs.readFileSync(jsonOut, "utf8")) as {
     repo?: string;
-    retro?: { commitCount?: number; recommendation?: string };
+    retro?: { commitCount?: number; recommendation?: string; visual?: { snapshotCount?: number } };
     publish?: { enabled?: boolean; targets?: Record<string, string> };
   };
   assert.equal(report.repo, "anup4khandelwal/codex-stack");
   assert.equal(report.retro?.commitCount, 12);
   assert.equal(report.retro?.recommendation, "Keep shipping. Review latency is under control.");
+  assert.equal(report.retro?.visual?.snapshotCount, 3);
   assert.equal(report.publish?.enabled, true);
   assert.ok(String(report.publish?.targets?.summary).endsWith(path.join("publish", "summary.txt")));
   assert.ok(String(report.publish?.targets?.slackJson).endsWith(path.join("publish", "slack.json")));
@@ -93,9 +108,12 @@ console.log(JSON.stringify({
 
   assert.match(summary, /Weekly digest for anup4khandelwal\/codex-stack/);
   assert.match(summary, /PR health: 5 PRs scanned/);
+  assert.match(summary, /Visual QA: 2 regressions across 3 scored snapshots, avg score 81\.4\./);
   assert.match(String(slackJson.text), /Weekly digest for anup4khandelwal\/codex-stack/);
   assert.equal(slackJson.blocks?.[0]?.type, "header");
+  assert.equal(slackJson.blocks?.[4]?.type, "section");
   assert.match(email, /Weekly Engineering Digest/);
+  assert.match(email, /## Visual QA/);
   assert.equal(manifest.repo, "anup4khandelwal/codex-stack");
   assert.ok(String(manifest.outputs?.markdown).endsWith("digest.md"));
   assert.ok(String(manifest.outputs?.manifest).endsWith(path.join("publish", "manifest.json")));

--- a/scripts/weekly-digest.ts
+++ b/scripts/weekly-digest.ts
@@ -42,6 +42,25 @@ interface GithubAnalytics {
   topReviewers?: CountEntry[];
 }
 
+interface VisualRegression {
+  name: string;
+  status: string;
+  targetPath: string;
+  device: string;
+  score: number;
+  diffRatio: number;
+}
+
+interface VisualAnalytics {
+  available: boolean;
+  manifestCount: number;
+  snapshotCount: number;
+  failingSnapshotCount: number;
+  avgImageDiffScore: number;
+  avgImageDiffRatio: number;
+  topRegressions: VisualRegression[];
+}
+
 interface RetroSummary {
   since: string;
   commitCount: number;
@@ -52,6 +71,7 @@ interface RetroSummary {
   recentSubjects: RecentSubject[];
   recommendation: string;
   github: GithubAnalytics;
+  visual: VisualAnalytics;
 }
 
 interface PublishTargets {
@@ -249,6 +269,18 @@ ${prHealthLines(retro).join("\n")}
 ## Reviewer load
 
 ${bullets(retro.github.topReviewers || [], "No reviewer data available.", (item) => `${item.name}: ${item.count} reviews`)}
+
+## Visual QA
+
+${retro.visual.available ? [
+  `- Visual manifests scanned: ${retro.visual.manifestCount}`,
+  `- Snapshots scored: ${retro.visual.snapshotCount}`,
+  `- Regressions found: ${retro.visual.failingSnapshotCount}`,
+  `- Avg image diff score: ${retro.visual.avgImageDiffScore}`,
+  `- Avg image diff ratio: ${retro.visual.avgImageDiffRatio}`,
+].join("\n") : "- No published visual packs found."}
+
+${bullets(retro.visual.topRegressions || [], "No ranked visual regressions.", (item) => `${item.name} @ ${item.targetPath} (${item.device}) • ${item.status} • score ${item.score} • ratio ${item.diffRatio}`)}
 `;
 }
 
@@ -269,6 +301,15 @@ function buildSummaryText(retro: RetroSummary): string {
     );
   } else {
     lines.push(`PR health: GitHub analytics disabled (${retro.github.reason || "unavailable"}).`);
+  }
+
+  if (retro.visual.available) {
+    lines.push(
+      `Visual QA: ${retro.visual.failingSnapshotCount} regressions across ${retro.visual.snapshotCount} scored snapshots, avg score ${retro.visual.avgImageDiffScore}.`,
+      `Top visual regressions: ${topNames(retro.visual.topRegressions || [], "none", (item) => `${item.name} (${item.score})`)}`
+    );
+  } else {
+    lines.push("Visual QA: no published visual packs found.");
   }
 
   return `${lines.join("\n")}\n`;
@@ -293,6 +334,15 @@ function buildSlackMarkdown(retro: RetroSummary): string {
     parts.push(`*PR health*: GitHub analytics disabled (${retro.github.reason || "unavailable"})`);
   }
 
+  if (retro.visual.available) {
+    parts.push(
+      `*Visual QA*: ${retro.visual.failingSnapshotCount} regressions, avg score ${retro.visual.avgImageDiffScore}`,
+      `*Top visual regressions*: ${topNames(retro.visual.topRegressions || [], "none", (item) => `${item.name} (${item.score})`)}`
+    );
+  } else {
+    parts.push("*Visual QA*: no published visual packs found");
+  }
+
   return `${parts.join("\n")}\n`;
 }
 
@@ -300,6 +350,9 @@ function buildSlackPayload(retro: RetroSummary, generatedAt: string): SlackPaylo
   const health = retro.github.enabled
     ? `${retro.github.scannedCount || 0} PRs scanned | ${retro.github.avgTimeToMergeHours || 0}h merge | ${retro.github.avgFirstReviewLatencyHours || 0}h first review | backlog ${retro.github.pendingReviewCount || 0}`
     : `GitHub analytics disabled (${retro.github.reason || "unavailable"})`;
+  const visual = retro.visual.available
+    ? `${retro.visual.failingSnapshotCount} regressions | avg score ${retro.visual.avgImageDiffScore} | top ${topNames(retro.visual.topRegressions || [], "none", (item) => `${item.name} (${item.score})`, 2)}`
+    : "No published visual packs found";
 
   return {
     text: `Weekly digest for ${repoLabel(retro)}: ${retro.recommendation}`,
@@ -343,6 +396,13 @@ function buildSlackPayload(retro: RetroSummary, generatedAt: string): SlackPaylo
           text: `*PR health*\n${health}`,
         },
       },
+      {
+        type: "section",
+        text: {
+          type: "mrkdwn",
+          text: `*Visual QA*\n${visual}`,
+        },
+      },
     ],
   };
 }
@@ -380,6 +440,17 @@ ${prHealthLines(retro).join("\n")}
 ## Reviewer load
 
 ${bullets(retro.github.topReviewers || [], "No reviewer data available.", (item) => `${item.name}: ${item.count} reviews`)}
+
+## Visual QA
+
+${retro.visual.available ? [
+  `- Visual manifests scanned: ${retro.visual.manifestCount}`,
+  `- Snapshots scored: ${retro.visual.snapshotCount}`,
+  `- Regressions found: ${retro.visual.failingSnapshotCount}`,
+  `- Avg image diff score: ${retro.visual.avgImageDiffScore}`,
+].join("\n") : "- No published visual packs found."}
+
+${bullets(retro.visual.topRegressions || [], "No ranked visual regressions.", (item) => `${item.name} @ ${item.targetPath} (${item.device}) • ${item.status} • score ${item.score} • ratio ${item.diffRatio}`)}
 `;
 }
 


### PR DESCRIPTION
## Summary
- add image-diff scoring and diff heatmaps to snapshot visual packs
- surface hosted visual badges and inline screenshots in PR review comments
- aggregate published visual regression evidence into retro and weekly digest outputs

## Validation
- bun run typecheck
- bun run smoke
- bun scripts/browse-snapshot-visual-pack.spec.ts
- bun scripts/render-pr-review.spec.ts
- bun scripts/retro-report.spec.ts
- bun scripts/weekly-digest.spec.ts
