### PR TITLE
feat: add visual risk scoring and baseline history

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,10 +49,10 @@ Use the repo in this order:
 - Portable session import/export with cookie and storage-state bundles
 - Checked-in and local browser flows with import/export for JSON, YAML, and Markdown
 - Page snapshots and snapshot comparison artifacts with self-contained visual packs, diff heatmaps, and image-diff scores
-- QA reports with typed categories, severity, health score, diff-aware route inference, saved evidence, annotated screenshots, and published visual packs for snapshot failures
+- QA reports with typed categories, severity, health score, diff-aware route inference, stale-baseline detection, visual-risk scoring, saved evidence, annotated screenshots, and published visual packs for snapshot failures
 - Historical QA trend artifacts under `.codex-stack/qa/trends.json` and `.codex-stack/qa/trends.md`
 - Preview verification with URL template resolution, readiness polling, deploy/page verification, QA execution, and PR comment output for preview deployments
-- Deploy verification with page and device matrices, screenshot manifests, console capture, tracked evidence, and `visual/index.html` review packs with ranked regressions
+- Deploy verification with page and device matrices, screenshot manifests, console capture, tracked evidence, and `visual/index.html` review packs with ranked regressions plus a consolidated visual-risk score
 - Shipping automation with PR body generation, labels, reviewers, assignees, projects, and optional deploy verification
 - PR comments with deploy verification summaries and artifact references after `ship --pr`
 - Tracked QA evidence published under `docs/qa/<branch>/` during shipping so PR comments can link to real files
@@ -346,6 +346,8 @@ On GitHub, `.github/workflows/qa-pages.yml` deploys the merged `docs/qa/` report
 
 When a published QA report includes snapshot evidence, the Pages site now surfaces `visual/index.html` as the primary review-evidence entrypoint alongside the raw markdown, JSON, annotation, and screenshot files.
 Those visual packs now include a diff heatmap and an image-diff score so regressions can be ranked instead of treated as binary drift only.
+The merged QA Pages site also renders visual history charts for risk score, image-diff score, and baseline age so drift over time is visible without opening each report one by one.
+Snapshot baselines now carry route and device metadata, and QA/deploy/preview runs flag stale baselines automatically when the saved reference is too old.
 
 The same `gh-pages` branch also hosts PR previews under `pr-preview/pr-<number>/`. Configure these repo variables if you want richer automatic preview coverage in `pr-review.yml`:
 

--- a/browse/src/cli.ts
+++ b/browse/src/cli.ts
@@ -91,6 +91,9 @@ interface SnapshotElement {
 interface SnapshotPayload {
   capturedAt: string;
   url: string;
+  origin?: string;
+  routePath?: string;
+  device?: DevicePresetName;
   title: string;
   bodyText: string;
   page: {
@@ -338,6 +341,24 @@ function defaultSnapshotName(url: string): string {
     return slugify(`${parsed.hostname}${parsed.pathname}`.replace(/\/+/g, "-"));
   } catch {
     return slugify(url);
+  }
+}
+
+function routePathFromUrl(url: string): string {
+  try {
+    const parsed = new URL(url);
+    const pathWithQuery = `${parsed.pathname || "/"}${parsed.search || ""}`;
+    return pathWithQuery || "/";
+  } catch {
+    return "/";
+  }
+}
+
+function originFromUrl(url: string): string {
+  try {
+    return new URL(url).origin;
+  } catch {
+    return "";
   }
 }
 
@@ -667,6 +688,20 @@ export function createSnapshotVisualPack({
     name,
     title: `Snapshot visual pack • ${name}`,
     status: comparison.status,
+    baseline: baselineSnapshot ? {
+      capturedAt: baselineSnapshot.capturedAt || "",
+      routePath: baselineSnapshot.routePath || routePathFromUrl(baselineSnapshot.url || ""),
+      origin: baselineSnapshot.origin || originFromUrl(baselineSnapshot.url || ""),
+      device: baselineSnapshot.device || "",
+      url: baselineSnapshot.url || "",
+    } : null,
+    current: currentSnapshot ? {
+      capturedAt: currentSnapshot.capturedAt || "",
+      routePath: currentSnapshot.routePath || routePathFromUrl(currentSnapshot.url || ""),
+      origin: currentSnapshot.origin || originFromUrl(currentSnapshot.url || ""),
+      device: currentSnapshot.device || "",
+      url: currentSnapshot.url || "",
+    } : null,
     summary: comparison.summary,
     imageDiff,
     markers: markers.map((item) => ({ selector: item.selector, label: item.label })),
@@ -2068,6 +2103,9 @@ async function main(): Promise<void> {
     const baseline = {
       ...payload,
       name: snapshotName,
+      origin: originFromUrl(payload.url || url),
+      routePath: routePathFromUrl(payload.url || url),
+      device: device?.name || "desktop",
       screenshotPath: path.relative(process.cwd(), baselineScreenshot),
       screenshotHash: fileHash(baselineScreenshot),
     };
@@ -2111,6 +2149,9 @@ async function main(): Promise<void> {
     const currentSnapshot = {
       ...current,
       name: snapshotName,
+      origin: originFromUrl(current.url || url),
+      routePath: routePathFromUrl(current.url || url),
+      device: device?.name || "desktop",
       screenshotPath: path.relative(process.cwd(), artifactScreenshot),
       screenshotHash: fileHash(artifactScreenshot),
     };

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -142,6 +142,8 @@ Notes:
 - Snapshot-based failures also emit annotated SVG evidence under `.codex-stack/qa/annotations/`.
 - `compare-snapshot` now emits a self-contained visual pack, and `qa --publish-dir ...` copies that pack into `visual/index.html` and `visual/manifest.json`.
 - Every `qa-run` also refreshes `.codex-stack/qa/trends.json` and `.codex-stack/qa/trends.md` so you can compare the latest run against prior QA history.
+- Snapshot baselines now store route/device metadata and QA flags stale baselines automatically when the saved reference ages out.
+- `qa-run` also emits a consolidated visual-risk score so preview, deploy, and Pages rendering rank the same evidence consistently.
 - Use `--publish-dir docs/qa/<name>` when you want tracked copies of the QA report and evidence.
 - Use `--update-snapshot` when the UI change is intentional and the baseline should move.
 - Run `bun scripts/render-qa-pages.ts --out .site` to turn tracked `docs/qa/` artifacts into a static site locally or in CI.
@@ -173,6 +175,7 @@ Notes:
 - Template placeholders support `{repo}`, `{owner}`, `{repo_name}`, `{pr}`, `{branch}`, `{branch_slug}`, `{sha}`, and `{short_sha}`.
 - The script polls preview readiness before it delegates to `deploy-verify.ts`.
 - `--session-bundle <path>` imports an exported browser session into the named preview session before live checks run.
+- Preview reports now expose the deploy visual-risk score, including stale-baseline counts and top drivers.
 - `preview-verify.yml` is the manual rerun path. `pr-review.yml` is the automatic PR-time path and publishes the GitHub Pages preview before verification.
 - For same-repo PRs, preview evidence is republished into the same Pages subtree under `__codex/visual/index.html`.
 - Both preview workflows can consume the repo secret `CODEX_STACK_PREVIEW_SESSION_BUNDLE_B64` and decode it to a temp bundle file without exposing the contents in logs.
@@ -193,6 +196,7 @@ Notes:
 - Flow and snapshot checks are delegated to the existing QA runtime so the deploy report reuses the same finding model and artifacts.
 - `--session-bundle <path>` validates the bundle up front, imports it into the named deploy session when live browser checks need it, and passes it through to `qa-run.ts`.
 - The script writes `report.md`, `report.json`, `comment.md`, `screenshots.json`, and a visual review pack under `visual/index.html` and `visual/manifest.json`.
+- Deploy reports now include a single visual-risk score that combines path/device failures, console errors, snapshot drift, and stale baselines.
 
 ## Retro workflow
 
@@ -262,6 +266,7 @@ Notes:
 - Session bundles capture cookies plus origin storage so authenticated QA setups can move between named sessions.
 - `import-browser-cookies` is the local macOS path for Chrome, Arc, Brave, and Edge profiles when you need to bootstrap an authenticated session without replaying login flows manually.
 - `compare-snapshot` creates a portable visual pack with baseline/current screenshots, diff heatmap, image-diff score, annotation SVG, manifest JSON, and an HTML index page.
+- Snapshot baselines now record captured route/device metadata so later QA runs can detect stale or mismatched references more reliably.
 - `upload`, `dialog`, and the expanded assertion set are available both as direct commands and as flow actions.
 - `wait` supports `load:<state>` plus `state:<visible|hidden|attached|detached>:<selector>` for richer synchronization.
 - Selector arguments accept semantic prefixes as well as CSS: `role:<role>[:<name>]`, `label:<text>`, `placeholder:<text>`, `text:<text>`, and `testid:<value>`.

--- a/scripts/ci-check.sh
+++ b/scripts/ci-check.sh
@@ -103,6 +103,7 @@ run_ts scripts/upgrade-check.ts --offline --json >/tmp/codex-stack-upgrade.json
 run_ts scripts/upgrade-check.spec.ts >/tmp/codex-stack-upgrade-spec.log
 run_ts scripts/preview-verify.spec.ts >/tmp/codex-stack-preview-spec.log
 run_ts scripts/weekly-digest.spec.ts >/tmp/codex-stack-weekly-spec.log
+run_ts scripts/render-qa-pages.spec.ts >/tmp/codex-stack-render-qa-pages-spec.log
 grep -q '"overallStatus"' /tmp/codex-stack-upgrade.json
 grep -q '"offline": true' /tmp/codex-stack-upgrade.json
 run_ts scripts/retro-report.ts --since "1 day ago" --artifact-dir /tmp/codex-stack-retros --no-github >/tmp/codex-stack-retro.log
@@ -115,6 +116,9 @@ run_eval "process.stdout.write(Buffer.from('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQA
 cat > .codex-stack/browse/snapshots/example.json <<'JSON'
 {
   "name": "example",
+  "capturedAt": "2025-01-01T00:00:00.000Z",
+  "routePath": "/",
+  "device": "desktop",
   "elements": [
     {
       "selector": "h1",
@@ -179,7 +183,7 @@ cat > /tmp/codex-stack-qa-fixture.json <<'JSON'
 JSON
 run_ts scripts/qa-run.ts --fixture /tmp/codex-stack-qa-fixture.json --json >/tmp/codex-stack-qa.json
 grep -q '"status": "critical"' /tmp/codex-stack-qa.json
-grep -q '"healthScore": 48' /tmp/codex-stack-qa.json
+grep -q '"healthScore": 36' /tmp/codex-stack-qa.json
 grep -q '"annotation": ".codex-stack/qa/annotations/' /tmp/codex-stack-qa.json
 rm -rf docs/qa/smoke-fixture
 run_ts scripts/qa-run.ts --fixture /tmp/codex-stack-qa-fixture.json --publish-dir docs/qa/smoke-fixture --json >/tmp/codex-stack-qa-published.json
@@ -194,10 +198,12 @@ run_ts scripts/render-qa-pages.ts --out .site >/tmp/codex-stack-qa-pages.log
 test -f .site/index.html
 test -f .site/qa/index.html
 test -f .site/qa/smoke-fixture/index.html
+test -f .site/qa/history.json
 test -f .site/manifest.json
 test -f .site/.nojekyll
 grep -q 'codex-stack QA Reports' .site/index.html
 grep -q 'Visual pack' .site/index.html
+grep -q 'Visual history' .site/index.html
 grep -q 'smoke-fixture' .site/manifest.json
 grep -q 'github.io' .site/manifest.json
 bun run build >/tmp/codex-stack-preview-build.log

--- a/scripts/deploy-verify.spec.ts
+++ b/scripts/deploy-verify.spec.ts
@@ -63,6 +63,9 @@ async function main(): Promise<void> {
   }, null, 2));
   fs.writeFileSync(baselinePath, JSON.stringify({
     name: "portal-dashboard",
+    capturedAt: "2025-01-01T00:00:00.000Z",
+    routePath: "/dashboard",
+    device: "mobile",
     elements: [{ selector: "h1", bounds: { x: 0, y: 0, width: 1, height: 1 } }],
   }, null, 2));
   fs.writeFileSync(currentPath, JSON.stringify({
@@ -196,6 +199,7 @@ async function main(): Promise<void> {
     url?: string;
     urlSource?: string;
     recommendation?: string;
+    visualRisk?: { level?: string; score?: number; staleBaselines?: number; topDrivers?: string[] };
     readiness?: { status?: string; attempts?: number };
     checks?: { paths?: string[]; devices?: string[]; strictHttp?: boolean };
     pathResults?: Array<{ path?: string; device?: string; status?: string; httpStatus?: number | null; screenshot?: string; console?: { errors?: string[]; warnings?: string[] } }>;
@@ -212,6 +216,10 @@ async function main(): Promise<void> {
   assert.deepEqual(report.checks?.paths, ["/", "/dashboard"]);
   assert.deepEqual(report.checks?.devices, ["desktop", "mobile"]);
   assert.equal(report.status, "critical");
+  assert.equal(report.visualRisk?.level, "critical");
+  assert.ok(Number(report.visualRisk?.score || 0) >= 80);
+  assert.equal(report.visualRisk?.staleBaselines, 1);
+  assert.ok(report.visualRisk?.topDrivers?.some((entry) => String(entry).includes("critical page/device")));
   assert.match(String(report.recommendation), /Do not ship|Do not merge/i);
   assert.equal(report.pathResults?.length, 4);
   assert.ok(report.pathResults?.some((entry) => entry.path === "/dashboard" && entry.device === "mobile" && entry.status === "critical"));
@@ -224,10 +232,13 @@ async function main(): Promise<void> {
   assert.ok(String(report.visualPack?.index).includes("visual/index.html"));
   assert.ok(String(report.visualPack?.manifest).includes("visual/manifest.json"));
   const visualManifest = JSON.parse(fs.readFileSync(path.join(publishDir, "visual", "manifest.json"), "utf8")) as {
-    snapshots?: Array<{ imageDiffScore?: number; diffImage?: string }>;
+    visualRisk?: { score?: number; staleBaselines?: number };
+    snapshots?: Array<{ imageDiffScore?: number; diffImage?: string; baselineFreshness?: { stale?: boolean; routePath?: string } }>;
   };
+  assert.equal(visualManifest.visualRisk?.staleBaselines, 1);
   assert.ok(visualManifest.snapshots?.some((entry) => entry.imageDiffScore === 68.2));
   assert.ok(visualManifest.snapshots?.some((entry) => String(entry.diffImage).includes("diff.png")));
+  assert.ok(visualManifest.snapshots?.some((entry) => entry.baselineFreshness?.stale === true && entry.baselineFreshness?.routePath === "/dashboard"));
 
   assert.ok(fs.existsSync(markdownOut));
   assert.ok(fs.existsSync(jsonOut));
@@ -252,6 +263,8 @@ async function main(): Promise<void> {
   assert.match(markdown, /dashboard-mobile\.png/);
   assert.match(markdown, /portal-dashboard/);
   assert.match(markdown, /Visual pack/);
+  assert.match(markdown, /Visual risk: CRITICAL/);
+  assert.match(markdown, /baselineAge=/);
   assert.match(comment, /Deploy URL: https:\/\/preview-77\.example\.com/);
 
   console.log("deploy-verify spec passed");

--- a/scripts/deploy-verify.ts
+++ b/scripts/deploy-verify.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import process from "node:process";
 import { execSync, spawnSync } from "node:child_process";
 import { readSessionBundle, type SessionStorageEntry } from "../browse/src/session-bundle.ts";
+import { computeVisualRisk, type BaselineFreshness, type VisualRiskSummary } from "./visual-risk.ts";
 
 type DeployStatus = "pass" | "warning" | "critical" | "error";
 type UrlSource = "direct" | "template";
@@ -142,6 +143,7 @@ interface QaSnapshotReport {
   status?: string;
   annotation?: string;
   screenshot?: string;
+  baselineFreshness?: BaselineFreshness | null;
   visualPack?: VisualPackRef | null;
 }
 
@@ -163,6 +165,7 @@ export interface DeploySnapshotResult {
   report: string;
   annotation: string;
   screenshot: string;
+  baselineFreshness?: BaselineFreshness | null;
   visualPack?: VisualPackRef | null;
 }
 
@@ -208,6 +211,7 @@ export interface DeployReport {
   };
   pathResults: DeployPathResult[];
   qa: DeployQaSummary;
+  visualRisk: VisualRiskSummary;
   artifactRoot: string;
   screenshotManifest: string;
   visualPack?: DeployVisualPack | null;
@@ -638,6 +642,7 @@ function renderDeployVisualIndex(manifest: {
   title: string;
   generatedAt: string;
   status: DeployStatus;
+  visualRisk?: VisualRiskSummary;
   previewUrl: string;
   screenshotManifest: string;
   screenshots: Array<Record<string, unknown>>;
@@ -659,6 +664,7 @@ function renderDeployVisualIndex(manifest: {
       <article class="card">
         <h2>${escapeHtml(String(item.name || "snapshot"))}</h2>
         <p>Status: <strong>${escapeHtml(item.status || "unknown")}</strong> • ${escapeHtml(`${item.targetPath || "/"} @ ${item.device || "desktop"}`)}</p>
+        ${item.baselineFreshness ? `<p>Baseline: <strong>${escapeHtml(`${asObject(item.baselineFreshness)?.stale ? "stale" : "fresh"}`)}</strong> • age ${escapeHtml(`${asObject(item.baselineFreshness)?.ageDays ?? "n/a"}d`)}</p>` : ""}
         ${typeof item.imageDiffScore === "number" ? `<p>Image diff score: <strong>${escapeHtml(item.imageDiffScore)}</strong> • ratio ${escapeHtml(item.imageDiffRatio ?? "n/a")}</p>` : ""}
         ${item.index ? `<p><a href="${escapeHtml(String(item.index))}">Open visual pack</a></p>` : ""}
         ${item.manifest ? `<p><a href="${escapeHtml(String(item.manifest))}">Manifest JSON</a></p>` : ""}
@@ -693,6 +699,7 @@ function renderDeployVisualIndex(manifest: {
     <div class="meta">
       <div class="card"><strong>Status</strong><div>${escapeHtml(manifest.status)}</div></div>
       <div class="card"><strong>Generated</strong><div>${escapeHtml(manifest.generatedAt)}</div></div>
+      <div class="card"><strong>Visual risk</strong><div>${escapeHtml(`${asObject(manifest.visualRisk)?.level ? String(asObject(manifest.visualRisk)?.level).toUpperCase() : "NONE"} (${asObject(manifest.visualRisk)?.score ?? 0}/100)`)}</div></div>
       <div class="card"><strong>Preview URL</strong><div>${manifest.previewUrl ? `<a href="${escapeHtml(manifest.previewUrl)}">${escapeHtml(manifest.previewUrl)}</a>` : "n/a"}</div></div>
       <div class="card"><strong>Screenshot manifest</strong><div>${manifest.screenshotManifest ? `<a href="${escapeHtml(manifest.screenshotManifest)}">Open JSON</a>` : "n/a"}</div></div>
     </div>
@@ -1121,6 +1128,7 @@ function aggregateQa({
       report: cleanSubject(entry.report.artifacts?.published?.markdown || entry.report.artifacts?.markdown || ""),
       annotation: cleanSubject(entry.report.snapshotResult?.annotation || entry.report.artifacts?.published?.annotation || entry.report.artifacts?.annotation || ""),
       screenshot: cleanSubject(entry.report.snapshotResult?.screenshot || entry.report.artifacts?.published?.screenshot || entry.report.artifacts?.screenshot || ""),
+      baselineFreshness: entry.report.snapshotResult?.baselineFreshness || null,
       visualPack: entry.report.snapshotResult?.visualPack || entry.report.artifacts?.published?.visualPack || entry.report.artifacts?.visualPack || null,
     }));
   const healthScore = reports.reduce((lowest, entry) => {
@@ -1203,6 +1211,7 @@ function renderSnapshotLines(snapshotResults: DeploySnapshotResult[]): string[] 
     const refs = [
       `${item.name} @ ${item.targetPath} (${item.device})`,
       `status=${item.status}`,
+      item.baselineFreshness ? `baselineAge=${item.baselineFreshness.ageDays}d${item.baselineFreshness.stale ? "-stale" : ""}` : "",
       item.visualPack?.imageDiff ? `imageScore=${item.visualPack.imageDiff.score}` : "",
       item.report ? `report=${item.report}` : "",
       item.annotation ? `annotation=${item.annotation}` : "",
@@ -1227,6 +1236,7 @@ export function renderDeployMarkdown(report: DeployReport): string {
     `- Readiness: ${report.readiness.status} after ${report.readiness.attempts} attempt(s)`,
     report.readiness.httpStatus ? `- Last HTTP status: ${report.readiness.httpStatus}` : "",
     `- Overall status: ${report.status}`,
+    `- Visual risk: ${report.visualRisk.level.toUpperCase()} (${report.visualRisk.score}/100)`,
     `- Devices: ${report.checks.devices.join(", ")}`,
     `- Paths: ${report.checks.paths.join(", ")}`,
     `- Strict console errors: ${report.checks.strictConsole ? "yes" : "no"}`,
@@ -1257,6 +1267,7 @@ export function renderDeployMarkdown(report: DeployReport): string {
     report.screenshotManifest ? `- Screenshot manifest: \`${report.screenshotManifest}\`` : "",
     report.visualPack?.index ? `- Visual pack: \`${report.visualPack.index}\`` : "",
     report.visualPack?.manifest ? `- Visual manifest: \`${report.visualPack.manifest}\`` : "",
+    report.visualRisk.topDrivers.length ? `- Visual risk drivers: ${report.visualRisk.topDrivers.join("; ")}` : "",
     primaryQaArtifacts.markdown ? `- QA report: \`${primaryQaArtifacts.markdown}\`` : "",
     primaryQaArtifacts.json ? `- QA json: \`${primaryQaArtifacts.json}\`` : "",
     primaryQaArtifacts.annotation ? `- QA annotation: \`${primaryQaArtifacts.annotation}\`` : "",
@@ -1305,6 +1316,7 @@ function writeVisualPack({
   snapshotResults,
   screenshotManifest,
   status,
+  visualRisk,
 }: {
   publishDir: string;
   resolvedUrl: string;
@@ -1312,6 +1324,7 @@ function writeVisualPack({
   snapshotResults: DeploySnapshotResult[];
   screenshotManifest: string;
   status: DeployStatus;
+  visualRisk: VisualRiskSummary;
 }): DeployVisualPack {
   const visualDir = path.join(publishDir, "visual");
   const screenshotDir = path.join(visualDir, "screenshots");
@@ -1355,6 +1368,7 @@ function writeVisualPack({
       annotation: copiedAnnotation ? relFrom(visualDir, path.resolve(process.cwd(), copiedAnnotation)) : (fs.existsSync(path.join(targetDir, "annotation.svg")) ? relFrom(visualDir, path.join(targetDir, "annotation.svg")) : ""),
       screenshot: copiedScreenshot ? relFrom(visualDir, path.resolve(process.cwd(), copiedScreenshot)) : (fs.existsSync(path.join(targetDir, "current.png")) ? relFrom(visualDir, path.join(targetDir, "current.png")) : ""),
       diffImage: copiedDiff ? relFrom(visualDir, path.resolve(process.cwd(), copiedDiff)) : (fs.existsSync(path.join(targetDir, "diff.png")) ? relFrom(visualDir, path.join(targetDir, "diff.png")) : ""),
+      baselineFreshness: entry.baselineFreshness || null,
       imageDiffScore: entry.visualPack?.imageDiff?.score ?? null,
       imageDiffRatio: entry.visualPack?.imageDiff?.diffRatio ?? null,
     };
@@ -1364,6 +1378,7 @@ function writeVisualPack({
     generatedAt: new Date().toISOString(),
     title: "codex-stack visual review pack",
     status,
+    visualRisk,
     previewUrl: resolvedUrl,
     screenshotManifest: screenshotManifest ? relFrom(visualDir, path.resolve(process.cwd(), screenshotManifest)) : "",
     screenshots: screenshotEntries,
@@ -1443,6 +1458,10 @@ export async function runDeployVerification(args: DeployArgs): Promise<DeployRep
     },
     pathResults,
     qa,
+    visualRisk: computeVisualRisk({
+      pathResults,
+      snapshotResults: qa.snapshotResults,
+    }),
     artifactRoot: publishDir,
     screenshotManifest: "",
     visualPack: null,
@@ -1458,6 +1477,7 @@ export async function runDeployVerification(args: DeployArgs): Promise<DeployRep
     snapshotResults: report.qa.snapshotResults,
     screenshotManifest: report.screenshotManifest,
     status: report.status,
+    visualRisk: report.visualRisk,
   });
   report.recommendation = recommendation(report);
 

--- a/scripts/preview-verify.spec.ts
+++ b/scripts/preview-verify.spec.ts
@@ -61,6 +61,9 @@ async function main(): Promise<void> {
   }, null, 2));
   fs.writeFileSync(baselinePath, JSON.stringify({
     name: "landing-home",
+    capturedAt: "2025-01-01T00:00:00.000Z",
+    routePath: "/",
+    device: "desktop",
     elements: [{ selector: "h1", bounds: { x: 0, y: 0, width: 1, height: 1 } }],
   }, null, 2));
   fs.writeFileSync(currentPath, JSON.stringify({ name: "landing-home", elements: [] }, null, 2));
@@ -171,6 +174,7 @@ async function main(): Promise<void> {
     url?: string;
     urlSource?: string;
     recommendation?: string;
+    visualRisk?: { level?: string; score?: number; staleBaselines?: number; topDrivers?: string[] };
     readiness?: { status?: string; attempts?: number };
     context?: { branchSlug?: string; shortSha?: string };
     deploy?: { screenshotManifest?: string; visualPack?: { index?: string; manifest?: string }; pathResults?: Array<{ status?: string; screenshot?: string }> };
@@ -181,6 +185,9 @@ async function main(): Promise<void> {
   assert.equal(report.url, "https://preview-42.example.com");
   assert.equal(report.urlSource, "template");
   assert.equal(report.status, "critical");
+  assert.equal(report.visualRisk?.level, "medium");
+  assert.ok(Number(report.visualRisk?.score || 0) > 0);
+  assert.equal(report.visualRisk?.staleBaselines, 1);
   assert.match(String(report.recommendation), /Do not ship|Do not merge/i);
   assert.equal(report.readiness?.status, "ready");
   assert.ok(Number(report.readiness?.attempts || 0) >= 3);
@@ -204,6 +211,7 @@ async function main(): Promise<void> {
   assert.match(markdown, /codex-stack preview verification/);
   assert.match(markdown, /Preview URL: https:\/\/preview-42\.example\.com/);
   assert.match(markdown, /Readiness: ready after 3 attempt/);
+  assert.match(markdown, /Visual risk: MEDIUM/);
   assert.match(markdown, /Workflow run: https:\/\/github.com\/anup4khandelwal\/codex-stack\/actions\/runs\/123456/);
   assert.match(markdown, /## Deploy checks/);
   assert.match(markdown, /root-desktop\.png/);

--- a/scripts/preview-verify.ts
+++ b/scripts/preview-verify.ts
@@ -12,6 +12,7 @@ import {
   type DeployReport,
   type ReadinessResult,
 } from "./deploy-verify.ts";
+import type { VisualRiskSummary } from "./visual-risk.ts";
 
 type PreviewStatus = "pass" | "warning" | "critical" | "error";
 
@@ -48,6 +49,7 @@ interface PreviewReport {
   context: DeployContext;
   readiness: ReadinessResult;
   qa: PreviewQaCompat;
+  visualRisk: VisualRiskSummary;
   artifactRoot: string;
   visualPack?: DeployReport["visualPack"];
   runUrl: string;
@@ -162,6 +164,7 @@ function renderMarkdown(report: PreviewReport): string {
     `- Readiness: ${report.readiness.status} after ${report.readiness.attempts} attempt(s)`,
     report.readiness.httpStatus ? `- Last HTTP status: ${report.readiness.httpStatus}` : "",
     `- Overall status: ${report.status}`,
+    `- Visual risk: ${report.visualRisk.level.toUpperCase()} (${report.visualRisk.score}/100)`,
     `- Health score: ${report.qa.healthScore ?? "n/a"}`,
     `- Recommendation: ${report.recommendation}`,
     report.runUrl ? `- Workflow run: ${report.runUrl}` : "",
@@ -188,6 +191,7 @@ function renderMarkdown(report: PreviewReport): string {
     report.deploy.screenshotManifest ? `- Screenshot manifest: \`${report.deploy.screenshotManifest}\`` : "",
     report.visualPack?.index ? `- Visual pack: \`${report.visualPack.index}\`` : "",
     report.visualPack?.manifest ? `- Visual manifest: \`${report.visualPack.manifest}\`` : "",
+    report.visualRisk.topDrivers.length ? `- Visual risk drivers: ${report.visualRisk.topDrivers.join("; ")}` : "",
     published.markdown ? `- QA report: \`${published.markdown}\`` : "",
     published.json ? `- QA json: \`${published.json}\`` : "",
     published.annotation ? `- Annotation: \`${published.annotation}\`` : "",
@@ -223,6 +227,7 @@ async function main(): Promise<void> {
     context,
     readiness: deploy.readiness,
     qa: buildCompatQa(deploy),
+    visualRisk: deploy.visualRisk,
     artifactRoot: deploy.artifactRoot,
     visualPack: deploy.visualPack,
     runUrl: deploy.runUrl,

--- a/scripts/qa-run.spec.ts
+++ b/scripts/qa-run.spec.ts
@@ -33,6 +33,9 @@ const importMarker = path.join(fixtureRoot, "imported-session.json");
     JSON.stringify(
       {
         name: "landing-home",
+        capturedAt: "2025-01-01T00:00:00.000Z",
+        routePath: "/login",
+        device: "desktop",
         elements: [{ selector: "h1", bounds: { x: 0, y: 0, width: 1, height: 1 } }],
       },
       null,
@@ -154,14 +157,18 @@ process.exit(1);
   const report = JSON.parse(raw) as {
     status?: string;
     healthScore?: number;
+    visualRisk?: { level?: string; score?: number; staleBaselines?: number };
     flowResults?: Array<{ name?: string; status?: string; steps?: number }>;
-    snapshotResult?: { name?: string; status?: string; annotation?: string; screenshot?: string; visualPack?: { index?: string; manifest?: string; diffImage?: string; imageDiff?: { score?: number } } | null };
+    snapshotResult?: { name?: string; status?: string; annotation?: string; screenshot?: string; baselineFreshness?: { routePath?: string; device?: string; ageDays?: number; stale?: boolean } | null; visualPack?: { index?: string; manifest?: string; diffImage?: string; imageDiff?: { score?: number } } | null };
     findings?: Array<{ severity?: string; category?: string; title?: string; evidence?: { annotation?: string } }>;
     artifacts?: { annotation?: string; visualPack?: { index?: string; manifest?: string } | null };
   };
 
   assert.equal(report.status, "critical");
-  assert.equal(report.healthScore, 48);
+  assert.equal(report.healthScore, 36);
+  assert.equal(report.visualRisk?.level, "low");
+  assert.ok(Number(report.visualRisk?.score || 0) > 0);
+  assert.equal(report.visualRisk?.staleBaselines, 1);
   assert.equal(report.flowResults?.[0]?.name, "login-smoke");
   assert.equal(report.flowResults?.[0]?.status, "pass");
   assert.equal(report.flowResults?.[0]?.steps, 2);
@@ -173,8 +180,12 @@ process.exit(1);
   assert.ok(String(report.snapshotResult?.visualPack?.manifest).includes("visual/manifest.json"));
   assert.ok(String(report.snapshotResult?.visualPack?.diffImage).includes("visual/diff.png"));
   assert.equal(report.snapshotResult?.visualPack?.imageDiff?.score, 72.4);
+  assert.equal(report.snapshotResult?.baselineFreshness?.routePath, "/login");
+  assert.equal(report.snapshotResult?.baselineFreshness?.device, "desktop");
+  assert.equal(report.snapshotResult?.baselineFreshness?.stale, true);
   assert.ok(report.findings?.some((item) => item.severity === "critical" && item.category === "visual" && item.title === "Expected UI selectors are missing"));
   assert.ok(report.findings?.some((item) => item.severity === "medium" && item.category === "visual" && item.title === "Snapshot drift detected"));
+  assert.ok(report.findings?.some((item) => item.title === "Snapshot baseline is stale"));
   assert.ok(report.findings?.some((item) => item.evidence?.annotation));
   assert.ok(report.artifacts?.annotation);
   assert.ok(report.artifacts?.visualPack?.index);

--- a/scripts/qa-run.ts
+++ b/scripts/qa-run.ts
@@ -6,6 +6,7 @@ import { spawnSync } from "node:child_process";
 import { readSessionBundle } from "../browse/src/session-bundle.ts";
 import { inferChangedRoutes, type RouteCandidate } from "./qa-diff.ts";
 import { writeQaTrendArtifacts } from "./qa-trends.ts";
+import { computeBaselineFreshness, computeVisualRisk, type BaselineFreshness, type VisualRiskSummary } from "./visual-risk.ts";
 
 type QaMode = "quick" | "full" | "regression" | string;
 type FindingSeverity = "critical" | "high" | "medium" | "low";
@@ -41,6 +42,15 @@ interface SnapshotElement {
 
 interface SnapshotDocument {
   name?: string;
+  capturedAt?: string;
+  url?: string;
+  origin?: string;
+  routePath?: string;
+  device?: string;
+  page?: {
+    width?: number;
+    height?: number;
+  };
   elements?: SnapshotElement[];
   screenshotPath?: string;
 }
@@ -140,6 +150,7 @@ interface QaSnapshotSummary {
   current: string;
   screenshot: string;
   annotation: string;
+  baselineFreshness?: BaselineFreshness | null;
   visualPack?: VisualPackRef | null;
 }
 
@@ -204,6 +215,7 @@ interface QaReport {
   routeResults: QaRouteResult[];
   diffSummary: QaDiffSummary | null;
   snapshotResult: QaSnapshotSummary | null;
+  visualRisk: VisualRiskSummary;
   artifacts: QaArtifacts;
 }
 
@@ -539,6 +551,19 @@ function recommendation(status: ReportStatus, healthScore: number): string {
   return "QA checks passed. Keep the snapshot baseline fresh when intentional UI changes land.";
 }
 
+function routePathForSnapshot(snapshot: SnapshotDocument | null, fallbackUrl: string): string {
+  const explicit = String(snapshot?.routePath || "").trim();
+  if (explicit) return explicit;
+  const rawUrl = String(snapshot?.url || fallbackUrl || "").trim();
+  if (!rawUrl) return "/";
+  try {
+    const parsed = new URL(rawUrl);
+    return `${parsed.pathname || "/"}${parsed.search || ""}` || "/";
+  } catch {
+    return "/";
+  }
+}
+
 function buildMarkdown(report: QaReport): string {
   const findingLines = report.findings.length
     ? report.findings
@@ -580,6 +605,9 @@ function buildMarkdown(report: QaReport): string {
   const snapshotLine = report.snapshotResult
     ? [
         `- Snapshot: ${report.snapshotResult.status} (${report.snapshotResult.name})`,
+        report.snapshotResult.baselineFreshness
+          ? `- Baseline freshness: ${report.snapshotResult.baselineFreshness.stale ? "stale" : "fresh"} (${report.snapshotResult.baselineFreshness.ageDays}d old at ${report.snapshotResult.baselineFreshness.routePath} on ${report.snapshotResult.baselineFreshness.device})`
+          : "",
         report.snapshotResult.screenshot ? `- Screenshot: ${report.snapshotResult.screenshot}` : "",
         report.snapshotResult.annotation ? `- Annotation: ${report.snapshotResult.annotation}` : "",
         report.snapshotResult.visualPack?.index ? `- Visual pack: ${report.snapshotResult.visualPack.index}` : "",
@@ -599,6 +627,7 @@ function buildMarkdown(report: QaReport): string {
 - Status: ${report.status}
 - Health score: ${report.healthScore}
 - Recommendation: ${report.recommendation}
+- Visual risk: ${report.visualRisk.level.toUpperCase()} (${report.visualRisk.score}/100)
 
 ## Findings
 
@@ -930,6 +959,17 @@ function buildReport({
   diffSummary: QaDiffSummary | null;
 }): QaReport {
   const findings: QaFinding[] = [];
+  const baselineDocument = snapshotEvidence
+    ? loadSnapshotDocument(snapshotEvidence.result.baseline || snapshotEvidence.result.snapshot || "")
+    : null;
+  const baselineFreshness = snapshotEvidence
+    ? computeBaselineFreshness({
+        snapshot: args.snapshot || baselineDocument?.name || "snapshot",
+        routePath: routePathForSnapshot(baselineDocument, args.url),
+        device: String(baselineDocument?.device || "desktop"),
+        capturedAt: baselineDocument?.capturedAt,
+      })
+    : null;
 
   for (const flow of flowEvidence) {
     if (!flow.ok) {
@@ -998,6 +1038,24 @@ function buildReport({
     }
   }
 
+  if (baselineFreshness?.stale) {
+    const severity: FindingSeverity = baselineFreshness.ageDays >= baselineFreshness.staleAfterDays * 2 ? "medium" : "low";
+    findings.push(
+      finding(
+        severity,
+        "visual",
+        "Snapshot baseline is stale",
+        `The saved baseline for ${baselineFreshness.snapshot} is ${baselineFreshness.ageDays} days old. Refresh it intentionally if the current UI is now the expected state.`,
+        {
+          snapshot: baselineFreshness.snapshot,
+          route: baselineFreshness.routePath,
+          device: baselineFreshness.device,
+          capturedAt: baselineFreshness.capturedAt,
+        },
+      ),
+    );
+  }
+
   for (const route of routeEvidence) {
     if (route.dynamic) {
       findings.push(
@@ -1035,6 +1093,21 @@ function buildReport({
   const healthScore = scoreFindings(findings);
   const status = statusFromFindings(findings);
   const generatedAt = new Date().toISOString();
+  const snapshotResult = snapshotEvidence
+    ? {
+        name: args.snapshot,
+        status: snapshotEvidence.result.status || (snapshotEvidence.ok ? "ok" : "failed"),
+        baseline: snapshotEvidence.result.baseline || snapshotEvidence.result.snapshot || "",
+        current: snapshotEvidence.result.current || "",
+        screenshot: snapshotEvidence.result.screenshot || "",
+        annotation: "",
+        baselineFreshness,
+        visualPack: snapshotEvidence.result.visualPack || null,
+      }
+    : null;
+  const visualRisk = computeVisualRisk({
+    snapshotResults: snapshotResult ? [snapshotResult] : [],
+  });
   return {
     generatedAt,
     url: args.url,
@@ -1057,17 +1130,8 @@ function buildReport({
       reason: item.reason,
     })),
     diffSummary,
-    snapshotResult: snapshotEvidence
-      ? {
-          name: args.snapshot,
-          status: snapshotEvidence.result.status || (snapshotEvidence.ok ? "ok" : "failed"),
-          baseline: snapshotEvidence.result.baseline || snapshotEvidence.result.snapshot || "",
-          current: snapshotEvidence.result.current || "",
-          screenshot: snapshotEvidence.result.screenshot || "",
-          annotation: "",
-          visualPack: snapshotEvidence.result.visualPack || null,
-        }
-      : null,
+    snapshotResult,
+    visualRisk,
     artifacts: snapshotEvidence?.result.visualPack ? { visualPack: snapshotEvidence.result.visualPack } : {},
   };
 }

--- a/scripts/render-pr-review.spec.ts
+++ b/scripts/render-pr-review.spec.ts
@@ -65,6 +65,12 @@ async function main(): Promise<void> {
     url: "https://preview-23.example.com",
     runUrl: "https://github.com/anup4khandelwal/codex-stack/actions/runs/123456",
     recommendation: "Do not merge until the preview is fixed.",
+    visualRisk: {
+      level: "critical",
+      score: 91.2,
+      staleBaselines: 1,
+      topDrivers: ["1 critical page/device check", "1 stale baseline"],
+    },
     readiness: {
       status: "ready",
       attempts: 2,
@@ -124,6 +130,10 @@ async function main(): Promise<void> {
             targetPath: "/",
             device: "desktop",
             status: "changed",
+            baselineFreshness: {
+              ageDays: 43,
+              stale: true,
+            },
             report: "preview-artifacts/qa/report.md",
             annotation: "preview-artifacts/annotation.svg",
             screenshot: "preview-artifacts/screenshot.png",
@@ -159,10 +169,13 @@ async function main(): Promise<void> {
   assert.match(stdout, /Preview URL: https:\/\/preview-23\.example\.com/);
   assert.match(stdout, /Workflow run: https:\/\/github\.com\/anup4khandelwal\/codex-stack\/actions\/runs\/123456/);
   assert.match(stdout, /Hosted visual pack: https:\/\/anup4khandelwal\.github\.io\/codex-stack\/pr-preview\/pr-23\/__codex\/visual\/index\.html/);
+  assert.match(stdout, /Visual risk: CRITICAL \(91\.2\/100\)/);
   assert.match(stdout, /`changed` `score 68\.2` `ratio 0\.318` dashboard @ \//);
+  assert.match(stdout, /1 stale baseline need review or refresh/);
   assert.match(stdout, /CRITICAL\/VISUAL/);
   assert.match(stdout, /annotation\.svg/);
   assert.match(stdout, /### Deploy checks/);
+  assert.match(stdout, /baselineAge=43d-stale/);
   assert.match(stdout, /!\[dashboard desktop\]\(https:\/\/anup4khandelwal\.github\.io\/codex-stack\/pr-preview\/pr-23\/__codex\/visual\/snapshots\/dashboard-root-desktop\/diff\.png\)/);
   assert.match(stdout, /consoleWarnings=1/);
   assert.match(stdout, /screenshots\.json/);

--- a/scripts/render-pr-review.ts
+++ b/scripts/render-pr-review.ts
@@ -55,6 +55,12 @@ interface PreviewReport {
   url?: string;
   runUrl?: string;
   recommendation?: string;
+  visualRisk?: {
+    score?: number;
+    level?: string;
+    staleBaselines?: number;
+    topDrivers?: string[];
+  };
   readiness?: {
     status?: string;
     attempts?: number;
@@ -83,13 +89,17 @@ interface PreviewReport {
           name?: string;
           targetPath?: string;
           device?: string;
-          status?: string;
-          report?: string;
-          annotation?: string;
-          screenshot?: string;
-          visualPack?: {
-            index?: string;
-            manifest?: string;
+        status?: string;
+        report?: string;
+        annotation?: string;
+        screenshot?: string;
+        baselineFreshness?: {
+          ageDays?: number;
+          stale?: boolean;
+        } | null;
+        visualPack?: {
+          index?: string;
+          manifest?: string;
           } | null;
         }>;
       };
@@ -271,6 +281,7 @@ function deploySnapshotLines(preview: PreviewReport | null): string[] {
     const bits = [
       `${item.name || "snapshot"} @ ${item.targetPath || "/"} (${item.device || "desktop"})`,
       `status=${item.status || "unknown"}`,
+      item.baselineFreshness ? `baselineAge=${item.baselineFreshness.ageDays ?? "n/a"}d${item.baselineFreshness.stale ? "-stale" : ""}` : "",
       item.annotation ? `annotation=${item.annotation}` : "",
       item.screenshot ? `screenshot=${item.screenshot}` : "",
       item.report ? `report=${item.report}` : "",
@@ -354,6 +365,7 @@ function renderPreviewSection(preview: PreviewReport | null, summary: ReviewSumm
 - Status: ${preview.status || "unknown"}
 - Readiness: ${preview.readiness?.status || "unknown"}${preview.readiness?.attempts ? ` after ${preview.readiness.attempts} attempt(s)` : ""}
 - Health score: ${preview.qa?.healthScore ?? "n/a"}
+- Visual risk: ${preview.visualRisk?.level ? `${String(preview.visualRisk.level).toUpperCase()} (${preview.visualRisk.score ?? "n/a"}/100)` : "n/a"}
 - Block merge: ${summary.previewBlocking ? "yes" : "no"}
 - Recommendation: ${preview.recommendation || preview.qa?.recommendation || "n/a"}
 ${preview.url ? `- Preview URL: ${preview.url}` : ""}
@@ -383,6 +395,16 @@ ${deploySnapshotLines(preview).join("\n")}
 ### Visual summary
 
 ${visualBadgeLines(preview, previewPagesRoot).join("\n")}
+
+${preview.visualRisk?.topDrivers?.length ? `### Visual risk drivers
+
+${preview.visualRisk.topDrivers.map((item) => `- ${item}`).join("\n")}
+` : ""}
+
+${preview.visualRisk?.staleBaselines ? `### Stale baselines
+
+- ${preview.visualRisk.staleBaselines} stale baseline${preview.visualRisk.staleBaselines === 1 ? "" : "s"} need review or refresh.
+` : ""}
 
 ${visualImageEmbeds(preview, previewPagesRoot).join("\n\n")}
 `;

--- a/scripts/render-qa-pages.spec.ts
+++ b/scripts/render-qa-pages.spec.ts
@@ -1,0 +1,151 @@
+#!/usr/bin/env bun
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import process from "node:process";
+import { execFileSync } from "node:child_process";
+
+const rootDir = process.cwd();
+const bun = process.execPath || "bun";
+const fixtureRoot = fs.mkdtempSync(path.join(os.tmpdir(), "codex-stack-render-qa-pages-"));
+
+function writeReport(dirPath: string, payload: Record<string, unknown>): void {
+  fs.mkdirSync(path.join(dirPath, "visual"), { recursive: true });
+  fs.writeFileSync(path.join(dirPath, "report.json"), JSON.stringify(payload, null, 2));
+  fs.writeFileSync(path.join(dirPath, "report.md"), "# report\n");
+  fs.writeFileSync(path.join(dirPath, "annotation.svg"), "<svg xmlns=\"http://www.w3.org/2000/svg\"></svg>");
+  fs.writeFileSync(path.join(dirPath, "screenshot.png"), Buffer.from("iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAusB9Y9l9i8AAAAASUVORK5CYII=", "base64"));
+  fs.writeFileSync(path.join(dirPath, "visual", "index.html"), "<html><body>visual pack</body></html>");
+  fs.writeFileSync(path.join(dirPath, "visual", "manifest.json"), JSON.stringify({ ok: true }, null, 2));
+}
+
+async function main(): Promise<void> {
+  const sourceDir = path.join(fixtureRoot, "docs", "qa");
+  const outDir = path.join(fixtureRoot, ".site");
+  const reportA = path.join(sourceDir, "2026-03-01-login");
+  const reportB = path.join(sourceDir, "2026-03-15-dashboard");
+
+  writeReport(reportA, {
+    generatedAt: "2026-03-01T10:00:00.000Z",
+    url: "https://preview.example.com/login",
+    status: "warning",
+    healthScore: 82,
+    recommendation: "Review the login copy drift.",
+    findings: [],
+    flowResults: [],
+    snapshotResult: {
+      name: "login",
+      status: "changed",
+      baseline: "baseline.json",
+      current: "current.json",
+      baselineFreshness: {
+        routePath: "/login",
+        device: "mobile",
+        ageDays: 12,
+        stale: false,
+      },
+      visualPack: {
+        imageDiff: {
+          score: 88.4,
+          diffRatio: 0.116,
+        },
+      },
+    },
+    visualRisk: {
+      score: 28,
+      level: "medium",
+      staleBaselines: 0,
+    },
+  });
+
+  writeReport(reportB, {
+    generatedAt: "2026-03-15T10:00:00.000Z",
+    url: "https://preview.example.com/dashboard",
+    status: "critical",
+    healthScore: 46,
+    recommendation: "Do not merge until the dashboard baseline is refreshed or fixed.",
+    findings: [],
+    flowResults: [],
+    snapshotResult: {
+      name: "dashboard",
+      status: "changed",
+      baseline: "baseline.json",
+      current: "current.json",
+      baselineFreshness: {
+        routePath: "/dashboard",
+        device: "desktop",
+        ageDays: 47,
+        stale: true,
+      },
+      visualPack: {
+        imageDiff: {
+          score: 63.7,
+          diffRatio: 0.363,
+        },
+      },
+    },
+    visualRisk: {
+      score: 86,
+      level: "critical",
+      staleBaselines: 1,
+    },
+  });
+
+  execFileSync(
+    bun,
+    [
+      path.join(rootDir, "scripts", "render-qa-pages.ts"),
+      "--source",
+      sourceDir,
+      "--out",
+      outDir,
+      "--base-url",
+      "https://anup4khandelwal.github.io/codex-stack/",
+    ],
+    {
+      cwd: rootDir,
+      encoding: "utf8",
+    },
+  );
+
+  const indexHtml = fs.readFileSync(path.join(outDir, "index.html"), "utf8");
+  const reportHtml = fs.readFileSync(path.join(outDir, "qa", "2026-03-15-dashboard", "index.html"), "utf8");
+  const history = JSON.parse(fs.readFileSync(path.join(outDir, "qa", "history.json"), "utf8")) as Array<{
+    slug?: string;
+    visualRiskScore?: number;
+    imageDiffScore?: number;
+    baselineAgeDays?: number;
+    staleBaseline?: boolean;
+  }>;
+  const manifest = JSON.parse(fs.readFileSync(path.join(outDir, "manifest.json"), "utf8")) as {
+    historyPath?: string;
+    reports?: Array<{ visualRiskScore?: number; staleBaseline?: boolean }>;
+  };
+
+  assert.match(indexHtml, /Visual history/);
+  assert.match(indexHtml, /Visual risk score/);
+  assert.match(indexHtml, /Snapshot image diff score/);
+  assert.match(indexHtml, /Baseline age \(days\)/);
+  assert.match(indexHtml, /Latest visual risk:<\/strong> CRITICAL \(86\/100\)/);
+  assert.match(indexHtml, /Baseline age:<\/strong> 47d • stale/);
+  assert.match(reportHtml, /Route:<\/strong> \/dashboard/);
+  assert.match(reportHtml, /Baseline age:<\/strong> 47d • stale/);
+  assert.equal(history.length, 2);
+  assert.equal(history[1]?.slug, "2026-03-15-dashboard");
+  assert.equal(history[1]?.visualRiskScore, 86);
+  assert.equal(history[1]?.imageDiffScore, 63.7);
+  assert.equal(history[1]?.baselineAgeDays, 47);
+  assert.equal(history[1]?.staleBaseline, true);
+  assert.equal(manifest.historyPath, "qa/history.json");
+  assert.equal(manifest.reports?.[0]?.visualRiskScore, 86);
+  assert.equal(manifest.reports?.[0]?.staleBaseline, true);
+
+  console.log("render-qa-pages spec passed");
+}
+
+try {
+  await main();
+} finally {
+  fs.rmSync(fixtureRoot, { recursive: true, force: true });
+}

--- a/scripts/render-qa-pages.ts
+++ b/scripts/render-qa-pages.ts
@@ -32,6 +32,28 @@ interface QaSnapshotResult {
   status?: string;
   baseline?: string;
   current?: string;
+  baselineFreshness?: {
+    snapshot?: string;
+    routePath?: string;
+    device?: string;
+    capturedAt?: string;
+    ageDays?: number;
+    stale?: boolean;
+    staleAfterDays?: number;
+  } | null;
+  visualPack?: {
+    imageDiff?: {
+      score?: number;
+      diffRatio?: number;
+    } | null;
+  } | null;
+}
+
+interface QaVisualRisk {
+  score?: string | number;
+  level?: string;
+  staleBaselines?: string | number;
+  topDrivers?: string[];
 }
 
 interface QaReportData extends Record<string, unknown> {
@@ -45,6 +67,7 @@ interface QaReportData extends Record<string, unknown> {
   findings?: QaFinding[];
   flowResults?: QaFlowResult[];
   snapshotResult?: QaSnapshotResult;
+  visualRisk?: QaVisualRisk;
 }
 
 interface CollectedReport {
@@ -63,6 +86,24 @@ interface CollectedReport {
   stableAnnotationUrl: string;
   stableScreenshotUrl: string;
   stableVisualUrl: string;
+  visualRiskScore: number | null;
+  visualRiskLevel: string;
+  imageDiffScore: number | null;
+  baselineAgeDays: number | null;
+  staleBaseline: boolean;
+}
+
+interface VisualHistoryPoint {
+  slug: string;
+  generatedAt: string;
+  status: string;
+  healthScore: number | null;
+  visualRiskScore: number | null;
+  visualRiskLevel: string;
+  imageDiffScore: number | null;
+  baselineAgeDays: number | null;
+  staleBaseline: boolean;
+  stableUrl: string;
 }
 
 interface LayoutProps {
@@ -202,6 +243,15 @@ function formatDate(value: unknown): string {
   }
 }
 
+function asNumber(value: unknown): number | null {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string" && value.trim()) {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+  return null;
+}
+
 function severityClass(status: unknown): string {
   const normalized = String(status || "").toLowerCase();
   if (normalized === "critical") return "critical";
@@ -240,6 +290,107 @@ function reportRows(report: CollectedReport): string {
       ${evidence ? `<div class="evidence">${evidence}</div>` : ""}
     </li>`;
   }).join("\n");
+}
+
+function buildVisualHistory(reports: CollectedReport[]): VisualHistoryPoint[] {
+  return [...reports]
+    .map((report) => ({
+      slug: report.slug,
+      generatedAt: String(report.data.generatedAt || ""),
+      status: String(report.data.status || "pass"),
+      healthScore: asNumber(report.data.healthScore),
+      visualRiskScore: report.visualRiskScore,
+      visualRiskLevel: report.visualRiskLevel,
+      imageDiffScore: report.imageDiffScore,
+      baselineAgeDays: report.baselineAgeDays,
+      staleBaseline: report.staleBaseline,
+      stableUrl: report.stableUrl,
+    }))
+    .sort((left, right) => (Date.parse(left.generatedAt || "0") || 0) - (Date.parse(right.generatedAt || "0") || 0));
+}
+
+function renderHistoryChart(points: VisualHistoryPoint[], {
+  title,
+  accessor,
+  color,
+  maxValue = 100,
+}: {
+  title: string;
+  accessor: (point: VisualHistoryPoint) => number | null;
+  color: string;
+  maxValue?: number;
+}): string {
+  const values = points.map(accessor);
+  const numeric = values.filter((item): item is number => typeof item === "number" && Number.isFinite(item));
+  if (!numeric.length) {
+    return `<article class="card section"><h2>${escapeHtml(title)}</h2><p class="empty">No chart data yet.</p></article>`;
+  }
+  const width = 720;
+  const height = 220;
+  const padding = 22;
+  const usableWidth = width - (padding * 2);
+  const usableHeight = height - (padding * 2);
+  const max = Math.max(maxValue, ...numeric);
+  const step = points.length > 1 ? usableWidth / (points.length - 1) : 0;
+  const coords = points.map((point, index) => {
+    const value = accessor(point);
+    if (value === null || !Number.isFinite(value)) return null;
+    const x = padding + (index * step);
+    const y = padding + usableHeight - ((value / max) * usableHeight);
+    return { x, y, value, point };
+  }).filter((item): item is { x: number; y: number; value: number; point: VisualHistoryPoint } => Boolean(item));
+  const polyline = coords.map((item) => `${item.x},${item.y}`).join(" ");
+  const markers = coords.map((item) => `<a xlink:href="${escapeHtml(item.point.stableUrl || "#")}"><circle cx="${item.x}" cy="${item.y}" r="4.5" fill="${escapeHtml(color)}"><title>${escapeHtml(`${item.point.slug}: ${item.value}`)}</title></circle></a>`).join("");
+  const labels = coords.length
+    ? `<div class="chart-legend"><span>Oldest: ${escapeHtml(coords[0].point.slug)}</span><span>Newest: ${escapeHtml(coords[coords.length - 1].point.slug)}</span></div>`
+    : "";
+  return `<article class="card section">
+    <h2>${escapeHtml(title)}</h2>
+    <svg class="chart" viewBox="0 0 ${width} ${height}" role="img" aria-label="${escapeHtml(title)}">
+      <rect x="0" y="0" width="${width}" height="${height}" rx="18" fill="#fffaf2"></rect>
+      <line x1="${padding}" y1="${height - padding}" x2="${width - padding}" y2="${height - padding}" stroke="#d1c6b6" stroke-width="1.5"></line>
+      <line x1="${padding}" y1="${padding}" x2="${padding}" y2="${height - padding}" stroke="#d1c6b6" stroke-width="1.5"></line>
+      <polyline fill="none" stroke="${escapeHtml(color)}" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" points="${escapeHtml(polyline)}"></polyline>
+      ${markers}
+    </svg>
+    ${labels}
+  </article>`;
+}
+
+function renderHistorySection(reports: CollectedReport[]): string {
+  const points = buildVisualHistory(reports);
+  if (!points.length) return "";
+  const staleCount = points.filter((item) => item.staleBaseline).length;
+  const latest = points[points.length - 1];
+  const summary = [
+    `<span><strong>Reports:</strong> ${points.length}</span>`,
+    latest.visualRiskScore !== null ? `<span><strong>Latest visual risk:</strong> ${latest.visualRiskLevel.toUpperCase()} (${latest.visualRiskScore}/100)</span>` : "",
+    latest.imageDiffScore !== null ? `<span><strong>Latest image diff score:</strong> ${latest.imageDiffScore}</span>` : "",
+    `<span><strong>Stale baselines:</strong> ${staleCount}</span>`,
+  ].filter(Boolean).join("");
+  return `<section class="grid two" style="margin-top: 24px;">
+    <article class="card section">
+      <h2>Visual history</h2>
+      <p>Track risk, drift, and baseline age across published QA reports.</p>
+      <div class="meta">${summary}</div>
+    </article>
+    ${renderHistoryChart(points, {
+      title: "Visual risk score",
+      accessor: (point) => point.visualRiskScore,
+      color: "#b42318",
+    })}
+    ${renderHistoryChart(points, {
+      title: "Snapshot image diff score",
+      accessor: (point) => point.imageDiffScore,
+      color: "#1d4ed8",
+    })}
+    ${renderHistoryChart(points, {
+      title: "Baseline age (days)",
+      accessor: (point) => point.baselineAgeDays,
+      color: "#b45308",
+      maxValue: Math.max(30, ...points.map((item) => item.baselineAgeDays || 0)),
+    })}
+  </section>`;
 }
 
 function flowRows(report: CollectedReport): string {
@@ -412,6 +563,22 @@ function layout({ title, body, baseUrl, heading, subheading }: LayoutProps): str
       object-fit: contain;
       background: #f8f5ee;
     }
+    .chart {
+      width: 100%;
+      height: auto;
+      border: 1px solid var(--line);
+      border-radius: 16px;
+      background: #fffaf2;
+      margin-top: 14px;
+    }
+    .chart-legend {
+      display: flex;
+      justify-content: space-between;
+      gap: 12px;
+      margin-top: 12px;
+      color: var(--muted);
+      font-size: 0.9rem;
+    }
     .empty { color: var(--muted); }
     footer {
       margin-top: 32px;
@@ -446,6 +613,9 @@ function renderIndex({ reports, baseUrl }: { reports: CollectedReport[]; baseUrl
         <p>${escapeHtml(report.data.recommendation || "No recommendation recorded.")}</p>
         <div class="meta">
           <span><strong>Health score:</strong> ${escapeHtml(report.data.healthScore)}</span>
+          ${report.visualRiskScore !== null ? `<span><strong>Visual risk:</strong> ${escapeHtml(`${report.visualRiskLevel.toUpperCase()} (${report.visualRiskScore}/100)`)}</span>` : ""}
+          ${report.imageDiffScore !== null ? `<span><strong>Image diff:</strong> ${escapeHtml(report.imageDiffScore)}</span>` : ""}
+          ${report.baselineAgeDays !== null ? `<span><strong>Baseline age:</strong> ${escapeHtml(`${report.baselineAgeDays}d${report.staleBaseline ? " • stale" : ""}`)}</span>` : ""}
           <span><strong>Generated:</strong> ${escapeHtml(formatDate(report.data.generatedAt))}</span>
           <span><strong>URL:</strong> ${escapeHtml(report.data.url || "fixture")}</span>
         </div>
@@ -469,7 +639,7 @@ function renderIndex({ reports, baseUrl }: { reports: CollectedReport[]; baseUrl
     heading: "codex-stack QA Reports",
     subheading: "Stable GitHub Pages view for tracked QA evidence generated during shipping.",
     baseUrl,
-    body: `<section class="report-grid">${content}</section>`,
+    body: `${renderHistorySection(reports)}<section class="report-grid">${content}</section>`,
   });
 }
 
@@ -513,6 +683,10 @@ function renderReport(report: CollectedReport, baseUrl: string): string {
           <div class="meta">
             <span><strong>Name:</strong> ${escapeHtml(snapshot.name || "n/a")}</span>
             <span><strong>Status:</strong> ${escapeHtml(snapshot.status || "n/a")}</span>
+            ${report.visualRiskScore !== null ? `<span><strong>Visual risk:</strong> ${escapeHtml(`${report.visualRiskLevel.toUpperCase()} (${report.visualRiskScore}/100)`)}</span>` : ""}
+            ${snapshot.baselineFreshness?.routePath ? `<span><strong>Route:</strong> ${escapeHtml(snapshot.baselineFreshness.routePath)}</span>` : ""}
+            ${snapshot.baselineFreshness?.device ? `<span><strong>Device:</strong> ${escapeHtml(snapshot.baselineFreshness.device)}</span>` : ""}
+            ${snapshot.baselineFreshness?.ageDays !== undefined ? `<span><strong>Baseline age:</strong> ${escapeHtml(`${snapshot.baselineFreshness.ageDays}d${snapshot.baselineFreshness.stale ? " • stale" : ""}`)}</span>` : ""}
             ${snapshot.baseline ? `<span><strong>Baseline:</strong> ${escapeHtml(snapshot.baseline)}</span>` : ""}
             ${snapshot.current ? `<span><strong>Current:</strong> ${escapeHtml(snapshot.current)}</span>` : ""}
           </div>
@@ -561,6 +735,11 @@ function collectReports(sourceDir: string, baseUrl: string): CollectedReport[] {
         stableAnnotationUrl: "",
         stableScreenshotUrl: "",
         stableVisualUrl: "",
+        visualRiskScore: asNumber(data.visualRisk?.score),
+        visualRiskLevel: cleanSubject(data.visualRisk?.level || "none") || "none",
+        imageDiffScore: asNumber(data.snapshotResult?.visualPack?.imageDiff?.score),
+        baselineAgeDays: asNumber(data.snapshotResult?.baselineFreshness?.ageDays),
+        staleBaseline: Boolean(data.snapshotResult?.baselineFreshness?.stale),
       };
       report.stableUrl = reportLink(baseUrl, report);
       report.stableAnnotationUrl = report.annotationPath ? assetLink(baseUrl, report, "annotation.svg") : "";
@@ -605,6 +784,7 @@ function main(): void {
     baseUrl,
     sourceDir: relativeFile(args.source),
     outDir: relativeFile(args.out),
+    historyPath: "qa/history.json",
     reports: reports.map((report) => ({
       slug: report.slug,
       status: report.data.status,
@@ -615,8 +795,14 @@ function main(): void {
       stableAnnotationUrl: report.stableAnnotationUrl,
       stableScreenshotUrl: report.stableScreenshotUrl,
       stableVisualUrl: report.stableVisualUrl,
+      visualRiskScore: report.visualRiskScore,
+      visualRiskLevel: report.visualRiskLevel,
+      imageDiffScore: report.imageDiffScore,
+      baselineAgeDays: report.baselineAgeDays,
+      staleBaseline: report.staleBaseline,
     })),
   };
+  fs.writeFileSync(path.join(args.out, "qa", "history.json"), JSON.stringify(buildVisualHistory(reports), null, 2));
   fs.writeFileSync(path.join(args.out, "manifest.json"), JSON.stringify(manifest, null, 2));
   fs.writeFileSync(path.join(args.out, ".nojekyll"), "");
 

--- a/scripts/ship-branch.ts
+++ b/scripts/ship-branch.ts
@@ -210,6 +210,12 @@ interface DeployReportSummary {
   recommendation?: string;
   artifactRoot?: string;
   screenshotManifest?: string;
+  visualRisk?: {
+    score?: number;
+    level?: string;
+    staleBaselines?: number;
+    topDrivers?: string[];
+  };
   pathResults?: DeployPathResult[];
   qa?: DeployQaReport;
 }
@@ -235,6 +241,9 @@ interface VerificationSummary {
   session: string;
   status: string;
   healthScore: number | null;
+  visualRiskScore: number | null;
+  visualRiskLevel: string;
+  staleBaselines: number;
   consoleErrors: number;
   reportPath: string;
   stableReportUrl: string;
@@ -1143,6 +1152,7 @@ function buildDeployPrComment({
     "",
     `- Status: ${report.status}`,
     `- Health score: ${report.qa?.healthScore ?? "n/a"}`,
+    report.visualRisk?.level ? `- Visual risk: ${String(report.visualRisk.level).toUpperCase()} (${report.visualRisk?.score ?? "n/a"}/100)` : "",
     `- Recommendation: ${report.recommendation || report.qa?.recommendation || "n/a"}`,
     "",
     "### Findings",
@@ -1157,6 +1167,15 @@ function buildDeployPrComment({
     "",
     ...flowLines,
   ];
+
+  if (report.visualRisk?.topDrivers?.length) {
+    sections.push(
+      "",
+      "### Visual risk drivers",
+      "",
+      ...report.visualRisk.topDrivers.map((item) => `- ${item}`),
+    );
+  }
 
   if (report.qa?.snapshotResults?.length) {
     sections.push(
@@ -1244,6 +1263,12 @@ function printText(result: ShipResult): void {
   if (result.verification.healthScore !== null) {
     console.log(`- Verification health score: ${result.verification.healthScore}`);
   }
+  if (result.verification.visualRiskLevel) {
+    console.log(`- Verification visual risk: ${result.verification.visualRiskLevel.toUpperCase()} (${result.verification.visualRiskScore ?? "n/a"}/100)`);
+  }
+  if (result.verification.staleBaselines) {
+    console.log(`- Verification stale baselines: ${result.verification.staleBaselines}`);
+  }
   if (result.verification.consoleErrors) {
     console.log(`- Verification console errors: ${result.verification.consoleErrors}`);
   }
@@ -1297,6 +1322,9 @@ const result: ShipResult = {
     session: cleanSubject(args.verifySession),
     status: "",
     healthScore: null,
+    visualRiskScore: null,
+    visualRiskLevel: "",
+    staleBaselines: 0,
     consoleErrors: 0,
     reportPath: "",
     stableReportUrl: "",
@@ -1409,6 +1437,9 @@ if (shouldRunVerification(args)) {
     }
     result.verification.status = verification.report.status || "";
     result.verification.healthScore = verification.report.qa?.healthScore ?? null;
+    result.verification.visualRiskScore = typeof verification.report.visualRisk?.score === "number" ? verification.report.visualRisk.score : null;
+    result.verification.visualRiskLevel = String(verification.report.visualRisk?.level || "");
+    result.verification.staleBaselines = Number(verification.report.visualRisk?.staleBaselines || 0);
     result.verification.consoleErrors = (verification.report.pathResults || []).reduce((count: number, entry: DeployPathResult) => (
       count + (Array.isArray(entry.console?.errors) ? entry.console?.errors.length : 0)
     ), 0);

--- a/scripts/visual-risk.ts
+++ b/scripts/visual-risk.ts
@@ -1,0 +1,172 @@
+#!/usr/bin/env bun
+
+export type VisualRiskLevel = "none" | "low" | "medium" | "high" | "critical";
+
+export interface BaselineFreshness {
+  snapshot: string;
+  routePath: string;
+  device: string;
+  capturedAt: string;
+  ageDays: number;
+  stale: boolean;
+  staleAfterDays: number;
+}
+
+export interface VisualRiskSummary {
+  available: boolean;
+  score: number;
+  level: VisualRiskLevel;
+  summary: string;
+  criticalChecks: number;
+  warningChecks: number;
+  consoleErrors: number;
+  changedSnapshots: number;
+  staleBaselines: number;
+  avgImageDiffScore: number | null;
+  topDrivers: string[];
+}
+
+interface VisualPathResult {
+  status?: string;
+  path?: string;
+  device?: string;
+  console?: {
+    errors?: string[];
+    warnings?: string[];
+  };
+}
+
+interface VisualSnapshotResult {
+  name?: string;
+  status?: string;
+  targetPath?: string;
+  device?: string;
+  visualPack?: {
+    imageDiff?: {
+      score?: number;
+    } | null;
+  } | null;
+  baselineFreshness?: BaselineFreshness | null;
+}
+
+interface VisualRiskInput {
+  pathResults?: VisualPathResult[];
+  snapshotResults?: VisualSnapshotResult[];
+}
+
+export const DEFAULT_STALE_BASELINE_DAYS = 30;
+
+function round(value: number): number {
+  return Number.isFinite(value) ? Math.round(value * 10) / 10 : 0;
+}
+
+function cleanSubject(value: unknown): string {
+  return String(value || "").replace(/\s+/g, " ").trim();
+}
+
+export function computeBaselineFreshness({
+  snapshot,
+  routePath,
+  device,
+  capturedAt,
+  staleAfterDays = DEFAULT_STALE_BASELINE_DAYS,
+  now = new Date(),
+}: {
+  snapshot: string;
+  routePath?: string;
+  device?: string;
+  capturedAt?: string;
+  staleAfterDays?: number;
+  now?: Date;
+}): BaselineFreshness | null {
+  const captured = cleanSubject(capturedAt);
+  if (!captured) return null;
+  const capturedMillis = Date.parse(captured);
+  if (!Number.isFinite(capturedMillis)) return null;
+  const ageDays = round((now.getTime() - capturedMillis) / 86_400_000);
+  const threshold = staleAfterDays > 0 ? staleAfterDays : DEFAULT_STALE_BASELINE_DAYS;
+  return {
+    snapshot: cleanSubject(snapshot || "snapshot") || "snapshot",
+    routePath: cleanSubject(routePath || "/") || "/",
+    device: cleanSubject(device || "desktop") || "desktop",
+    capturedAt: new Date(capturedMillis).toISOString(),
+    ageDays: Math.max(0, ageDays),
+    stale: ageDays >= threshold,
+    staleAfterDays: threshold,
+  };
+}
+
+function buildDrivers(parts: Array<{ label: string; weight: number }>): string[] {
+  return parts
+    .filter((item) => item.weight > 0)
+    .sort((left, right) => right.weight - left.weight || left.label.localeCompare(right.label))
+    .slice(0, 4)
+    .map((item) => item.label);
+}
+
+export function computeVisualRisk({ pathResults = [], snapshotResults = [] }: VisualRiskInput): VisualRiskSummary {
+  const criticalChecks = pathResults.filter((item) => ["critical", "error"].includes(cleanSubject(item.status).toLowerCase())).length;
+  const warningChecks = pathResults.filter((item) => cleanSubject(item.status).toLowerCase() === "warning").length;
+  const consoleErrors = pathResults.reduce((count, item) => (
+    count + (Array.isArray(item.console?.errors) ? item.console?.errors.length : 0)
+  ), 0);
+  const changedSnapshots = snapshotResults.filter((item) => {
+    const status = cleanSubject(item.status).toLowerCase();
+    return Boolean(status) && !["pass", "match", "ok"].includes(status);
+  }).length;
+  const staleBaselines = snapshotResults.filter((item) => item.baselineFreshness?.stale).length;
+  const imageScores = snapshotResults
+    .map((item) => item.visualPack?.imageDiff?.score)
+    .filter((item): item is number => typeof item === "number" && Number.isFinite(item));
+  const avgImageDiffScore = imageScores.length
+    ? round(imageScores.reduce((sum, item) => sum + item, 0) / imageScores.length)
+    : null;
+
+  const score = Math.min(
+    100,
+    round(
+      (criticalChecks * 30)
+      + (warningChecks * 12)
+      + (Math.min(consoleErrors, 5) * 6)
+      + (changedSnapshots * 8)
+      + (staleBaselines * 6)
+      + (avgImageDiffScore === null ? 0 : Math.max(0, 100 - avgImageDiffScore) * 0.35),
+    ),
+  );
+
+  let level: VisualRiskLevel = "none";
+  if (criticalChecks > 0 || score >= 80) level = "critical";
+  else if (score >= 55) level = "high";
+  else if (score >= 25) level = "medium";
+  else if (score > 0) level = "low";
+
+  const topDrivers = buildDrivers([
+    { label: `${criticalChecks} critical page/device check${criticalChecks === 1 ? "" : "s"}`, weight: criticalChecks * 30 },
+    { label: `${warningChecks} warning page/device check${warningChecks === 1 ? "" : "s"}`, weight: warningChecks * 12 },
+    { label: `${consoleErrors} console error${consoleErrors === 1 ? "" : "s"}`, weight: Math.min(consoleErrors, 5) * 6 },
+    { label: `${changedSnapshots} changed snapshot${changedSnapshots === 1 ? "" : "s"}`, weight: changedSnapshots * 8 },
+    { label: `${staleBaselines} stale baseline${staleBaselines === 1 ? "" : "s"}`, weight: staleBaselines * 6 },
+    { label: `avg image diff score ${avgImageDiffScore}`, weight: avgImageDiffScore === null ? 0 : Math.max(0, 100 - avgImageDiffScore) * 0.35 },
+  ]);
+
+  const available = Boolean(pathResults.length || snapshotResults.length);
+  const summary = !available
+    ? "No visual evidence collected yet."
+    : level === "none"
+      ? "Visual checks are clean."
+      : `${level.toUpperCase()} visual risk (${score}/100): ${topDrivers.join("; ") || "review the visual evidence."}`;
+
+  return {
+    available,
+    score,
+    level,
+    summary,
+    criticalChecks,
+    warningChecks,
+    consoleErrors,
+    changedSnapshots,
+    staleBaselines,
+    avgImageDiffScore,
+    topDrivers,
+  };
+}


### PR DESCRIPTION
## Summary
- add shared visual-risk scoring and stale-baseline detection across QA, deploy, preview, ship, and PR review output
- add route/device metadata to snapshot baselines plus visual history charts for the QA Pages site
- add regression coverage for QA risk scoring, deploy/preview propagation, PR review rendering, and QA Pages history output

## Validation
- bun run typecheck
- bun run smoke
