### PR TITLE
feat: add accessibility and performance QA

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Use the repo in this order:
 - Checked-in and local browser flows with import/export for JSON, YAML, and Markdown
 - Page snapshots and snapshot comparison artifacts with self-contained visual packs, diff heatmaps, and image-diff scores
 - QA reports with typed categories, severity, health score, diff-aware route inference, stale-baseline detection, visual-risk scoring, saved evidence, annotated screenshots, and published visual packs for snapshot failures
+- Opt-in accessibility scans and performance budget checks that feed the same QA, preview, deploy, ship, PR review, and Pages report surfaces
 - Historical QA trend artifacts under `.codex-stack/qa/trends.json` and `.codex-stack/qa/trends.md`
 - Preview verification with URL template resolution, readiness polling, deploy/page verification, QA execution, and PR comment output for preview deployments
 - Deploy verification with page and device matrices, screenshot manifests, console capture, tracked evidence, and `visual/index.html` review packs with ranked regressions plus a consolidated visual-risk score
@@ -166,15 +167,18 @@ bun src/cli.ts list
 bun src/cli.ts show qa
 bun src/cli.ts review --json --base origin/main
 bun src/cli.ts qa http://127.0.0.1:4173/dashboard --flow portal-dashboard --snapshot portal-dashboard --session demo --json
+bun src/cli.ts qa http://127.0.0.1:4173/dashboard --flow portal-dashboard --snapshot portal-dashboard --a11y --a11y-scope main --perf --perf-budget lcp=2s --perf-budget cls=0.1 --session demo --json
 bun src/cli.ts qa https://preview.example.com --mode diff-aware --base-ref origin/main --session preview --json
 bun src/cli.ts qa https://preview.example.com/dashboard --flow portal-dashboard --session preview-auth --session-bundle .codex-stack/private/preview-auth.json --json
 bun src/cli.ts preview --url "https://anup4khandelwal.github.io/codex-stack/pr-preview/pr-42/" --pr 42 --branch feat/42-preview --sha abcdef123 --path /login --path /dashboard --device desktop --device mobile --flow portal-full-demo
 bun src/cli.ts preview --url-template "https://preview-{pr}.example.com" --pr 42 --branch feat/42-preview --sha abcdef123 --path / --path /dashboard --device desktop --device mobile --flow landing-smoke --snapshot landing-home
 bun src/cli.ts preview --url "https://anup4khandelwal.github.io/codex-stack/pr-preview/pr-42/" --pr 42 --branch feat/42-preview --sha abcdef123 --path /dashboard --device desktop --flow portal-dashboard --session preview-auth --session-bundle .codex-stack/private/preview-auth.json
 bun src/cli.ts deploy --url https://staging.example.com --path / --path /dashboard --device desktop --device mobile --flow portal-dashboard --snapshot portal-dashboard
+bun src/cli.ts deploy --url https://staging.example.com --path /dashboard --device desktop --flow portal-dashboard --snapshot portal-dashboard --a11y --a11y-scope main --perf --perf-budget lcp=2s --perf-budget cls=0.1
 bun src/cli.ts deploy --url https://staging.example.com --path /dashboard --device desktop --flow portal-dashboard --session staging-auth --session-bundle .codex-stack/private/staging-auth.json
 bun src/cli.ts ship --message "feat: ready for review" --push --pr --reviewer octocat --assignee @me --project "Engineering Roadmap"
 bun src/cli.ts ship --dry-run --pr --verify-url http://127.0.0.1:4173 --verify-path /dashboard --verify-device mobile --verify-console-errors --verify-flow portal-dashboard --verify-snapshot portal-dashboard
+bun src/cli.ts ship --dry-run --pr --verify-url http://127.0.0.1:4173 --verify-path /dashboard --verify-device mobile --verify-flow portal-dashboard --verify-snapshot portal-dashboard --verify-a11y --verify-a11y-scope main --verify-perf --verify-perf-budget lcp=2s
 bun src/cli.ts retro --since "7 days ago" --repo anup4khandelwal/codex-stack
 bun src/cli.ts upgrade --offline --json
 bun src/cli.ts upgrade --offline --apply
@@ -242,6 +246,7 @@ Use `qa` when you want a decision-ready report:
 - findings with category + evidence
 - diff-aware route inference from changed files
 - annotated SVG evidence for snapshot-based failures
+- optional accessibility and performance findings with dedicated artifacts and markdown summaries
 - saved markdown/json report under `.codex-stack/qa/`
 - automatic trend summaries across saved QA runs
 
@@ -261,7 +266,11 @@ bun src/cli.ts preview \
   --path /dashboard \
   --device desktop \
   --device mobile \
-  --flow portal-full-demo
+  --flow portal-full-demo \
+  --a11y \
+  --a11y-scope main \
+  --perf \
+  --perf-budget lcp=2s
 ```
 
 For same-repo PRs, `pr-review.yml` publishes this preview site automatically to GitHub Pages before it verifies the deployment. `preview-verify.yml` remains available as a manual rerun or for external preview URLs.
@@ -298,7 +307,11 @@ bun src/cli.ts ship \
   --pr \
   --verify-url https://staging.example.com/dashboard \
   --verify-flow landing-smoke \
-  --verify-snapshot landing-home
+  --verify-snapshot landing-home \
+  --verify-a11y \
+  --verify-a11y-scope main \
+  --verify-perf \
+  --verify-perf-budget lcp=2s
 ```
 
 This keeps QA in the shipping path instead of as a manual follow-up.
@@ -347,6 +360,7 @@ On GitHub, `.github/workflows/qa-pages.yml` deploys the merged `docs/qa/` report
 When a published QA report includes snapshot evidence, the Pages site now surfaces `visual/index.html` as the primary review-evidence entrypoint alongside the raw markdown, JSON, annotation, and screenshot files.
 Those visual packs now include a diff heatmap and an image-diff score so regressions can be ranked instead of treated as binary drift only.
 The merged QA Pages site also renders visual history charts for risk score, image-diff score, and baseline age so drift over time is visible without opening each report one by one.
+When a report includes accessibility or performance data, the Pages site also exposes the latest violation counts, perf-budget failures, LCP/CLS summaries, and matching history charts.
 Snapshot baselines now carry route and device metadata, and QA/deploy/preview runs flag stale baselines automatically when the saved reference is too old.
 
 The same `gh-pages` branch also hosts PR previews under `pr-preview/pr-<number>/`. Configure these repo variables if you want richer automatic preview coverage in `pr-review.yml`:

--- a/browse/src/cli.ts
+++ b/browse/src/cli.ts
@@ -17,6 +17,16 @@ import {
   type SessionOriginState,
   type SessionStorageEntry,
 } from "./session-bundle.ts";
+import {
+  parseAccessibilityImpact,
+  parsePerformanceBudget,
+  runAccessibilityAudit,
+  runPerformanceAudit,
+  type AccessibilityAuditResult,
+  type AccessibilityImpact,
+  type PerformanceAuditResult,
+  type PerformanceBudget,
+} from "./page-insights.ts";
 
 type FlowFormat = "json" | "yaml" | "markdown";
 type FlowSource = "local" | "repo";
@@ -29,6 +39,10 @@ type PlaywrightPage = {
 } & Record<string, any>;
 type PlaywrightContext = Record<string, any>;
 type StepResult = Record<string, unknown>;
+
+function cleanSubject(value: unknown): string {
+  return String(value || "").replace(/\s+/g, " ").trim();
+}
 
 interface SessionState {
   name: string;
@@ -168,6 +182,18 @@ interface ProbeResult {
   bodyLength: number;
 }
 
+interface AccessibilityCommandArgs {
+  url: string;
+  scopeSelectors: string[];
+  minimumImpact: AccessibilityImpact;
+}
+
+interface PerformanceCommandArgs {
+  url: string;
+  waitMs: number;
+  budgetSpecs: string[];
+}
+
 type WaitState = "visible" | "hidden" | "attached" | "detached";
 type LoadState = "load" | "domcontentloaded" | "networkidle" | "commit";
 type DevicePresetName = "desktop" | "tablet" | "mobile";
@@ -222,6 +248,8 @@ Usage:
   codex-stack browse snapshot <url> [name] [--session <name>] [--device <desktop|tablet|mobile>]
   codex-stack browse compare-snapshot <url> <name> [--session <name>] [--device <desktop|tablet|mobile>]
   codex-stack browse probe <url> [--session <name>] [--device <desktop|tablet|mobile>]
+  codex-stack browse a11y <url> [--scope <selector>] [--impact <critical|serious|moderate|minor>] [--session <name>] [--device <desktop|tablet|mobile>]
+  codex-stack browse perf <url> [--budget <metric=value>] [--wait-ms <n>] [--session <name>] [--device <desktop|tablet|mobile>]
   codex-stack browse text <url> [--session <name>] [--device <desktop|tablet|mobile>]
   codex-stack browse html <url> [selector] [--session <name>] [--device <desktop|tablet|mobile>]
   codex-stack browse links <url> [--session <name>] [--device <desktop|tablet|mobile>]
@@ -760,6 +788,49 @@ function parseGlobalArgs(argv: string[]): ParsedGlobalArgs {
     }
   }
   return out;
+}
+
+function takeOptionValues(args: string[], flag: string): string[] {
+  const values: string[] = [];
+  for (let index = 0; index < args.length; index += 1) {
+    if (args[index] !== flag) continue;
+    values.push(String(args[index + 1] || ""));
+    args.splice(index, 2);
+    index -= 1;
+  }
+  return values.map((item) => cleanSubject(item)).filter(Boolean);
+}
+
+function takeSingleOption(args: string[], flag: string): string {
+  const values = takeOptionValues(args, flag);
+  return values.length ? values[values.length - 1] : "";
+}
+
+function parseAccessibilityArgs(rest: string[]): AccessibilityCommandArgs {
+  const args = [...rest];
+  const url = cleanSubject(args.shift() || "");
+  if (!url) usage();
+  const scopeSelectors = takeOptionValues(args, "--scope");
+  const minimumImpact = parseAccessibilityImpact(takeSingleOption(args, "--impact") || "serious");
+  return {
+    url,
+    scopeSelectors,
+    minimumImpact,
+  };
+}
+
+function parsePerformanceArgs(rest: string[]): PerformanceCommandArgs {
+  const args = [...rest];
+  const url = cleanSubject(args.shift() || "");
+  if (!url) usage();
+  const budgetSpecs = takeOptionValues(args, "--budget");
+  const waitRaw = takeSingleOption(args, "--wait-ms");
+  const parsedWait = Number.parseInt(waitRaw || "", 10);
+  return {
+    url,
+    waitMs: Number.isFinite(parsedWait) && parsedWait >= 0 ? parsedWait : 250,
+    budgetSpecs,
+  };
 }
 
 function parseFlow(jsonText: string): FlowStep[] | null {
@@ -1907,7 +1978,7 @@ async function main(): Promise<void> {
     console.log(`- snapshot root: ${SNAPSHOT_DIR}`);
     console.log(`- artifact root: ${ARTIFACT_DIR}`);
     console.log("- session model: persistent browser profile per named session");
-    console.log("- commands: sessions, flows, save-flow, save-repo-flow, import-flow, import-repo-flow, export-flow, show-flow, delete-flow, clear-session, export-session, import-session, import-cookies, import-browser-cookies, snapshot, compare-snapshot, probe, text, html, links, screenshot, eval, click, fill, upload, dialog, wait, press, assert-visible, assert-hidden, assert-enabled, assert-disabled, assert-checked, assert-editable, assert-focused, assert-text, assert-url, assert-count, flow, run-flow, login");
+    console.log("- commands: sessions, flows, save-flow, save-repo-flow, import-flow, import-repo-flow, export-flow, show-flow, delete-flow, clear-session, export-session, import-session, import-cookies, import-browser-cookies, snapshot, compare-snapshot, probe, a11y, perf, text, html, links, screenshot, eval, click, fill, upload, dialog, wait, press, assert-visible, assert-hidden, assert-enabled, assert-disabled, assert-checked, assert-editable, assert-focused, assert-text, assert-url, assert-count, flow, run-flow, login");
     console.log(`- repo flow root: ${REPO_FLOW_DIR}`);
     console.log("- flow search order: local .codex-stack flow overrides checked-in repo flow with the same name");
     console.log("- interchange formats: json, yaml, markdown (fenced yaml/json)");
@@ -2203,6 +2274,45 @@ async function main(): Promise<void> {
       };
     });
     recordSession(session, { lastCommand: "probe", lastUrl: url, output: `${result.status ?? "n/a"}:${result.bodyLength}` });
+    printJson(result);
+    return;
+  }
+
+  if (command === "a11y") {
+    const parsedArgs = parseAccessibilityArgs(rest);
+    const result = await withPage(session, parsedArgs.url, device, async ({ page }) => (
+      runAccessibilityAudit({
+        page: page as any,
+        url: parsedArgs.url,
+        scopeSelectors: parsedArgs.scopeSelectors,
+        minimumImpact: parsedArgs.minimumImpact,
+      })
+    ));
+    recordSession(session, {
+      lastCommand: "a11y",
+      lastUrl: parsedArgs.url,
+      output: `${result.violationCount} violations`,
+    });
+    printJson(result);
+    return;
+  }
+
+  if (command === "perf") {
+    const parsedArgs = parsePerformanceArgs(rest);
+    const budgets: PerformanceBudget[] = parsedArgs.budgetSpecs.map((item) => parsePerformanceBudget(item));
+    const result = await withPage(session, "", device, async ({ page }) => (
+      runPerformanceAudit({
+        page: page as any,
+        url: parsedArgs.url,
+        waitMs: parsedArgs.waitMs,
+        budgets,
+      })
+    ));
+    recordSession(session, {
+      lastCommand: "perf",
+      lastUrl: parsedArgs.url,
+      output: `${result.budgetViolationCount} perf budget violations`,
+    });
     printJson(result);
     return;
   }

--- a/browse/src/page-insights.ts
+++ b/browse/src/page-insights.ts
@@ -1,0 +1,456 @@
+export type AccessibilityImpact = "critical" | "serious" | "moderate" | "minor";
+export type PerformanceMetricName =
+  | "ttfb"
+  | "domContentLoaded"
+  | "loadEvent"
+  | "fcp"
+  | "lcp"
+  | "cls"
+  | "jsHeapUsed"
+  | "resourceCount"
+  | "failedResourceCount";
+
+export interface AccessibilityViolation {
+  id: string;
+  impact: string;
+  description: string;
+  help: string;
+  helpUrl: string;
+  selectors: string[];
+  nodeCount: number;
+}
+
+export interface AccessibilityAuditResult {
+  url: string;
+  finalUrl: string;
+  title: string;
+  minimumImpact: AccessibilityImpact;
+  scopeSelectors: string[];
+  violationCount: number;
+  passCount: number;
+  incompleteCount: number;
+  topRules: string[];
+  violations: AccessibilityViolation[];
+  status: "pass" | "warning";
+}
+
+export interface PerformanceBudget {
+  metric: PerformanceMetricName;
+  label: string;
+  threshold: number;
+  unit: string;
+  severity: "high" | "medium";
+  raw: string;
+}
+
+export interface PerformanceBudgetResult extends PerformanceBudget {
+  value: number | null;
+  passed: boolean;
+  detail: string;
+}
+
+export interface PerformanceMetrics {
+  ttfb: number | null;
+  domContentLoaded: number | null;
+  loadEvent: number | null;
+  fcp: number | null;
+  lcp: number | null;
+  cls: number | null;
+  jsHeapUsed: number | null;
+  resourceCount: number;
+  failedResourceCount: number;
+}
+
+export interface PerformanceAuditResult {
+  url: string;
+  finalUrl: string;
+  title: string;
+  waitMs: number;
+  metrics: PerformanceMetrics;
+  budgets: PerformanceBudgetResult[];
+  budgetViolationCount: number;
+  topViolations: string[];
+  status: "pass" | "warning";
+}
+
+interface RawAxeViolation {
+  id?: string;
+  impact?: string;
+  description?: string;
+  help?: string;
+  helpUrl?: string;
+  nodes?: Array<{ target?: string[] }>;
+}
+
+interface RawAxeResult {
+  violations?: RawAxeViolation[];
+  passes?: unknown[];
+  incomplete?: unknown[];
+}
+
+interface RawPerfResult {
+  finalUrl?: string;
+  title?: string;
+  ttfb?: number | null;
+  domContentLoaded?: number | null;
+  loadEvent?: number | null;
+  fcp?: number | null;
+  lcp?: number | null;
+  cls?: number | null;
+  jsHeapUsed?: number | null;
+  resourceCount?: number;
+}
+
+interface PlaywrightPage {
+  addScriptTag(options: { content: string }): Promise<unknown>;
+  addInitScript?(script: () => void): Promise<unknown>;
+  evaluateOnNewDocument?(script: () => void): Promise<unknown>;
+  goto(url: string, options?: Record<string, unknown>): Promise<unknown>;
+  waitForTimeout(timeout: number): Promise<unknown>;
+  on(event: string, listener: (...args: any[]) => unknown): void;
+  evaluate<TResult>(pageFunction: () => TResult): Promise<TResult>;
+  evaluate<TArg, TResult>(pageFunction: (arg: TArg) => TResult, arg: TArg): Promise<TResult>;
+}
+
+const IMPACT_ORDER: AccessibilityImpact[] = ["minor", "moderate", "serious", "critical"];
+
+function cleanSubject(value: unknown): string {
+  return String(value || "").replace(/\s+/g, " ").trim();
+}
+
+function asNumber(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function impactRank(value: string): number {
+  const index = IMPACT_ORDER.indexOf(parseAccessibilityImpact(value));
+  return index >= 0 ? index : 0;
+}
+
+export function parseAccessibilityImpact(value: unknown): AccessibilityImpact {
+  const normalized = cleanSubject(value).toLowerCase();
+  if (normalized === "critical" || normalized === "serious" || normalized === "moderate" || normalized === "minor") {
+    return normalized;
+  }
+  return "serious";
+}
+
+function normalizeMetricName(value: string): PerformanceMetricName {
+  const normalized = cleanSubject(value).toLowerCase();
+  if (normalized === "ttfb") return "ttfb";
+  if (normalized === "domcontentloaded" || normalized === "dcl" || normalized === "dom_content_loaded") return "domContentLoaded";
+  if (normalized === "loadevent" || normalized === "load" || normalized === "load_event") return "loadEvent";
+  if (normalized === "fcp" || normalized === "firstcontentfulpaint") return "fcp";
+  if (normalized === "lcp" || normalized === "largestcontentfulpaint") return "lcp";
+  if (normalized === "cls") return "cls";
+  if (normalized === "jsheapused" || normalized === "heap" || normalized === "usedjsheap") return "jsHeapUsed";
+  if (normalized === "resourcecount" || normalized === "resources") return "resourceCount";
+  if (normalized === "failedresourcecount" || normalized === "failedresources") return "failedResourceCount";
+  throw new Error(`Unknown performance metric: ${JSON.stringify(value)}.`);
+}
+
+function metricLabel(metric: PerformanceMetricName): string {
+  if (metric === "ttfb") return "TTFB";
+  if (metric === "domContentLoaded") return "DOMContentLoaded";
+  if (metric === "loadEvent") return "Load event";
+  if (metric === "fcp") return "FCP";
+  if (metric === "lcp") return "LCP";
+  if (metric === "cls") return "CLS";
+  if (metric === "jsHeapUsed") return "JS heap used";
+  if (metric === "resourceCount") return "Resource count";
+  return "Failed resource count";
+}
+
+function metricSeverity(metric: PerformanceMetricName): "high" | "medium" {
+  return metric === "lcp" || metric === "cls" || metric === "failedResourceCount" ? "high" : "medium";
+}
+
+function metricUnit(metric: PerformanceMetricName): string {
+  if (metric === "cls" || metric === "resourceCount" || metric === "failedResourceCount") return "";
+  if (metric === "jsHeapUsed") return "bytes";
+  return "ms";
+}
+
+function parseThreshold(raw: string, metric: PerformanceMetricName): { value: number; unit: string } {
+  const trimmed = cleanSubject(raw).toLowerCase();
+  if (!trimmed) {
+    throw new Error(`Missing threshold for ${metricLabel(metric)}.`);
+  }
+
+  if (metric === "cls" || metric === "resourceCount" || metric === "failedResourceCount") {
+    const numeric = Number.parseFloat(trimmed);
+    if (!Number.isFinite(numeric)) throw new Error(`Invalid threshold ${JSON.stringify(raw)} for ${metricLabel(metric)}.`);
+    return { value: numeric, unit: "" };
+  }
+
+  if (metric === "jsHeapUsed") {
+    const match = trimmed.match(/^([0-9]*\.?[0-9]+)\s*(b|kb|mb|gb)?$/);
+    if (!match) throw new Error(`Invalid heap threshold ${JSON.stringify(raw)}.`);
+    const numeric = Number.parseFloat(match[1]);
+    const unit = match[2] || "b";
+    const multiplier = unit === "gb" ? 1024 ** 3 : unit === "mb" ? 1024 ** 2 : unit === "kb" ? 1024 : 1;
+    return { value: numeric * multiplier, unit: "bytes" };
+  }
+
+  const match = trimmed.match(/^([0-9]*\.?[0-9]+)\s*(ms|s)?$/);
+  if (!match) throw new Error(`Invalid timing threshold ${JSON.stringify(raw)} for ${metricLabel(metric)}.`);
+  const numeric = Number.parseFloat(match[1]);
+  const unit = match[2] || "ms";
+  return { value: unit === "s" ? numeric * 1000 : numeric, unit: "ms" };
+}
+
+export function parsePerformanceBudget(raw: string): PerformanceBudget {
+  const input = cleanSubject(raw);
+  const separator = input.indexOf("=");
+  if (separator === -1) {
+    throw new Error(`Performance budgets must use metric=value format. Received ${JSON.stringify(raw)}.`);
+  }
+  const metric = normalizeMetricName(input.slice(0, separator));
+  const thresholdRaw = input.slice(separator + 1);
+  const threshold = parseThreshold(thresholdRaw, metric);
+  return {
+    metric,
+    label: metricLabel(metric),
+    threshold: threshold.value,
+    unit: threshold.unit || metricUnit(metric),
+    severity: metricSeverity(metric),
+    raw: input,
+  };
+}
+
+function formatMetricValue(metric: PerformanceMetricName, value: number | null): string {
+  if (value === null || !Number.isFinite(value)) return "n/a";
+  if (metric === "cls") return String(Number(value.toFixed(3)));
+  if (metric === "jsHeapUsed") {
+    if (value >= 1024 ** 2) return `${Number((value / (1024 ** 2)).toFixed(2))} MB`;
+    if (value >= 1024) return `${Number((value / 1024).toFixed(1))} KB`;
+    return `${Math.round(value)} B`;
+  }
+  if (metric === "resourceCount" || metric === "failedResourceCount") return String(Math.round(value));
+  return `${Math.round(value)} ms`;
+}
+
+async function loadAxeSource(): Promise<string> {
+  if (process.env.CODEX_STACK_AXE_SOURCE) return process.env.CODEX_STACK_AXE_SOURCE;
+  const mod = await import("axe-core");
+  const source = String((mod as { source?: string; default?: { source?: string } }).source || (mod as { default?: { source?: string } }).default?.source || "");
+  if (!source) {
+    throw new Error("Unable to load axe-core source.");
+  }
+  return source;
+}
+
+export async function runAccessibilityAudit({
+  page,
+  url,
+  scopeSelectors,
+  minimumImpact,
+}: {
+  page: PlaywrightPage;
+  url: string;
+  scopeSelectors: string[];
+  minimumImpact: AccessibilityImpact;
+}): Promise<AccessibilityAuditResult> {
+  const axeSource = await loadAxeSource();
+  await page.addScriptTag({ content: axeSource });
+  const raw = await page.evaluate(
+    async ({ selectors, impact, marker }) => {
+      const axe = (window as Window & { axe?: { run: (context?: unknown, options?: unknown) => Promise<RawAxeResult> } }).axe;
+      if (!axe?.run) {
+        throw new Error(`${marker}: axe.run is unavailable on the page.`);
+      }
+      const context = Array.isArray(selectors) && selectors.length
+        ? { include: selectors.map((selector) => [selector]) }
+        : document;
+      const results = await axe.run(context, {});
+      return {
+        finalUrl: window.location.href,
+        title: document.title,
+        violations: Array.isArray(results.violations) ? results.violations : [],
+        passesCount: Array.isArray(results.passes) ? results.passes.length : 0,
+        incompleteCount: Array.isArray(results.incomplete) ? results.incomplete.length : 0,
+        minimumImpact: impact,
+      };
+    },
+    {
+      selectors: scopeSelectors,
+      impact: minimumImpact,
+      marker: "codex-stack-a11y",
+    },
+  ) as {
+    finalUrl?: string;
+    title?: string;
+    violations?: RawAxeViolation[];
+    passesCount?: number;
+    incompleteCount?: number;
+    minimumImpact?: string;
+  };
+
+  const filteredViolations = (Array.isArray(raw.violations) ? raw.violations : [])
+    .filter((item) => impactRank(cleanSubject(item.impact || "minor")) >= impactRank(minimumImpact))
+    .map((item) => {
+      const selectors = [...new Set((Array.isArray(item.nodes) ? item.nodes : []).flatMap((node) => Array.isArray(node.target) ? node.target.map((target) => cleanSubject(target)) : []).filter(Boolean))];
+      return {
+        id: cleanSubject(item.id),
+        impact: cleanSubject(item.impact || "unknown") || "unknown",
+        description: cleanSubject(item.description || item.help || ""),
+        help: cleanSubject(item.help || item.id || "Accessibility violation"),
+        helpUrl: cleanSubject(item.helpUrl || ""),
+        selectors,
+        nodeCount: Array.isArray(item.nodes) ? item.nodes.length : selectors.length,
+      } satisfies AccessibilityViolation;
+    });
+
+  const topRules = filteredViolations
+    .map((item) => `${item.id || item.help}${item.nodeCount ? ` (${item.nodeCount})` : ""}`)
+    .slice(0, 5);
+
+  return {
+    url,
+    finalUrl: cleanSubject(raw.finalUrl || url) || url,
+    title: cleanSubject(raw.title || ""),
+    minimumImpact,
+    scopeSelectors,
+    violationCount: filteredViolations.length,
+    passCount: typeof raw.passesCount === "number" ? raw.passesCount : 0,
+    incompleteCount: typeof raw.incompleteCount === "number" ? raw.incompleteCount : 0,
+    topRules,
+    violations: filteredViolations,
+    status: filteredViolations.length ? "warning" : "pass",
+  };
+}
+
+export async function runPerformanceAudit({
+  page,
+  url,
+  waitMs,
+  budgets,
+}: {
+  page: PlaywrightPage;
+  url: string;
+  waitMs: number;
+  budgets: PerformanceBudget[];
+}): Promise<PerformanceAuditResult> {
+  const failedRequests: string[] = [];
+  page.on("requestfailed", (request: { url?: () => string } | Record<string, unknown>) => {
+    const value = typeof request?.url === "function" ? cleanSubject(request.url()) : "";
+    if (value) failedRequests.push(value);
+  });
+
+  const installInitScript = page.addInitScript || page.evaluateOnNewDocument;
+  if (!installInitScript) {
+    throw new Error("The current Playwright page implementation does not support init script injection.");
+  }
+
+  await installInitScript.call(page, () => {
+    const state = {
+      lcp: null as number | null,
+      cls: 0,
+      fcp: null as number | null,
+    };
+    (window as Window & { __codexStackPerf?: typeof state }).__codexStackPerf = state;
+    try {
+      const lcpObserver = new PerformanceObserver((entryList) => {
+        const entries = entryList.getEntries();
+        const last = entries[entries.length - 1] as PerformanceEntry | undefined;
+        if (!last) return;
+        const candidate = Number((last as PerformanceEntry & { renderTime?: number; loadTime?: number }).renderTime || (last as PerformanceEntry & { loadTime?: number }).loadTime || last.startTime || 0);
+        if (Number.isFinite(candidate) && candidate >= 0) {
+          state.lcp = candidate;
+        }
+      });
+      lcpObserver.observe({ type: "largest-contentful-paint", buffered: true });
+    } catch {}
+    try {
+      const clsObserver = new PerformanceObserver((entryList) => {
+        for (const entry of entryList.getEntries()) {
+          const payload = entry as PerformanceEntry & { value?: number; hadRecentInput?: boolean };
+          if (!payload.hadRecentInput) {
+            state.cls += Number(payload.value || 0);
+          }
+        }
+      });
+      clsObserver.observe({ type: "layout-shift", buffered: true });
+    } catch {}
+    try {
+      const paintObserver = new PerformanceObserver((entryList) => {
+        for (const entry of entryList.getEntries()) {
+          if (entry.name === "first-contentful-paint") {
+            state.fcp = entry.startTime;
+          }
+        }
+      });
+      paintObserver.observe({ type: "paint", buffered: true });
+    } catch {}
+  });
+
+  await page.goto(url, { waitUntil: "networkidle" });
+  if (waitMs > 0) {
+    await page.waitForTimeout(waitMs);
+  }
+  const raw = await page.evaluate(
+    ({ marker }) => {
+      const navigation = performance.getEntriesByType("navigation")[0] as PerformanceNavigationTiming | undefined;
+      const paintEntries = performance.getEntriesByType("paint");
+      const state = (window as Window & { __codexStackPerf?: { lcp?: number | null; cls?: number | null; fcp?: number | null } }).__codexStackPerf || {};
+      const fcpEntry = paintEntries.find((entry) => entry.name === "first-contentful-paint");
+      const memory = performance as Performance & { memory?: { usedJSHeapSize?: number } };
+      return {
+        marker,
+        finalUrl: window.location.href,
+        title: document.title,
+        ttfb: navigation ? navigation.responseStart - navigation.requestStart : null,
+        domContentLoaded: navigation ? navigation.domContentLoadedEventEnd : null,
+        loadEvent: navigation ? navigation.loadEventEnd : null,
+        fcp: state.fcp ?? (fcpEntry ? fcpEntry.startTime : null),
+        lcp: state.lcp ?? null,
+        cls: state.cls ?? null,
+        jsHeapUsed: memory.memory?.usedJSHeapSize ?? null,
+        resourceCount: performance.getEntriesByType("resource").length,
+      };
+    },
+    { marker: "codex-stack-perf" },
+  ) as RawPerfResult;
+
+  const metrics: PerformanceMetrics = {
+    ttfb: asNumber(raw.ttfb),
+    domContentLoaded: asNumber(raw.domContentLoaded),
+    loadEvent: asNumber(raw.loadEvent),
+    fcp: asNumber(raw.fcp),
+    lcp: asNumber(raw.lcp),
+    cls: asNumber(raw.cls),
+    jsHeapUsed: asNumber(raw.jsHeapUsed),
+    resourceCount: typeof raw.resourceCount === "number" ? raw.resourceCount : 0,
+    failedResourceCount: failedRequests.length,
+  };
+
+  const budgetResults = budgets.map((budget) => {
+    const value = metrics[budget.metric];
+    const passed = typeof value === "number" ? value <= budget.threshold : true;
+    return {
+      ...budget,
+      value: typeof value === "number" ? value : null,
+      passed,
+      detail: typeof value === "number"
+        ? `${budget.label} ${formatMetricValue(budget.metric, value)} ${passed ? "within" : "exceeds"} threshold ${formatMetricValue(budget.metric, budget.threshold)}.`
+        : `${budget.label} was unavailable in this browser run.`,
+    } satisfies PerformanceBudgetResult;
+  });
+
+  const topViolations = budgetResults
+    .filter((item) => !item.passed)
+    .map((item) => `${item.label}: ${formatMetricValue(item.metric, item.value)} > ${formatMetricValue(item.metric, item.threshold)}`)
+    .slice(0, 5);
+
+  return {
+    url,
+    finalUrl: cleanSubject(raw.finalUrl || url) || url,
+    title: cleanSubject(raw.title || ""),
+    waitMs,
+    metrics,
+    budgets: budgetResults,
+    budgetViolationCount: budgetResults.filter((item) => !item.passed).length,
+    topViolations,
+    status: budgetResults.some((item) => !item.passed) ? "warning" : "pass",
+  };
+}

--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "codex-stack",
       "dependencies": {
+        "axe-core": "^4.11.0",
         "playwright": "^1.58.2",
         "pngjs": "^7.0.0",
       },
@@ -19,6 +20,8 @@
     "@types/node": ["@types/node@25.5.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw=="],
 
     "@types/pngjs": ["@types/pngjs@6.0.5", "", { "dependencies": { "@types/node": "*" } }, "sha512-0k5eKfrA83JOZPppLtS2C7OUtyNAl2wKNxfyYl9Q5g9lPkgBl/9hNyAu6HuEH2J4XmIv2znEpkDd0SaZVxW6iQ=="],
+
+    "axe-core": ["axe-core@4.11.1", "", {}, "sha512-BASOg+YwO2C+346x3LZOeoovTIoTrRqEsqMa6fmfAV0P+U9mFr9NsyOEpiYvFjbc64NMrSswhV50WdXzdb/Z5A=="],
 
     "fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -11,13 +11,17 @@ bun src/cli.ts issue branch 42 --title "Add PR workflow" --prefix feat
 bun src/cli.ts review
 bun src/cli.ts review --json
 bun src/cli.ts qa http://127.0.0.1:4173/dashboard --flow portal-dashboard --snapshot portal-dashboard --session demo --json
+bun src/cli.ts qa http://127.0.0.1:4173/dashboard --flow portal-dashboard --snapshot portal-dashboard --a11y --a11y-scope main --perf --perf-budget lcp=2s --perf-budget cls=0.1 --session demo --json
 bun src/cli.ts qa https://preview.example.com --mode diff-aware --base-ref origin/main --session preview --json
 bun src/cli.ts preview --url-template "https://preview-{pr}.example.com" --pr 42 --branch feat/42-preview --sha abcdef1234567890 --path / --path /dashboard --device desktop --device mobile --flow landing-smoke --snapshot landing-home
+bun src/cli.ts preview --url-template "https://preview-{pr}.example.com" --pr 42 --branch feat/42-preview --sha abcdef1234567890 --path /dashboard --device desktop --flow landing-smoke --snapshot landing-home --a11y --a11y-scope main --perf --perf-budget lcp=2s
 bun src/cli.ts deploy --url https://staging.example.com --path / --path /dashboard --device desktop --device mobile --flow portal-dashboard --snapshot portal-dashboard
+bun src/cli.ts deploy --url https://staging.example.com --path /dashboard --device desktop --flow portal-dashboard --snapshot portal-dashboard --a11y --a11y-scope main --perf --perf-budget lcp=2s --perf-budget cls=0.1
 bun src/cli.ts ship --dry-run
 bun src/cli.ts ship --message "feat: ready for review" --push --pr --template .github/pull_request_template.md
 bun src/cli.ts ship --message "feat: ready for review" --push --pr --reviewer octocat --team-reviewer acme/platform --assignee @me --project "Engineering Roadmap" --label release-candidate
 bun src/cli.ts ship --dry-run --pr --verify-url http://127.0.0.1:4173 --verify-path /dashboard --verify-device mobile --verify-console-errors --verify-flow portal-dashboard --verify-snapshot portal-dashboard
+bun src/cli.ts ship --dry-run --pr --verify-url http://127.0.0.1:4173 --verify-path /dashboard --verify-device mobile --verify-flow portal-dashboard --verify-snapshot portal-dashboard --verify-a11y --verify-a11y-scope main --verify-perf --verify-perf-budget lcp=2s
 bun src/cli.ts retro --since "7 days ago"
 bun src/cli.ts retro --since "7 days ago" --artifact-dir .codex-stack/retros
 bun src/cli.ts retro --since "7 days ago" --repo anup4khandelwal/codex-stack
@@ -107,6 +111,7 @@ bun scripts/ship-branch.ts --message "feat: ready for review" --push --pr
 bun scripts/ship-branch.ts --message "feat: ready for review" --push --pr --template .github/pull_request_template.md
 bun scripts/ship-branch.ts --message "feat: ready for review" --push --pr --reviewer octocat --team-reviewer acme/platform --assignee @me --project "Engineering Roadmap" --label release-candidate
 bun scripts/ship-branch.ts --dry-run --pr --verify-url http://127.0.0.1:4173 --verify-path /dashboard --verify-device mobile --verify-console-errors --verify-flow portal-dashboard --verify-snapshot portal-dashboard
+bun scripts/ship-branch.ts --dry-run --pr --verify-url http://127.0.0.1:4173 --verify-path /dashboard --verify-device mobile --verify-flow portal-dashboard --verify-snapshot portal-dashboard --verify-a11y --verify-a11y-scope main --verify-perf --verify-perf-budget lcp=2s
 bun scripts/ship-branch.ts --message "feat: ready for review" --push --pr --draft
 ```
 
@@ -119,6 +124,7 @@ Notes:
 - When GitHub access is available, `ship` creates missing labels before attaching them to the PR.
 - `ship` can also assign users and attach projects with `--assignee`, `--assign-self`, and `--project`.
 - `ship` can call the deploy verification workflow before push/PR creation with `--verify-url`, `--verify-path`, `--verify-device`, `--verify-flow`, and `--verify-snapshot`.
+- `ship` can also pass through accessibility and performance verification with `--verify-a11y`, `--verify-a11y-scope`, `--verify-a11y-impact`, `--verify-perf`, `--verify-perf-budget`, and `--verify-perf-wait-ms`.
 - `--verify-console-errors` upgrades captured console errors from warnings to merge-blocking failures.
 - When `ship --pr` runs with deploy verification, it also posts a PR comment with the deploy summary and any available artifact references.
 - During verification, `ship` publishes tracked evidence under `docs/qa/<branch>/deploy/` before push/PR creation.
@@ -129,6 +135,7 @@ Notes:
 
 ```bash
 bun scripts/qa-run.ts http://127.0.0.1:4173/dashboard --flow portal-dashboard --snapshot portal-dashboard --session demo --json
+bun scripts/qa-run.ts http://127.0.0.1:4173/dashboard --flow portal-dashboard --snapshot portal-dashboard --a11y --a11y-scope main --perf --perf-budget lcp=2s --perf-budget cls=0.1 --json
 bun scripts/qa-run.ts http://127.0.0.1:4173/login --flow portal-full-demo --snapshot portal-login --session demo
 bun scripts/qa-run.ts https://preview.example.com --mode diff-aware --base-ref origin/main --session preview --json
 bun scripts/qa-trends.ts --dir .codex-stack/qa --json
@@ -140,6 +147,8 @@ Notes:
 - It upgrades raw browser evidence into categorized findings, severity, health score, and recommendation.
 - `--mode diff-aware` inspects the git diff, infers changed routes for common app/page layouts, and probes those URLs from the supplied base URL.
 - Snapshot-based failures also emit annotated SVG evidence under `.codex-stack/qa/annotations/`.
+- `--a11y` injects `axe-core` into the current page/session and writes `a11y.json` plus `a11y.md` when enabled.
+- `--perf` captures browser metrics like TTFB, FCP, LCP, CLS, and failed resources, then writes `performance.json` plus `performance.md`.
 - `compare-snapshot` now emits a self-contained visual pack, and `qa --publish-dir ...` copies that pack into `visual/index.html` and `visual/manifest.json`.
 - Every `qa-run` also refreshes `.codex-stack/qa/trends.json` and `.codex-stack/qa/trends.md` so you can compare the latest run against prior QA history.
 - Snapshot baselines now store route/device metadata and QA flags stale baselines automatically when the saved reference ages out.
@@ -165,6 +174,7 @@ Notes:
 ```bash
 bun scripts/preview-verify.ts --url "https://anup4khandelwal.github.io/codex-stack/pr-preview/pr-42/" --repo anup4khandelwal/codex-stack --pr 42 --branch feat/42-preview --sha abcdef1234567890 --path /login --path /dashboard --device desktop --device mobile --flow portal-full-demo --markdown-out preview.md --json-out preview.json --comment-out preview-comment.md
 bun scripts/preview-verify.ts --url-template "https://preview-{pr}.example.com" --repo anup4khandelwal/codex-stack --pr 42 --branch feat/42-preview --sha abcdef1234567890 --path / --path /dashboard --device desktop --device mobile --flow landing-smoke --snapshot landing-home --markdown-out preview.md --json-out preview.json --comment-out preview-comment.md
+bun scripts/preview-verify.ts --url-template "https://preview-{pr}.example.com" --repo anup4khandelwal/codex-stack --pr 42 --branch feat/42-preview --sha abcdef1234567890 --path /dashboard --device desktop --flow landing-smoke --snapshot landing-home --a11y --a11y-scope main --perf --perf-budget lcp=2s --markdown-out preview.md --json-out preview.json --comment-out preview-comment.md
 bun scripts/preview-verify.ts --url "https://anup4khandelwal.github.io/codex-stack/pr-preview/pr-42/" --repo anup4khandelwal/codex-stack --pr 42 --branch feat/42-preview --sha abcdef1234567890 --path /dashboard --device desktop --flow portal-dashboard --session preview-auth --session-bundle .codex-stack/private/preview-auth.json --markdown-out preview.md --json-out preview.json --comment-out preview-comment.md
 bun scripts/preview-verify.ts --url https://preview.example.com --path /dashboard --device desktop --flow landing-smoke --snapshot landing-home --json
 ```
@@ -176,6 +186,7 @@ Notes:
 - The script polls preview readiness before it delegates to `deploy-verify.ts`.
 - `--session-bundle <path>` imports an exported browser session into the named preview session before live checks run.
 - Preview reports now expose the deploy visual-risk score, including stale-baseline counts and top drivers.
+- Preview reports also surface accessibility counts, top a11y rules, performance budget failures, and the worst captured perf metrics when those checks are enabled.
 - `preview-verify.yml` is the manual rerun path. `pr-review.yml` is the automatic PR-time path and publishes the GitHub Pages preview before verification.
 - For same-repo PRs, preview evidence is republished into the same Pages subtree under `__codex/visual/index.html`.
 - Both preview workflows can consume the repo secret `CODEX_STACK_PREVIEW_SESSION_BUNDLE_B64` and decode it to a temp bundle file without exposing the contents in logs.
@@ -185,6 +196,7 @@ Notes:
 
 ```bash
 bun scripts/deploy-verify.ts --url https://staging.example.com --path / --path /dashboard --device desktop --device mobile --flow portal-dashboard --snapshot portal-dashboard --markdown-out deploy.md --json-out deploy.json --comment-out deploy-comment.md
+bun scripts/deploy-verify.ts --url https://staging.example.com --path /dashboard --device desktop --flow portal-dashboard --snapshot portal-dashboard --a11y --a11y-scope main --perf --perf-budget lcp=2s --perf-budget cls=0.1 --markdown-out deploy.md --json-out deploy.json --comment-out deploy-comment.md
 bun scripts/deploy-verify.ts --url https://staging.example.com --path /dashboard --device desktop --flow portal-dashboard --session staging-auth --session-bundle .codex-stack/private/staging-auth.json --json
 bun scripts/deploy-verify.ts --url-template "https://preview-{pr}.example.com" --repo anup4khandelwal/codex-stack --pr 42 --branch feat/42-preview --sha abcdef1234567890 --path /dashboard --device mobile --strict-console --strict-http --json
 ```
@@ -194,6 +206,7 @@ Notes:
 - `deploy-verify.ts` resolves the live deploy URL from either `--url` or `--url-template`.
 - It waits for readiness, verifies every requested `path x device` combination, and captures screenshots plus console evidence.
 - Flow and snapshot checks are delegated to the existing QA runtime so the deploy report reuses the same finding model and artifacts.
+- The same runtime can also run accessibility and performance checks, and deploy reports now publish those summaries into both markdown and `visual/index.html`.
 - `--session-bundle <path>` validates the bundle up front, imports it into the named deploy session when live browser checks need it, and passes it through to `qa-run.ts`.
 - The script writes `report.md`, `report.json`, `comment.md`, `screenshots.json`, and a visual review pack under `visual/index.html` and `visual/manifest.json`.
 - Deploy reports now include a single visual-risk score that combines path/device failures, console errors, snapshot drift, and stale baselines.
@@ -250,6 +263,8 @@ bun browse/src/cli.ts export-flow portal-full-demo ./docs/portal-full-demo.md
 bun browse/src/cli.ts export-session ./tmp/staging-session.json --session staging
 bun browse/src/cli.ts import-session ./tmp/staging-session.json --session staging-copy
 bun browse/src/cli.ts import-browser-cookies chrome --session staging --profile Default
+bun browse/src/cli.ts a11y https://example.com/dashboard --scope main --impact serious --session staging
+bun browse/src/cli.ts perf https://example.com/dashboard --budget lcp=2s --budget cls=0.1 --wait-ms 400 --session staging
 bun browse/src/cli.ts probe https://example.com/settings --session staging
 bun browse/src/cli.ts snapshot https://example.com marketing-home --session staging
 bun browse/src/cli.ts compare-snapshot https://example.com marketing-home --session staging

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "browse:screenshot": "bun browse/src/cli.ts screenshot"
   },
   "dependencies": {
+    "axe-core": "^4.11.0",
     "playwright": "^1.58.2",
     "pngjs": "^7.0.0"
   },

--- a/scripts/browse-a11y-perf.spec.ts
+++ b/scripts/browse-a11y-perf.spec.ts
@@ -1,0 +1,195 @@
+#!/usr/bin/env bun
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import process from "node:process";
+import { execFileSync } from "node:child_process";
+
+const rootDir = process.cwd();
+const bun = process.execPath || "bun";
+const fixtureRoot = fs.mkdtempSync(path.join(os.tmpdir(), "codex-stack-browse-a11y-perf-"));
+const logPath = path.join(fixtureRoot, "playwright-log.json");
+const modulePath = path.join(fixtureRoot, "playwright-stub.mjs");
+
+function runBrowse(args: string[]): string {
+  return execFileSync(bun, [path.join(rootDir, "browse", "src", "cli.ts"), ...args], {
+    cwd: fixtureRoot,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      CODEX_STACK_PLAYWRIGHT_MODULE: modulePath,
+      CODEX_STACK_PLAYWRIGHT_LOG: logPath,
+      CODEX_STACK_AXE_SOURCE: "window.axe={run: async () => ({violations:[],passes:[],incomplete:[]})};",
+    },
+  }).trim();
+}
+
+async function main(): Promise<void> {
+  fs.writeFileSync(
+    modulePath,
+    `import fs from "node:fs";
+const LOG_PATH = process.env.CODEX_STACK_PLAYWRIGHT_LOG;
+function append(entry) {
+  const rows = fs.existsSync(LOG_PATH) ? JSON.parse(fs.readFileSync(LOG_PATH, "utf8")) : [];
+  rows.push(entry);
+  fs.writeFileSync(LOG_PATH, JSON.stringify(rows, null, 2));
+}
+class FakePage {
+  constructor() {
+    this.currentUrl = "";
+    this.handlers = {};
+  }
+  on(name, callback) {
+    if (!this.handlers[name]) this.handlers[name] = [];
+    this.handlers[name].push(callback);
+  }
+  async addScriptTag(options) {
+    append({ action: "addScriptTag", hasContent: Boolean(options?.content) });
+  }
+  async evaluateOnNewDocument(fn) {
+    append({ action: "evaluateOnNewDocument", registered: true });
+  }
+  async goto(url, options = {}) {
+    this.currentUrl = url;
+    append({ action: "goto", url, waitUntil: options.waitUntil || "" });
+    if (Array.isArray(this.handlers.requestfailed)) {
+      for (const callback of this.handlers.requestfailed) {
+        callback({ url: () => "https://example.com/static/chunk.js" });
+      }
+    }
+    return { status: () => 200, ok: () => true };
+  }
+  async waitForTimeout(ms) {
+    append({ action: "waitForTimeout", ms });
+  }
+  async evaluate(fn, arg) {
+    append({ action: "evaluate", marker: arg?.marker || "", impact: arg?.impact || "", scopes: arg?.selectors || [] });
+    if (arg?.marker === "codex-stack-a11y") {
+      return {
+        finalUrl: this.currentUrl,
+        title: "Preview dashboard",
+        violations: [
+          {
+            id: "color-contrast",
+            impact: "serious",
+            description: "Text contrast is too low.",
+            help: "Elements must meet minimum color contrast ratio thresholds",
+            helpUrl: "https://dequeuniversity.com/rules/axe/4.10/color-contrast",
+            nodes: [{ target: ["#hero-title"] }],
+          },
+        ],
+        passesCount: 8,
+        incompleteCount: 1,
+      };
+    }
+    if (arg?.marker === "codex-stack-perf") {
+      return {
+        finalUrl: this.currentUrl,
+        title: "Preview dashboard",
+        ttfb: 120,
+        domContentLoaded: 540,
+        loadEvent: 880,
+        fcp: 310,
+        lcp: 2550,
+        cls: 0.21,
+        jsHeapUsed: 10485760,
+        resourceCount: 14,
+      };
+    }
+    return null;
+  }
+  async title() { return "Preview dashboard"; }
+  url() { return this.currentUrl; }
+}
+const page = new FakePage();
+const context = {
+  pages() { return [page]; },
+  async newPage() { return page; },
+  async close() { append({ action: "close" }); },
+  async storageState() { return { cookies: [], origins: [] }; },
+  async clearCookies() {},
+  async addCookies() {},
+};
+export const chromium = {
+  async launchPersistentContext() {
+    append({ action: "launch" });
+    return context;
+  }
+};
+`,
+  );
+
+  const a11yOutput = runBrowse([
+    "a11y",
+    "https://example.com/dashboard",
+    "--scope",
+    "#app",
+    "--impact",
+    "serious",
+    "--session",
+    "insights",
+    "--device",
+    "mobile",
+  ]);
+  const a11y = JSON.parse(a11yOutput) as {
+    minimumImpact?: string;
+    scopeSelectors?: string[];
+    violationCount?: number;
+    topRules?: string[];
+    violations?: Array<{ id?: string; selectors?: string[] }>;
+  };
+  assert.equal(a11y.minimumImpact, "serious");
+  assert.deepEqual(a11y.scopeSelectors, ["#app"]);
+  assert.equal(a11y.violationCount, 1);
+  assert.ok(a11y.topRules?.some((item) => String(item).includes("color-contrast")));
+  assert.equal(a11y.violations?.[0]?.id, "color-contrast");
+  assert.deepEqual(a11y.violations?.[0]?.selectors, ["#hero-title"]);
+
+  const perfOutput = runBrowse([
+    "perf",
+    "https://example.com/dashboard",
+    "--budget",
+    "lcp=2s",
+    "--budget",
+    "cls=0.1",
+    "--budget",
+    "failedResourceCount=0",
+    "--wait-ms",
+    "400",
+    "--session",
+    "insights",
+    "--device",
+    "desktop",
+  ]);
+  const perf = JSON.parse(perfOutput) as {
+    waitMs?: number;
+    budgetViolationCount?: number;
+    topViolations?: string[];
+    metrics?: { lcp?: number; cls?: number; failedResourceCount?: number };
+    budgets?: Array<{ metric?: string; passed?: boolean; severity?: string }>;
+  };
+  assert.equal(perf.waitMs, 400);
+  assert.equal(perf.metrics?.lcp, 2550);
+  assert.equal(perf.metrics?.cls, 0.21);
+  assert.equal(perf.metrics?.failedResourceCount, 1);
+  assert.equal(perf.budgetViolationCount, 3);
+  assert.ok(perf.topViolations?.some((item) => String(item).includes("LCP")));
+  assert.ok(perf.budgets?.some((item) => item.metric === "lcp" && item.passed === false && item.severity === "high"));
+  assert.ok(perf.budgets?.some((item) => item.metric === "cls" && item.passed === false && item.severity === "high"));
+  assert.ok(perf.budgets?.some((item) => item.metric === "failedResourceCount" && item.passed === false && item.severity === "high"));
+
+  const log = JSON.parse(fs.readFileSync(logPath, "utf8")) as Array<Record<string, unknown>>;
+  assert.ok(log.some((entry) => entry.action === "addScriptTag" && entry.hasContent === true));
+  assert.ok(log.some((entry) => entry.action === "evaluate" && entry.marker === "codex-stack-a11y" && Array.isArray(entry.scopes)));
+  assert.ok(log.some((entry) => entry.action === "evaluateOnNewDocument"));
+  assert.ok(log.some((entry) => entry.action === "waitForTimeout" && entry.ms === 400));
+
+  console.log("browse-a11y-perf spec passed");
+}
+
+try {
+  await main();
+} finally {
+  fs.rmSync(fixtureRoot, { recursive: true, force: true });
+}

--- a/scripts/ci-check.sh
+++ b/scripts/ci-check.sh
@@ -82,6 +82,7 @@ run_ts scripts/browse-semantic-device.spec.ts >/tmp/codex-stack-browse-semantic-
 run_ts scripts/browse-iframe.spec.ts >/tmp/codex-stack-browse-iframe-spec.log
 run_ts scripts/browse-network.spec.ts >/tmp/codex-stack-browse-network-spec.log
 run_ts scripts/browse-download.spec.ts >/tmp/codex-stack-browse-download-spec.log
+run_ts scripts/browse-a11y-perf.spec.ts >/tmp/codex-stack-browse-a11y-perf-spec.log
 run_ts scripts/qa-diff.spec.ts >/tmp/codex-stack-qa-diff-spec.log
 run_ts scripts/qa-run.ts --help >/tmp/codex-stack-qa-help.log
 run_ts scripts/qa-run.spec.ts >/tmp/codex-stack-qa-spec.log

--- a/scripts/deploy-verify.spec.ts
+++ b/scripts/deploy-verify.spec.ts
@@ -98,6 +98,55 @@ async function main(): Promise<void> {
 
   fs.writeFileSync(qaFixturePath, JSON.stringify({
     url: "https://preview-77.example.com/dashboard",
+    accessibility: {
+      enabled: true,
+      minimumImpact: "serious",
+      scopeSelectors: ["#app"],
+      violationCount: 2,
+      passCount: 8,
+      incompleteCount: 0,
+      topRules: ["color-contrast (1)", "label (1)"],
+      violations: [
+        {
+          id: "color-contrast",
+          impact: "serious",
+          help: "Ensure text contrast is sufficient",
+          helpUrl: "https://dequeuniversity.com/rules/axe/4.11/color-contrast",
+          selectors: ["#hero-cta"],
+          nodeCount: 1,
+        },
+      ],
+    },
+    performance: {
+      enabled: true,
+      waitMs: 350,
+      metrics: {
+        ttfb: 110,
+        domContentLoaded: 410,
+        loadEvent: 700,
+        fcp: 290,
+        lcp: 2410,
+        cls: 0.17,
+        jsHeapUsed: 1048576,
+        resourceCount: 15,
+        failedResourceCount: 2,
+      },
+      budgets: [
+        {
+          metric: "lcp",
+          label: "LCP",
+          threshold: 2000,
+          unit: "ms",
+          severity: "high",
+          raw: "lcp=2s",
+          value: 2410,
+          passed: false,
+          detail: "LCP was 2410 ms which exceeds the budget of 2000 ms.",
+        },
+      ],
+      budgetViolationCount: 1,
+      topViolations: ["LCP was 2410 ms which exceeds the budget of 2000 ms."],
+    },
     snapshot: {
       name: "portal-dashboard",
       result: {
@@ -168,6 +217,16 @@ async function main(): Promise<void> {
     "portal-dashboard",
     "--session-bundle",
     sessionBundlePath,
+    "--a11y",
+    "--a11y-scope",
+    "#app",
+    "--a11y-impact",
+    "serious",
+    "--perf",
+    "--perf-budget",
+    "lcp=2s",
+    "--perf-wait-ms",
+    "350",
     "--strict-http",
     "--publish-dir",
     publishDir,
@@ -203,7 +262,14 @@ async function main(): Promise<void> {
     readiness?: { status?: string; attempts?: number };
     checks?: { paths?: string[]; devices?: string[]; strictHttp?: boolean };
     pathResults?: Array<{ path?: string; device?: string; status?: string; httpStatus?: number | null; screenshot?: string; console?: { errors?: string[]; warnings?: string[] } }>;
-    qa?: { status?: string; flowResults?: Array<{ name?: string }>; snapshotResults?: Array<{ name?: string; status?: string; annotation?: string }>; findings?: Array<{ title?: string }> };
+    qa?: {
+      status?: string;
+      flowResults?: Array<{ name?: string }>;
+      snapshotResults?: Array<{ name?: string; status?: string; annotation?: string }>;
+      findings?: Array<{ title?: string }>;
+      accessibility?: { enabled?: boolean; violationCount?: number; topRules?: string[] };
+      performance?: { enabled?: boolean; budgetViolationCount?: number; metrics?: { lcp?: number; cls?: number } };
+    };
     visualPack?: { index?: string; manifest?: string };
     screenshotManifest?: string;
   };
@@ -228,14 +294,24 @@ async function main(): Promise<void> {
   assert.ok(report.qa?.flowResults?.some((entry) => entry.name === "portal-dashboard"));
   assert.ok(report.qa?.snapshotResults?.some((entry) => entry.name === "portal-dashboard" && entry.status === "changed"));
   assert.ok(report.qa?.findings?.some((entry) => String(entry.title).includes("Expected UI selectors")));
+  assert.equal(report.qa?.accessibility?.enabled, true);
+  assert.equal(report.qa?.accessibility?.violationCount, 2);
+  assert.ok(report.qa?.accessibility?.topRules?.includes("color-contrast (1)"));
+  assert.equal(report.qa?.performance?.enabled, true);
+  assert.equal(report.qa?.performance?.budgetViolationCount, 1);
+  assert.equal(report.qa?.performance?.metrics?.lcp, 2410);
   assert.ok(report.screenshotManifest);
   assert.ok(String(report.visualPack?.index).includes("visual/index.html"));
   assert.ok(String(report.visualPack?.manifest).includes("visual/manifest.json"));
   const visualManifest = JSON.parse(fs.readFileSync(path.join(publishDir, "visual", "manifest.json"), "utf8")) as {
     visualRisk?: { score?: number; staleBaselines?: number };
+    accessibility?: { violationCount?: number };
+    performance?: { budgetViolationCount?: number };
     snapshots?: Array<{ imageDiffScore?: number; diffImage?: string; baselineFreshness?: { stale?: boolean; routePath?: string } }>;
   };
   assert.equal(visualManifest.visualRisk?.staleBaselines, 1);
+  assert.equal(visualManifest.accessibility?.violationCount, 2);
+  assert.equal(visualManifest.performance?.budgetViolationCount, 1);
   assert.ok(visualManifest.snapshots?.some((entry) => entry.imageDiffScore === 68.2));
   assert.ok(visualManifest.snapshots?.some((entry) => String(entry.diffImage).includes("diff.png")));
   assert.ok(visualManifest.snapshots?.some((entry) => entry.baselineFreshness?.stale === true && entry.baselineFreshness?.routePath === "/dashboard"));
@@ -265,6 +341,12 @@ async function main(): Promise<void> {
   assert.match(markdown, /Visual pack/);
   assert.match(markdown, /Visual risk: CRITICAL/);
   assert.match(markdown, /baselineAge=/);
+  assert.match(markdown, /## Accessibility/);
+  assert.match(markdown, /Violations: 2/);
+  assert.match(markdown, /Top rules: color-contrast \(1\), label \(1\)/);
+  assert.match(markdown, /## Performance/);
+  assert.match(markdown, /Budget violations: 1/);
+  assert.match(markdown, /LCP: 2410/);
   assert.match(comment, /Deploy URL: https:\/\/preview-77\.example\.com/);
 
   console.log("deploy-verify spec passed");

--- a/scripts/deploy-verify.ts
+++ b/scripts/deploy-verify.ts
@@ -29,6 +29,12 @@ export interface DeployArgs {
   updateSnapshot: boolean;
   session: string;
   sessionBundle: string;
+  a11y: boolean;
+  a11yScopes: string[];
+  a11yImpact: string;
+  perf: boolean;
+  perfBudgets: string[];
+  perfWaitMs: number;
   publishDir: string;
   markdownOut: string;
   jsonOut: string;
@@ -100,6 +106,63 @@ interface QaFlowResult {
   steps?: number;
 }
 
+interface QaAccessibilityViolation {
+  id?: string;
+  impact?: string;
+  help?: string;
+  helpUrl?: string;
+  selectors?: string[];
+  nodeCount?: number;
+}
+
+interface QaAccessibilitySummary {
+  enabled?: boolean;
+  minimumImpact?: string;
+  scopeSelectors?: string[];
+  violationCount?: number;
+  passCount?: number;
+  incompleteCount?: number;
+  topRules?: string[];
+  violations?: QaAccessibilityViolation[];
+  artifactJson?: string;
+  artifactMarkdown?: string;
+}
+
+interface QaPerformanceMetrics {
+  ttfb?: number | null;
+  domContentLoaded?: number | null;
+  loadEvent?: number | null;
+  fcp?: number | null;
+  lcp?: number | null;
+  cls?: number | null;
+  jsHeapUsed?: number | null;
+  resourceCount?: number;
+  failedResourceCount?: number;
+}
+
+interface QaPerformanceBudget {
+  metric?: string;
+  label?: string;
+  threshold?: number;
+  unit?: string;
+  severity?: string;
+  raw?: string;
+  value?: number | null;
+  passed?: boolean;
+  detail?: string;
+}
+
+interface QaPerformanceSummary {
+  enabled?: boolean;
+  waitMs?: number;
+  metrics?: QaPerformanceMetrics;
+  budgets?: QaPerformanceBudget[];
+  budgetViolationCount?: number;
+  topViolations?: string[];
+  artifactJson?: string;
+  artifactMarkdown?: string;
+}
+
 interface VisualPackRef {
   dir?: string;
   index?: string;
@@ -134,6 +197,10 @@ interface QaArtifacts {
   json?: string;
   annotation?: string;
   screenshot?: string;
+  accessibilityJson?: string;
+  accessibilityMarkdown?: string;
+  performanceJson?: string;
+  performanceMarkdown?: string;
   visualPack?: VisualPackRef | null;
   published?: QaPublishedArtifacts;
 }
@@ -154,6 +221,8 @@ interface QaRunReport {
   findings?: QaFinding[];
   flowResults?: QaFlowResult[];
   snapshotResult?: QaSnapshotReport | null;
+  accessibility?: QaAccessibilitySummary | null;
+  performance?: QaPerformanceSummary | null;
   artifacts?: QaArtifacts;
 }
 
@@ -176,6 +245,8 @@ export interface DeployQaSummary {
   findings: QaFinding[];
   flowResults: QaFlowResult[];
   snapshotResults: DeploySnapshotResult[];
+  accessibility: QaAccessibilitySummary | null;
+  performance: QaPerformanceSummary | null;
   artifacts: QaArtifacts;
 }
 
@@ -208,6 +279,16 @@ export interface DeployReport {
     strictConsole: boolean;
     strictHttp: boolean;
     session: string;
+    accessibility: {
+      enabled: boolean;
+      impact: string;
+      scopes: string[];
+    };
+    performance: {
+      enabled: boolean;
+      budgets: string[];
+      waitMs: number;
+    };
   };
   pathResults: DeployPathResult[];
   qa: DeployQaSummary;
@@ -248,7 +329,7 @@ function usage(): never {
   console.log(`deploy-verify
 
 Usage:
-  bun scripts/deploy-verify.ts [--url <url> | --url-template <template>] [--pr <number>] [--branch <ref>] [--sha <sha>] [--repo <owner/name>] [--path <path>] [--device <desktop|tablet|mobile>] [--flow <name>] [--snapshot <name>] [--update-snapshot] [--session <name>] [--session-bundle <path>] [--publish-dir <path>] [--markdown-out <path>] [--json-out <path>] [--comment-out <path>] [--strict-console] [--strict-http] [--wait-timeout <seconds>] [--wait-interval <seconds>] [--fixture <path>] [--qa-fixture <path>] [--readiness-fixture <path>] [--json]
+  bun scripts/deploy-verify.ts [--url <url> | --url-template <template>] [--pr <number>] [--branch <ref>] [--sha <sha>] [--repo <owner/name>] [--path <path>] [--device <desktop|tablet|mobile>] [--flow <name>] [--snapshot <name>] [--update-snapshot] [--session <name>] [--session-bundle <path>] [--a11y] [--a11y-scope <selector>] [--a11y-impact <critical|serious|moderate|minor>] [--perf] [--perf-budget <metric=value>] [--perf-wait-ms <n>] [--publish-dir <path>] [--markdown-out <path>] [--json-out <path>] [--comment-out <path>] [--strict-console] [--strict-http] [--wait-timeout <seconds>] [--wait-interval <seconds>] [--fixture <path>] [--qa-fixture <path>] [--readiness-fixture <path>] [--json]
 `);
   process.exit(0);
 }
@@ -331,6 +412,12 @@ export function parseDeployArgs(argv: string[]): DeployArgs {
     updateSnapshot: false,
     session: "",
     sessionBundle: "",
+    a11y: false,
+    a11yScopes: [],
+    a11yImpact: "serious",
+    perf: false,
+    perfBudgets: [],
+    perfWaitMs: 250,
     publishDir: "",
     markdownOut: "",
     jsonOut: "",
@@ -385,6 +472,22 @@ export function parseDeployArgs(argv: string[]): DeployArgs {
     } else if (arg === "--session-bundle") {
       args.sessionBundle = path.resolve(process.cwd(), argv[i + 1] || "");
       i += 1;
+    } else if (arg === "--a11y") {
+      args.a11y = true;
+    } else if (arg === "--a11y-scope") {
+      args.a11yScopes.push(cleanSubject(argv[i + 1] || ""));
+      i += 1;
+    } else if (arg === "--a11y-impact") {
+      args.a11yImpact = cleanSubject(argv[i + 1] || "") || args.a11yImpact;
+      i += 1;
+    } else if (arg === "--perf") {
+      args.perf = true;
+    } else if (arg === "--perf-budget") {
+      args.perfBudgets.push(cleanSubject(argv[i + 1] || ""));
+      i += 1;
+    } else if (arg === "--perf-wait-ms") {
+      args.perfWaitMs = parsePositiveInteger(argv[i + 1] || "", args.perfWaitMs);
+      i += 1;
     } else if (arg === "--publish-dir") {
       args.publishDir = path.resolve(process.cwd(), argv[i + 1] || "");
       i += 1;
@@ -427,6 +530,8 @@ export function parseDeployArgs(argv: string[]): DeployArgs {
   args.devices = [...new Set(args.devices.filter(Boolean))];
   args.flows = [...new Set(args.flows.filter(Boolean))];
   args.snapshots = [...new Set(args.snapshots.filter(Boolean))];
+  args.a11yScopes = [...new Set(args.a11yScopes.filter(Boolean))];
+  args.perfBudgets = [...new Set(args.perfBudgets.filter(Boolean))];
   if (!args.url && !args.urlTemplate) {
     throw new Error("Provide either --url or --url-template.");
   }
@@ -645,6 +750,8 @@ function renderDeployVisualIndex(manifest: {
   visualRisk?: VisualRiskSummary;
   previewUrl: string;
   screenshotManifest: string;
+  accessibility?: QaAccessibilitySummary | null;
+  performance?: QaPerformanceSummary | null;
   screenshots: Array<Record<string, unknown>>;
   snapshots: Array<Record<string, unknown>>;
 }): string {
@@ -672,6 +779,36 @@ function renderDeployVisualIndex(manifest: {
       </article>
     `).join("\n")
     : "<p>No snapshot visual packs recorded.</p>";
+
+  const accessibilitySummary = manifest.accessibility?.enabled
+    ? `
+      <article class="card">
+        <h2>Accessibility</h2>
+        <p>Violations: <strong>${escapeHtml(manifest.accessibility.violationCount ?? 0)}</strong> • Minimum impact: ${escapeHtml(manifest.accessibility.minimumImpact || "serious")}</p>
+        ${manifest.accessibility.topRules?.length ? `<p>Top rules: ${escapeHtml(manifest.accessibility.topRules.join(", "))}</p>` : "<p>No rule summary recorded.</p>"}
+      </article>
+    `
+    : `
+      <article class="card">
+        <h2>Accessibility</h2>
+        <p>Accessibility checks were not enabled for this deploy verification.</p>
+      </article>
+    `;
+
+  const performanceSummary = manifest.performance?.enabled
+    ? `
+      <article class="card">
+        <h2>Performance</h2>
+        <p>Budget violations: <strong>${escapeHtml(manifest.performance.budgetViolationCount ?? 0)}</strong> • Failed resources: ${escapeHtml(manifest.performance.metrics?.failedResourceCount ?? 0)}</p>
+        ${manifest.performance.topViolations?.length ? `<p>Top violations: ${escapeHtml(manifest.performance.topViolations.join("; "))}</p>` : "<p>No budget violations recorded.</p>"}
+      </article>
+    `
+    : `
+      <article class="card">
+        <h2>Performance</h2>
+        <p>Performance checks were not enabled for this deploy verification.</p>
+      </article>
+    `;
 
   return `<!doctype html>
 <html lang="en">
@@ -706,6 +843,10 @@ function renderDeployVisualIndex(manifest: {
     <section>
       <h2>Page/device checks</h2>
       <div class="grid">${screenshotCards}</div>
+    </section>
+    <section style="margin-top: 28px;">
+      <h2>Accessibility and performance</h2>
+      <div class="grid">${accessibilitySummary}${performanceSummary}</div>
     </section>
     <section style="margin-top: 28px;">
       <h2>Snapshot regressions</h2>
@@ -995,19 +1136,33 @@ function runQaReport({
   session,
   sessionBundle,
   publishDir,
+  device,
   flows,
   snapshot,
   updateSnapshot,
   fixture,
+  a11y,
+  a11yScopes,
+  a11yImpact,
+  perf,
+  perfBudgets,
+  perfWaitMs,
 }: {
   url: string;
   session: string;
   sessionBundle: string;
   publishDir: string;
+  device: DeviceName;
   flows: string[];
   snapshot: string;
   updateSnapshot: boolean;
   fixture: string;
+  a11y: boolean;
+  a11yScopes: string[];
+  a11yImpact: string;
+  perf: boolean;
+  perfBudgets: string[];
+  perfWaitMs: number;
 }): QaRunReport {
   const qaArgs = [path.resolve(process.cwd(), "scripts", "qa-run.ts")];
   if (fixture) {
@@ -1015,7 +1170,7 @@ function runQaReport({
   } else {
     qaArgs.push(url);
   }
-  qaArgs.push("--session", session, "--publish-dir", publishDir, "--json");
+  qaArgs.push("--session", session, "--device", device, "--publish-dir", publishDir, "--json");
   if (sessionBundle) {
     qaArgs.push("--session-bundle", sessionBundle);
   }
@@ -1027,6 +1182,14 @@ function runQaReport({
   }
   if (updateSnapshot) {
     qaArgs.push("--update-snapshot");
+  }
+  if (a11y) {
+    qaArgs.push("--a11y", "--a11y-impact", a11yImpact);
+    for (const scope of a11yScopes) qaArgs.push("--a11y-scope", scope);
+  }
+  if (perf) {
+    qaArgs.push("--perf", "--perf-wait-ms", String(perfWaitMs));
+    for (const budget of perfBudgets) qaArgs.push("--perf-budget", budget);
   }
 
   const result = spawnSync(BUN_RUNTIME, qaArgs, {
@@ -1058,14 +1221,16 @@ function aggregateQa({
 }): DeployQaSummary {
   const flows = [...args.flows];
   const snapshots = [...args.snapshots];
-  if (!flows.length && !snapshots.length) {
+  if (!flows.length && !snapshots.length && !args.a11y && !args.perf) {
     return {
       status: "pass",
       healthScore: 100,
-      recommendation: "No flow or snapshot QA checks were configured.",
+      recommendation: "No flow, snapshot, accessibility, or performance QA checks were configured.",
       findings: [],
       flowResults: [],
       snapshotResults: [],
+      accessibility: null,
+      performance: null,
       artifacts: {},
     };
   }
@@ -1084,10 +1249,17 @@ function aggregateQa({
       session: sessionName,
       sessionBundle,
       publishDir: primaryPublishDir,
-        flows,
-        snapshot: primarySnapshot,
-        updateSnapshot: args.updateSnapshot,
+      device: defaultDevice,
+      flows,
+      snapshot: primarySnapshot,
+      updateSnapshot: args.updateSnapshot,
         fixture: args.qaFixture,
+        a11y: args.a11y,
+        a11yScopes: args.a11yScopes,
+        a11yImpact: args.a11yImpact,
+        perf: args.perf,
+        perfBudgets: args.perfBudgets,
+        perfWaitMs: args.perfWaitMs,
       }),
     snapshotName: primarySnapshot,
     publishDir: primaryPublishDir,
@@ -1103,10 +1275,17 @@ function aggregateQa({
         session: sessionName,
         sessionBundle,
         publishDir: snapshotPublishDir,
+        device: defaultDevice,
         flows: [],
         snapshot,
         updateSnapshot: args.updateSnapshot,
         fixture: args.qaFixture,
+        a11y: args.a11y,
+        a11yScopes: args.a11yScopes,
+        a11yImpact: args.a11yImpact,
+        perf: args.perf,
+        perfBudgets: args.perfBudgets,
+        perfWaitMs: args.perfWaitMs,
       }),
       snapshotName: snapshot,
       publishDir: snapshotPublishDir,
@@ -1140,6 +1319,9 @@ function aggregateQa({
     .map((entry) => cleanSubject(entry.report.recommendation || ""))
     .find(Boolean) || "Deploy QA checks passed.";
 
+  const primaryAccessibility = reports[0]?.report.accessibility || null;
+  const primaryPerformance = reports[0]?.report.performance || null;
+
   return {
     status: deriveQaStatus(statuses),
     healthScore,
@@ -1147,6 +1329,8 @@ function aggregateQa({
     findings,
     flowResults,
     snapshotResults,
+    accessibility: primaryAccessibility,
+    performance: primaryPerformance,
     artifacts: reports[0]?.report.artifacts || {},
   };
 }
@@ -1221,6 +1405,42 @@ function renderSnapshotLines(snapshotResults: DeploySnapshotResult[]): string[] 
   });
 }
 
+function renderAccessibilityLines(summary: QaAccessibilitySummary | null | undefined): string[] {
+  if (!summary?.enabled) return ["- Accessibility checks were not enabled."];
+  return [
+    `- Minimum impact: ${summary.minimumImpact || "serious"}`,
+    `- Scope selectors: ${summary.scopeSelectors?.length ? summary.scopeSelectors.join(", ") : "document"}`,
+    `- Violations: ${summary.violationCount ?? 0}`,
+    `- Passes: ${summary.passCount ?? 0}`,
+    `- Incomplete: ${summary.incompleteCount ?? 0}`,
+    summary.topRules?.length ? `- Top rules: ${summary.topRules.join(", ")}` : "",
+    summary.artifactJson ? `- Accessibility JSON: \`${summary.artifactJson}\`` : "",
+    summary.artifactMarkdown ? `- Accessibility Markdown: \`${summary.artifactMarkdown}\`` : "",
+  ].filter(Boolean);
+}
+
+function renderPerformanceLines(summary: QaPerformanceSummary | null | undefined): string[] {
+  if (!summary?.enabled) return ["- Performance checks were not enabled."];
+  const metrics = summary.metrics || {};
+  const failedBudgets = (summary.budgets || []).filter((item) => item && item.passed === false);
+  return [
+    `- Wait after load: ${summary.waitMs ?? 250} ms`,
+    `- Budget violations: ${summary.budgetViolationCount ?? failedBudgets.length}`,
+    failedBudgets.length ? `- Failed budgets: ${failedBudgets.map((item) => item.label || item.metric || "metric").join(", ")}` : "",
+    `- TTFB: ${metrics.ttfb ?? "n/a"}`,
+    `- DOMContentLoaded: ${metrics.domContentLoaded ?? "n/a"}`,
+    `- Load event: ${metrics.loadEvent ?? "n/a"}`,
+    `- FCP: ${metrics.fcp ?? "n/a"}`,
+    `- LCP: ${metrics.lcp ?? "n/a"}`,
+    `- CLS: ${metrics.cls ?? "n/a"}`,
+    `- JS heap used: ${metrics.jsHeapUsed ?? "n/a"}`,
+    `- Resource count: ${metrics.resourceCount ?? 0}`,
+    `- Failed resources: ${metrics.failedResourceCount ?? 0}`,
+    summary.artifactJson ? `- Performance JSON: \`${summary.artifactJson}\`` : "",
+    summary.artifactMarkdown ? `- Performance Markdown: \`${summary.artifactMarkdown}\`` : "",
+  ].filter(Boolean);
+}
+
 export function renderDeployMarkdown(report: DeployReport): string {
   const primaryQaArtifacts = report.qa.artifacts?.published || {};
   const lines = [
@@ -1241,6 +1461,12 @@ export function renderDeployMarkdown(report: DeployReport): string {
     `- Paths: ${report.checks.paths.join(", ")}`,
     `- Strict console errors: ${report.checks.strictConsole ? "yes" : "no"}`,
     `- Strict HTTP errors: ${report.checks.strictHttp ? "yes" : "no"}`,
+    `- Accessibility enabled: ${report.checks.accessibility.enabled ? "yes" : "no"}`,
+    report.checks.accessibility.enabled ? `- Accessibility minimum impact: ${report.checks.accessibility.impact}` : "",
+    report.checks.accessibility.enabled && report.checks.accessibility.scopes.length ? `- Accessibility scopes: ${report.checks.accessibility.scopes.join(", ")}` : "",
+    `- Performance enabled: ${report.checks.performance.enabled ? "yes" : "no"}`,
+    report.checks.performance.enabled ? `- Performance wait: ${report.checks.performance.waitMs} ms` : "",
+    report.checks.performance.enabled && report.checks.performance.budgets.length ? `- Performance budgets: ${report.checks.performance.budgets.join(", ")}` : "",
     `- QA health score: ${report.qa.healthScore}`,
     `- Recommendation: ${report.recommendation}`,
     report.runUrl ? `- Workflow run: ${report.runUrl}` : "",
@@ -1256,6 +1482,14 @@ export function renderDeployMarkdown(report: DeployReport): string {
     "## Snapshot results",
     "",
     ...renderSnapshotLines(report.qa.snapshotResults),
+    "",
+    "## Accessibility",
+    "",
+    ...renderAccessibilityLines(report.qa.accessibility),
+    "",
+    "## Performance",
+    "",
+    ...renderPerformanceLines(report.qa.performance),
     "",
     "## QA findings",
     "",
@@ -1317,6 +1551,8 @@ function writeVisualPack({
   screenshotManifest,
   status,
   visualRisk,
+  accessibility,
+  performance,
 }: {
   publishDir: string;
   resolvedUrl: string;
@@ -1325,6 +1561,8 @@ function writeVisualPack({
   screenshotManifest: string;
   status: DeployStatus;
   visualRisk: VisualRiskSummary;
+  accessibility: QaAccessibilitySummary | null;
+  performance: QaPerformanceSummary | null;
 }): DeployVisualPack {
   const visualDir = path.join(publishDir, "visual");
   const screenshotDir = path.join(visualDir, "screenshots");
@@ -1381,6 +1619,8 @@ function writeVisualPack({
     visualRisk,
     previewUrl: resolvedUrl,
     screenshotManifest: screenshotManifest ? relFrom(visualDir, path.resolve(process.cwd(), screenshotManifest)) : "",
+    accessibility,
+    performance,
     screenshots: screenshotEntries,
     snapshots: snapshotEntries,
   };
@@ -1414,6 +1654,8 @@ export async function runDeployVerification(args: DeployArgs): Promise<DeployRep
     findings: [],
     flowResults: [],
     snapshotResults: [],
+    accessibility: null,
+    performance: null,
     artifacts: {},
   };
   let overallStatus: DeployStatus = readiness.status === "ready" ? "pass" : "error";
@@ -1455,6 +1697,16 @@ export async function runDeployVerification(args: DeployArgs): Promise<DeployRep
       strictConsole: args.strictConsole,
       strictHttp: args.strictHttp,
       session,
+      accessibility: {
+        enabled: args.a11y,
+        impact: args.a11yImpact,
+        scopes: [...args.a11yScopes],
+      },
+      performance: {
+        enabled: args.perf,
+        budgets: [...args.perfBudgets],
+        waitMs: args.perfWaitMs,
+      },
     },
     pathResults,
     qa,
@@ -1478,6 +1730,8 @@ export async function runDeployVerification(args: DeployArgs): Promise<DeployRep
     screenshotManifest: report.screenshotManifest,
     status: report.status,
     visualRisk: report.visualRisk,
+    accessibility: report.qa.accessibility,
+    performance: report.qa.performance,
   });
   report.recommendation = recommendation(report);
 

--- a/scripts/preview-verify.spec.ts
+++ b/scripts/preview-verify.spec.ts
@@ -84,6 +84,55 @@ async function main(): Promise<void> {
 
   fs.writeFileSync(qaFixturePath, JSON.stringify({
     url: "https://preview.example.com/dashboard",
+    accessibility: {
+      enabled: true,
+      minimumImpact: "serious",
+      scopeSelectors: ["main"],
+      violationCount: 1,
+      passCount: 10,
+      incompleteCount: 0,
+      topRules: ["color-contrast (1)"],
+      violations: [
+        {
+          id: "color-contrast",
+          impact: "serious",
+          help: "Ensure text contrast is sufficient",
+          helpUrl: "https://dequeuniversity.com/rules/axe/4.11/color-contrast",
+          selectors: ["#hero-copy"],
+          nodeCount: 1,
+        },
+      ],
+    },
+    performance: {
+      enabled: true,
+      waitMs: 250,
+      metrics: {
+        ttfb: 100,
+        domContentLoaded: 380,
+        loadEvent: 660,
+        fcp: 280,
+        lcp: 2260,
+        cls: 0.12,
+        jsHeapUsed: 1048576,
+        resourceCount: 11,
+        failedResourceCount: 1,
+      },
+      budgets: [
+        {
+          metric: "lcp",
+          label: "LCP",
+          threshold: 2000,
+          unit: "ms",
+          severity: "high",
+          raw: "lcp=2s",
+          value: 2260,
+          passed: false,
+          detail: "LCP was 2260 ms which exceeds the budget of 2000 ms.",
+        },
+      ],
+      budgetViolationCount: 1,
+      topViolations: ["LCP was 2260 ms which exceeds the budget of 2000 ms."],
+    },
     snapshot: {
       name: "landing-home",
       result: {
@@ -144,6 +193,16 @@ async function main(): Promise<void> {
     "landing-home",
     "--session-bundle",
     sessionBundlePath,
+    "--a11y",
+    "--a11y-scope",
+    "main",
+    "--a11y-impact",
+    "serious",
+    "--perf",
+    "--perf-budget",
+    "lcp=2s",
+    "--perf-wait-ms",
+    "250",
     "--publish-dir",
     publishDir,
     "--markdown-out",
@@ -178,7 +237,12 @@ async function main(): Promise<void> {
     readiness?: { status?: string; attempts?: number };
     context?: { branchSlug?: string; shortSha?: string };
     deploy?: { screenshotManifest?: string; visualPack?: { index?: string; manifest?: string }; pathResults?: Array<{ status?: string; screenshot?: string }> };
-    qa?: { snapshotResult?: { status?: string; annotation?: string }; findings?: Array<{ title?: string }> };
+    qa?: {
+      snapshotResult?: { status?: string; annotation?: string };
+      findings?: Array<{ title?: string }>;
+      accessibility?: { enabled?: boolean; violationCount?: number };
+      performance?: { enabled?: boolean; budgetViolationCount?: number; metrics?: { lcp?: number } };
+    };
     visualPack?: { index?: string; manifest?: string };
   };
 
@@ -199,6 +263,11 @@ async function main(): Promise<void> {
   assert.ok(report.deploy?.pathResults?.some((entry) => entry.status === "warning" && String(entry.screenshot).includes("root-desktop")));
   assert.equal(report.qa?.snapshotResult?.status, "changed");
   assert.ok(report.qa?.findings?.some((entry) => String(entry.title).includes("Expected UI selectors")));
+  assert.equal(report.qa?.accessibility?.enabled, true);
+  assert.equal(report.qa?.accessibility?.violationCount, 1);
+  assert.equal(report.qa?.performance?.enabled, true);
+  assert.equal(report.qa?.performance?.budgetViolationCount, 1);
+  assert.equal(report.qa?.performance?.metrics?.lcp, 2260);
 
   assert.ok(fs.existsSync(markdownOut));
   assert.ok(fs.existsSync(jsonOut));
@@ -217,6 +286,10 @@ async function main(): Promise<void> {
   assert.match(markdown, /root-desktop\.png/);
   assert.match(markdown, /Visual pack/);
   assert.match(markdown, /visual\/manifest\.json/);
+  assert.match(markdown, /## Accessibility/);
+  assert.match(markdown, /Violations: 1/);
+  assert.match(markdown, /## Performance/);
+  assert.match(markdown, /Budget violations: 1/);
   assert.match(comment, /Expected UI selectors are missing/);
 
   console.log("preview-verify spec passed");

--- a/scripts/preview-verify.ts
+++ b/scripts/preview-verify.ts
@@ -30,6 +30,8 @@ interface PreviewQaCompat {
   recommendation?: string;
   findings?: DeployReport["qa"]["findings"];
   flowResults?: DeployReport["qa"]["flowResults"];
+  accessibility?: DeployReport["qa"]["accessibility"];
+  performance?: DeployReport["qa"]["performance"];
   snapshotResult?: {
     name?: string;
     status?: string;
@@ -61,7 +63,7 @@ function usage(): never {
   console.log(`preview-verify
 
 Usage:
-  bun scripts/preview-verify.ts [--url <url> | --url-template <template>] [--pr <number>] [--branch <ref>] [--sha <sha>] [--repo <owner/name>] [--path <path>] [--device <desktop|tablet|mobile>] [--flow <name>] [--snapshot <name>] [--session <name>] [--session-bundle <path>] [--publish-dir <path>] [--markdown-out <path>] [--json-out <path>] [--comment-out <path>] [--wait-timeout <seconds>] [--wait-interval <seconds>] [--strict-console] [--strict-http] [--fixture <path>] [--qa-fixture <path>] [--readiness-fixture <path>] [--json]
+  bun scripts/preview-verify.ts [--url <url> | --url-template <template>] [--pr <number>] [--branch <ref>] [--sha <sha>] [--repo <owner/name>] [--path <path>] [--device <desktop|tablet|mobile>] [--flow <name>] [--snapshot <name>] [--session <name>] [--session-bundle <path>] [--a11y] [--a11y-scope <selector>] [--a11y-impact <critical|serious|moderate|minor>] [--perf] [--perf-budget <metric=value>] [--perf-wait-ms <n>] [--publish-dir <path>] [--markdown-out <path>] [--json-out <path>] [--comment-out <path>] [--wait-timeout <seconds>] [--wait-interval <seconds>] [--strict-console] [--strict-http] [--fixture <path>] [--qa-fixture <path>] [--readiness-fixture <path>] [--json]
 `);
   process.exit(0);
 }
@@ -95,6 +97,8 @@ function buildCompatQa(report: DeployReport): PreviewQaCompat {
     recommendation: report.qa.recommendation,
     findings: report.qa.findings,
     flowResults: report.qa.flowResults,
+    accessibility: report.qa.accessibility,
+    performance: report.qa.performance,
     snapshotResult: firstSnapshot
       ? {
           name: firstSnapshot.name,
@@ -148,6 +152,30 @@ function renderSnapshotLines(report: DeployReport): string[] {
   });
 }
 
+function renderAccessibilityLines(report: PreviewReport): string[] {
+  const summary = report.qa.accessibility;
+  if (!summary?.enabled) return ["- Accessibility checks were not enabled."];
+  return [
+    `- Violations: ${summary.violationCount ?? 0}`,
+    `- Minimum impact: ${summary.minimumImpact || "serious"}`,
+    summary.topRules?.length ? `- Top rules: ${summary.topRules.join(", ")}` : "",
+    summary.artifactMarkdown ? `- Accessibility Markdown: \`${summary.artifactMarkdown}\`` : "",
+  ].filter(Boolean);
+}
+
+function renderPerformanceLines(report: PreviewReport): string[] {
+  const summary = report.qa.performance;
+  if (!summary?.enabled) return ["- Performance checks were not enabled."];
+  return [
+    `- Budget violations: ${summary.budgetViolationCount ?? 0}`,
+    summary.topViolations?.length ? `- Top violations: ${summary.topViolations.join("; ")}` : "",
+    `- LCP: ${summary.metrics?.lcp ?? "n/a"}`,
+    `- CLS: ${summary.metrics?.cls ?? "n/a"}`,
+    `- Failed resources: ${summary.metrics?.failedResourceCount ?? 0}`,
+    summary.artifactMarkdown ? `- Performance Markdown: \`${summary.artifactMarkdown}\`` : "",
+  ].filter(Boolean);
+}
+
 function renderMarkdown(report: PreviewReport): string {
   const published = report.qa.artifacts?.published || {};
   const snapshot = report.qa.snapshotResult;
@@ -184,6 +212,14 @@ function renderMarkdown(report: PreviewReport): string {
     "## Snapshot results",
     "",
     ...renderSnapshotLines(report.deploy),
+    "",
+    "## Accessibility",
+    "",
+    ...renderAccessibilityLines(report),
+    "",
+    "## Performance",
+    "",
+    ...renderPerformanceLines(report),
     "",
     "## Artifacts",
     "",

--- a/scripts/qa-run.spec.ts
+++ b/scripts/qa-run.spec.ts
@@ -105,6 +105,68 @@ if (command === "run-flow") {
   console.log(JSON.stringify([{ action: "goto", url }, { action: "assert-text", selector: "h1" }]));
   process.exit(0);
 }
+if (command === "a11y") {
+  console.log(JSON.stringify({
+    url,
+    finalUrl: url,
+    title: "Login",
+    minimumImpact: "serious",
+    scopeSelectors: ["#app"],
+    violationCount: 1,
+    passCount: 12,
+    incompleteCount: 0,
+    topRules: ["color-contrast (1)"],
+    violations: [
+      {
+        id: "color-contrast",
+        impact: "serious",
+        description: "Insufficient contrast",
+        help: "Ensure foreground and background colors have enough contrast",
+        helpUrl: "https://dequeuniversity.com/rules/axe/4.11/color-contrast",
+        selectors: ["#login-button"],
+        nodeCount: 1
+      }
+    ],
+    status: "warning"
+  }, null, 2));
+  process.exit(0);
+}
+if (command === "perf") {
+  console.log(JSON.stringify({
+    url,
+    finalUrl: url,
+    title: "Login",
+    waitMs: 400,
+    metrics: {
+      ttfb: 120,
+      domContentLoaded: 450,
+      loadEvent: 710,
+      fcp: 360,
+      lcp: 2450,
+      cls: 0.19,
+      jsHeapUsed: 1048576,
+      resourceCount: 14,
+      failedResourceCount: 2
+    },
+    budgets: [
+      {
+        metric: "lcp",
+        label: "LCP",
+        threshold: 2000,
+        unit: "ms",
+        severity: "high",
+        raw: "lcp=2s",
+        value: 2450,
+        passed: false,
+        detail: "LCP was 2450 ms which exceeds the budget of 2000 ms."
+      }
+    ],
+    budgetViolationCount: 1,
+    topViolations: ["LCP was 2450 ms which exceeds the budget of 2000 ms."],
+    status: "warning"
+  }, null, 2));
+  process.exit(0);
+}
 if (command === "compare-snapshot") {
   console.log(JSON.stringify({
     status: "changed",
@@ -144,6 +206,16 @@ process.exit(1);
       "login-smoke",
       "--snapshot",
       "landing-home",
+      "--a11y",
+      "--a11y-scope",
+      "#app",
+      "--a11y-impact",
+      "serious",
+      "--perf",
+      "--perf-budget",
+      "lcp=2s",
+      "--perf-wait-ms",
+      "400",
       "--session-bundle",
       bundlePath,
       "--json",
@@ -158,17 +230,28 @@ process.exit(1);
     status?: string;
     healthScore?: number;
     visualRisk?: { level?: string; score?: number; staleBaselines?: number };
+    accessibility?: { enabled?: boolean; violationCount?: number; topRules?: string[]; artifactJson?: string; artifactMarkdown?: string };
+    performance?: { enabled?: boolean; budgetViolationCount?: number; topViolations?: string[]; metrics?: { lcp?: number; cls?: number; failedResourceCount?: number }; artifactJson?: string; artifactMarkdown?: string };
     flowResults?: Array<{ name?: string; status?: string; steps?: number }>;
     snapshotResult?: { name?: string; status?: string; annotation?: string; screenshot?: string; baselineFreshness?: { routePath?: string; device?: string; ageDays?: number; stale?: boolean } | null; visualPack?: { index?: string; manifest?: string; diffImage?: string; imageDiff?: { score?: number } } | null };
     findings?: Array<{ severity?: string; category?: string; title?: string; evidence?: { annotation?: string } }>;
-    artifacts?: { annotation?: string; visualPack?: { index?: string; manifest?: string } | null };
+    artifacts?: { annotation?: string; visualPack?: { index?: string; manifest?: string } | null; accessibilityJson?: string; accessibilityMarkdown?: string; performanceJson?: string; performanceMarkdown?: string };
   };
 
   assert.equal(report.status, "critical");
-  assert.equal(report.healthScore, 36);
+  assert.equal(report.healthScore, 0);
   assert.equal(report.visualRisk?.level, "low");
   assert.ok(Number(report.visualRisk?.score || 0) > 0);
   assert.equal(report.visualRisk?.staleBaselines, 1);
+  assert.equal(report.accessibility?.enabled, true);
+  assert.equal(report.accessibility?.violationCount, 1);
+  assert.ok(report.accessibility?.topRules?.includes("color-contrast (1)"));
+  assert.equal(report.performance?.enabled, true);
+  assert.equal(report.performance?.budgetViolationCount, 1);
+  assert.equal(report.performance?.metrics?.lcp, 2450);
+  assert.equal(report.performance?.metrics?.cls, 0.19);
+  assert.equal(report.performance?.metrics?.failedResourceCount, 2);
+  assert.ok(report.performance?.topViolations?.some((item) => item.includes("LCP")));
   assert.equal(report.flowResults?.[0]?.name, "login-smoke");
   assert.equal(report.flowResults?.[0]?.status, "pass");
   assert.equal(report.flowResults?.[0]?.steps, 2);
@@ -186,9 +269,15 @@ process.exit(1);
   assert.ok(report.findings?.some((item) => item.severity === "critical" && item.category === "visual" && item.title === "Expected UI selectors are missing"));
   assert.ok(report.findings?.some((item) => item.severity === "medium" && item.category === "visual" && item.title === "Snapshot drift detected"));
   assert.ok(report.findings?.some((item) => item.title === "Snapshot baseline is stale"));
+  assert.ok(report.findings?.some((item) => item.category === "accessibility" && item.title === "Accessibility violation: color-contrast"));
+  assert.ok(report.findings?.some((item) => item.category === "performance" && item.title === "Performance budget exceeded: LCP"));
   assert.ok(report.findings?.some((item) => item.evidence?.annotation));
   assert.ok(report.artifacts?.annotation);
   assert.ok(report.artifacts?.visualPack?.index);
+  assert.ok(String(report.artifacts?.accessibilityJson).includes("-a11y.json"));
+  assert.ok(String(report.artifacts?.accessibilityMarkdown).includes("-a11y.md"));
+  assert.ok(String(report.artifacts?.performanceJson).includes("-performance.json"));
+  assert.ok(String(report.artifacts?.performanceMarkdown).includes("-performance.md"));
   assert.ok(fs.existsSync(path.join(fixtureRoot, String(report.artifacts?.annotation))));
   const imported = JSON.parse(fs.readFileSync(importMarker, "utf8")) as { sourcePath?: string; sessionFlag?: string; sessionName?: string };
   assert.equal(imported.sourcePath, bundlePath);

--- a/scripts/qa-run.ts
+++ b/scripts/qa-run.ts
@@ -13,6 +13,7 @@ type FindingSeverity = "critical" | "high" | "medium" | "low";
 type FindingCategory = "functional" | "visual" | "ux" | "content" | "console" | "performance" | "accessibility" | "qa-system";
 type ReportStatus = "critical" | "warning" | "pass";
 type SnapshotCommand = "snapshot" | "compare-snapshot";
+type AccessibilityImpact = "critical" | "serious" | "moderate" | "minor";
 
 interface QaArgs {
   url: string;
@@ -20,9 +21,16 @@ interface QaArgs {
   snapshot: string;
   updateSnapshot: boolean;
   session: string;
+  device: string;
   sessionBundle: string;
   mode: QaMode;
   baseRef: string;
+  a11y: boolean;
+  a11yScopes: string[];
+  a11yImpact: AccessibilityImpact;
+  perf: boolean;
+  perfBudgets: string[];
+  perfWaitMs: number;
   json: boolean;
   fixture: string;
   publishDir: string;
@@ -154,6 +162,64 @@ interface QaSnapshotSummary {
   visualPack?: VisualPackRef | null;
 }
 
+interface AccessibilityViolation {
+  id: string;
+  impact: string;
+  description: string;
+  help: string;
+  helpUrl: string;
+  selectors: string[];
+  nodeCount: number;
+}
+
+interface QaAccessibilitySummary {
+  enabled: boolean;
+  minimumImpact: AccessibilityImpact;
+  scopeSelectors: string[];
+  violationCount: number;
+  passCount: number;
+  incompleteCount: number;
+  topRules: string[];
+  violations: AccessibilityViolation[];
+  artifactJson?: string;
+  artifactMarkdown?: string;
+}
+
+interface PerformanceMetrics {
+  ttfb: number | null;
+  domContentLoaded: number | null;
+  loadEvent: number | null;
+  fcp: number | null;
+  lcp: number | null;
+  cls: number | null;
+  jsHeapUsed: number | null;
+  resourceCount: number;
+  failedResourceCount: number;
+}
+
+interface PerformanceBudgetResult {
+  metric: string;
+  label: string;
+  threshold: number;
+  unit: string;
+  severity: "high" | "medium";
+  raw: string;
+  value: number | null;
+  passed: boolean;
+  detail: string;
+}
+
+interface QaPerformanceSummary {
+  enabled: boolean;
+  waitMs: number;
+  metrics: PerformanceMetrics;
+  budgets: PerformanceBudgetResult[];
+  budgetViolationCount: number;
+  topViolations: string[];
+  artifactJson?: string;
+  artifactMarkdown?: string;
+}
+
 interface PublishedArtifacts {
   dir: string;
   json: string;
@@ -162,6 +228,10 @@ interface PublishedArtifacts {
   screenshot: string;
   current: string;
   baseline: string;
+  accessibilityJson?: string;
+  accessibilityMarkdown?: string;
+  performanceJson?: string;
+  performanceMarkdown?: string;
   visualPack?: VisualPackRef | null;
 }
 
@@ -171,6 +241,10 @@ interface QaArtifacts {
   latestJson?: string;
   latestMarkdown?: string;
   annotation?: string;
+  accessibilityJson?: string;
+  accessibilityMarkdown?: string;
+  performanceJson?: string;
+  performanceMarkdown?: string;
   visualPack?: VisualPackRef | null;
   trendsJson?: string;
   trendsMarkdown?: string;
@@ -215,6 +289,8 @@ interface QaReport {
   routeResults: QaRouteResult[];
   diffSummary: QaDiffSummary | null;
   snapshotResult: QaSnapshotSummary | null;
+  accessibility: QaAccessibilitySummary | null;
+  performance: QaPerformanceSummary | null;
   visualRisk: VisualRiskSummary;
   artifacts: QaArtifacts;
 }
@@ -250,6 +326,32 @@ interface ProbeCommandResult {
   bodyLength?: number;
 }
 
+interface AccessibilityCommandResult {
+  url?: string;
+  finalUrl?: string;
+  title?: string;
+  minimumImpact?: string;
+  scopeSelectors?: string[];
+  violationCount?: number;
+  passCount?: number;
+  incompleteCount?: number;
+  topRules?: string[];
+  violations?: AccessibilityViolation[];
+  status?: string;
+}
+
+interface PerformanceCommandResult {
+  url?: string;
+  finalUrl?: string;
+  title?: string;
+  waitMs?: number;
+  metrics?: Partial<PerformanceMetrics>;
+  budgets?: PerformanceBudgetResult[];
+  budgetViolationCount?: number;
+  topViolations?: string[];
+  status?: string;
+}
+
 interface QaFixtureSnapshot extends SnapshotCommandResult {
   name?: string;
   ok?: boolean;
@@ -269,6 +371,8 @@ interface QaFixture {
   url?: string;
   snapshot?: QaFixtureSnapshot;
   flows?: QaFixtureFlow[];
+  accessibility?: QaAccessibilitySummary | null;
+  performance?: QaPerformanceSummary | null;
 }
 
 const QA_DIR = path.resolve(process.cwd(), ".codex-stack", "qa");
@@ -280,7 +384,7 @@ function usage(): never {
   console.log(`qa-run
 
 Usage:
-  bun scripts/qa-run.ts <url> [--flow <name>] [--snapshot <name>] [--update-snapshot] [--session <name>] [--session-bundle <path>] [--mode <quick|full|regression|diff-aware>] [--base-ref <ref>] [--publish-dir <path>] [--json]
+  bun scripts/qa-run.ts <url> [--flow <name>] [--snapshot <name>] [--update-snapshot] [--session <name>] [--device <desktop|tablet|mobile>] [--session-bundle <path>] [--mode <quick|full|regression|diff-aware>] [--base-ref <ref>] [--a11y] [--a11y-scope <selector>] [--a11y-impact <critical|serious|moderate|minor>] [--perf] [--perf-budget <metric=value>] [--perf-wait-ms <n>] [--publish-dir <path>] [--json]
   bun scripts/qa-run.ts --fixture <path> [--publish-dir <path>] [--json]
 `);
   process.exit(0);
@@ -293,9 +397,16 @@ function parseArgs(argv: string[]): QaArgs {
     snapshot: "",
     updateSnapshot: false,
     session: "qa",
+    device: "desktop",
     sessionBundle: "",
     mode: "full",
     baseRef: process.env.CODEX_STACK_QA_BASE_REF || "origin/main",
+    a11y: false,
+    a11yScopes: [],
+    a11yImpact: "serious",
+    perf: false,
+    perfBudgets: [],
+    perfWaitMs: 250,
     json: false,
     fixture: "",
     publishDir: "",
@@ -316,12 +427,30 @@ function parseArgs(argv: string[]): QaArgs {
       out.updateSnapshot = true;
     } else if (arg === "--session") {
       out.session = copy.shift() || out.session;
+    } else if (arg === "--device") {
+      out.device = copy.shift() || out.device;
     } else if (arg === "--session-bundle") {
       out.sessionBundle = copy.shift() || "";
     } else if (arg === "--mode") {
       out.mode = copy.shift() || out.mode;
     } else if (arg === "--base-ref") {
       out.baseRef = copy.shift() || out.baseRef;
+    } else if (arg === "--a11y") {
+      out.a11y = true;
+    } else if (arg === "--a11y-scope") {
+      out.a11yScopes.push(copy.shift() || "");
+    } else if (arg === "--a11y-impact") {
+      const raw = String(copy.shift() || out.a11yImpact).trim().toLowerCase();
+      if (raw === "critical" || raw === "serious" || raw === "moderate" || raw === "minor") {
+        out.a11yImpact = raw;
+      }
+    } else if (arg === "--perf") {
+      out.perf = true;
+    } else if (arg === "--perf-budget") {
+      out.perfBudgets.push(copy.shift() || "");
+    } else if (arg === "--perf-wait-ms") {
+      const raw = Number.parseInt(copy.shift() || "", 10);
+      out.perfWaitMs = Number.isFinite(raw) && raw >= 0 ? raw : out.perfWaitMs;
     } else if (arg === "--json") {
       out.json = true;
     } else if (arg === "--fixture") {
@@ -334,6 +463,8 @@ function parseArgs(argv: string[]): QaArgs {
   }
 
   out.flows = [...new Set(out.flows.filter(Boolean))];
+  out.a11yScopes = [...new Set(out.a11yScopes.filter(Boolean))];
+  out.perfBudgets = [...new Set(out.perfBudgets.filter(Boolean))];
   if (!out.fixture && !out.url) {
     usage();
   }
@@ -372,6 +503,10 @@ function asString(value: unknown, fallback = ""): string {
 
 function asNumber(value: unknown, fallback = 0): number {
   return typeof value === "number" && Number.isFinite(value) ? value : fallback;
+}
+
+function asNullableNumber(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
 }
 
 function asStringArray(value: unknown): string[] {
@@ -456,6 +591,97 @@ function asProbeCommandResult(value: unknown): ProbeCommandResult {
     status: typeof obj?.status === "number" ? obj.status : null,
     ok: obj?.ok === undefined ? true : Boolean(obj?.ok),
     bodyLength: typeof obj?.bodyLength === "number" ? obj.bodyLength : 0,
+  };
+}
+
+function asAccessibilityViolation(value: unknown): AccessibilityViolation | null {
+  const obj = asObject(value);
+  if (!obj) return null;
+  const id = asString(obj.id);
+  const help = asString(obj.help);
+  if (!id && !help) return null;
+  return {
+    id,
+    impact: asString(obj.impact),
+    description: asString(obj.description),
+    help,
+    helpUrl: asString(obj.helpUrl),
+    selectors: asStringArray(obj.selectors),
+    nodeCount: asNumber(obj.nodeCount),
+  };
+}
+
+function asAccessibilityResult(value: unknown): QaAccessibilitySummary | null {
+  const obj = asObject(value);
+  if (!obj) return null;
+  const violations = Array.isArray(obj.violations)
+    ? obj.violations.map(asAccessibilityViolation).filter((item): item is AccessibilityViolation => Boolean(item))
+    : [];
+  return {
+    enabled: true,
+    minimumImpact: (() => {
+      const raw = asString(obj.minimumImpact).toLowerCase();
+      if (raw === "critical" || raw === "serious" || raw === "moderate" || raw === "minor") return raw;
+      return "serious";
+    })(),
+    scopeSelectors: asStringArray(obj.scopeSelectors),
+    violationCount: typeof obj.violationCount === "number" ? obj.violationCount : violations.length,
+    passCount: asNumber(obj.passCount),
+    incompleteCount: asNumber(obj.incompleteCount),
+    topRules: asStringArray(obj.topRules),
+    violations,
+  };
+}
+
+function asPerformanceMetrics(value: unknown): PerformanceMetrics {
+  const obj = asObject(value);
+  return {
+    ttfb: asNullableNumber(obj?.ttfb),
+    domContentLoaded: asNullableNumber(obj?.domContentLoaded),
+    loadEvent: asNullableNumber(obj?.loadEvent),
+    fcp: asNullableNumber(obj?.fcp),
+    lcp: asNullableNumber(obj?.lcp),
+    cls: asNullableNumber(obj?.cls),
+    jsHeapUsed: asNullableNumber(obj?.jsHeapUsed),
+    resourceCount: typeof obj?.resourceCount === "number" ? obj.resourceCount : 0,
+    failedResourceCount: typeof obj?.failedResourceCount === "number" ? obj.failedResourceCount : 0,
+  };
+}
+
+function asPerformanceBudgetResult(value: unknown): PerformanceBudgetResult | null {
+  const obj = asObject(value);
+  if (!obj) return null;
+  const metric = asString(obj.metric);
+  if (!metric) return null;
+  const severity = asString(obj.severity) === "high" ? "high" : "medium";
+  return {
+    metric,
+    label: asString(obj.label) || metric,
+    threshold: typeof obj.threshold === "number" ? obj.threshold : 0,
+    unit: asString(obj.unit),
+    severity,
+    raw: asString(obj.raw) || metric,
+    value: asNullableNumber(obj.value),
+    passed: obj.passed !== false,
+    detail: asString(obj.detail),
+  };
+}
+
+function asPerformanceResult(value: unknown): QaPerformanceSummary | null {
+  const obj = asObject(value);
+  if (!obj) return null;
+  const budgets = Array.isArray(obj.budgets)
+    ? obj.budgets.map(asPerformanceBudgetResult).filter((item): item is PerformanceBudgetResult => Boolean(item))
+    : [];
+  return {
+    enabled: true,
+    waitMs: typeof obj.waitMs === "number" ? obj.waitMs : 250,
+    metrics: asPerformanceMetrics(obj.metrics),
+    budgets,
+    budgetViolationCount: typeof obj.budgetViolationCount === "number"
+      ? obj.budgetViolationCount
+      : budgets.filter((item) => !item.passed).length,
+    topViolations: asStringArray(obj.topViolations),
   };
 }
 
@@ -551,6 +777,99 @@ function recommendation(status: ReportStatus, healthScore: number): string {
   return "QA checks passed. Keep the snapshot baseline fresh when intentional UI changes land.";
 }
 
+function formatMetric(metric: string, value: number | null): string {
+  if (value === null || !Number.isFinite(value)) return "n/a";
+  if (metric === "cls") return String(Number(value.toFixed(3)));
+  if (metric === "jsHeapUsed") {
+    if (value >= 1024 ** 2) return `${Number((value / (1024 ** 2)).toFixed(2))} MB`;
+    if (value >= 1024) return `${Number((value / 1024).toFixed(1))} KB`;
+    return `${Math.round(value)} B`;
+  }
+  if (metric === "resourceCount" || metric === "failedResourceCount") return String(Math.round(value));
+  return `${Math.round(value)} ms`;
+}
+
+function buildAccessibilityMarkdown(accessibility: QaAccessibilitySummary | null): string {
+  if (!accessibility?.enabled) {
+    return "# Accessibility Audit\n\nAccessibility checks were not enabled for this run.\n";
+  }
+  const violationLines = accessibility.violations.length
+    ? accessibility.violations.map((item) => (
+      `- ${String(item.impact || "unknown").toUpperCase()} ${item.id || item.help}: ${item.description || item.help}${item.selectors.length ? ` | selectors: ${item.selectors.join(", ")}` : ""}${item.helpUrl ? ` | help: ${item.helpUrl}` : ""}`
+    )).join("\n")
+    : "- No accessibility violations above the configured impact threshold.";
+  return `# Accessibility Audit
+
+- Minimum impact: ${accessibility.minimumImpact}
+- Scope selectors: ${accessibility.scopeSelectors.length ? accessibility.scopeSelectors.join(", ") : "document"}
+- Violations: ${accessibility.violationCount}
+- Passes: ${accessibility.passCount}
+- Incomplete: ${accessibility.incompleteCount}
+- Top rules: ${accessibility.topRules.length ? accessibility.topRules.join(", ") : "none"}
+
+## Violations
+
+${violationLines}
+`;
+}
+
+function buildPerformanceMarkdown(performance: QaPerformanceSummary | null): string {
+  if (!performance?.enabled) {
+    return "# Performance Audit\n\nPerformance checks were not enabled for this run.\n";
+  }
+  const metrics = performance.metrics;
+  const budgetLines = performance.budgets.length
+    ? performance.budgets.map((item) => (
+      `- ${item.label}: ${formatMetric(item.metric, item.value)} vs ${formatMetric(item.metric, item.threshold)} (${item.passed ? "pass" : item.severity})`
+    )).join("\n")
+    : "- No performance budgets were configured.";
+  return `# Performance Audit
+
+- Wait after load: ${performance.waitMs} ms
+- Budget violations: ${performance.budgetViolationCount}
+- Top violations: ${performance.topViolations.length ? performance.topViolations.join("; ") : "none"}
+- TTFB: ${formatMetric("ttfb", metrics.ttfb)}
+- DOMContentLoaded: ${formatMetric("domContentLoaded", metrics.domContentLoaded)}
+- Load event: ${formatMetric("loadEvent", metrics.loadEvent)}
+- FCP: ${formatMetric("fcp", metrics.fcp)}
+- LCP: ${formatMetric("lcp", metrics.lcp)}
+- CLS: ${formatMetric("cls", metrics.cls)}
+- JS heap used: ${formatMetric("jsHeapUsed", metrics.jsHeapUsed)}
+- Resource count: ${formatMetric("resourceCount", metrics.resourceCount)}
+- Failed resource count: ${formatMetric("failedResourceCount", metrics.failedResourceCount)}
+
+## Budgets
+
+${budgetLines}
+`;
+}
+
+function collectAccessibilityEvidence(args: QaArgs): QaAccessibilitySummary | null {
+  if (!args.a11y) return null;
+  const commandArgs = ["a11y", args.url, "--session", args.session, "--device", args.device, "--impact", args.a11yImpact];
+  for (const selector of args.a11yScopes) {
+    commandArgs.push("--scope", selector);
+  }
+  const result = runBrowse(commandArgs);
+  if (!result.ok || !result.parsed) {
+    throw new Error(cleanSubject(result.stderr || result.stdout || "browse a11y did not produce a JSON report."));
+  }
+  return asAccessibilityResult(result.parsed);
+}
+
+function collectPerformanceEvidence(args: QaArgs): QaPerformanceSummary | null {
+  if (!args.perf) return null;
+  const commandArgs = ["perf", args.url, "--session", args.session, "--device", args.device, "--wait-ms", String(args.perfWaitMs)];
+  for (const budget of args.perfBudgets) {
+    commandArgs.push("--budget", budget);
+  }
+  const result = runBrowse(commandArgs);
+  if (!result.ok || !result.parsed) {
+    throw new Error(cleanSubject(result.stderr || result.stdout || "browse perf did not produce a JSON report."));
+  }
+  return asPerformanceResult(result.parsed);
+}
+
 function routePathForSnapshot(snapshot: SnapshotDocument | null, fallbackUrl: string): string {
   const explicit = String(snapshot?.routePath || "").trim();
   if (explicit) return explicit;
@@ -617,6 +936,36 @@ function buildMarkdown(report: QaReport): string {
         .filter(Boolean)
         .join("\n")
     : "- Snapshot: none";
+  const accessibilityLines = report.accessibility?.enabled
+    ? [
+        `- Minimum impact: ${report.accessibility.minimumImpact}`,
+        `- Scope selectors: ${report.accessibility.scopeSelectors.length ? report.accessibility.scopeSelectors.join(", ") : "document"}`,
+        `- Violations: ${report.accessibility.violationCount}`,
+        `- Passes: ${report.accessibility.passCount}`,
+        `- Incomplete: ${report.accessibility.incompleteCount}`,
+        report.accessibility.topRules.length ? `- Top rules: ${report.accessibility.topRules.join(", ")}` : "",
+        report.artifacts.accessibilityJson ? `- Accessibility JSON: ${report.artifacts.accessibilityJson}` : "",
+        report.artifacts.accessibilityMarkdown ? `- Accessibility Markdown: ${report.artifacts.accessibilityMarkdown}` : "",
+      ].filter(Boolean).join("\n")
+    : "- Accessibility: not enabled";
+  const performanceLines = report.performance?.enabled
+    ? [
+        `- Wait after load: ${report.performance.waitMs} ms`,
+        `- Budget violations: ${report.performance.budgetViolationCount}`,
+        `- Top violations: ${report.performance.topViolations.length ? report.performance.topViolations.join("; ") : "none"}`,
+        `- TTFB: ${formatMetric("ttfb", report.performance.metrics.ttfb)}`,
+        `- DOMContentLoaded: ${formatMetric("domContentLoaded", report.performance.metrics.domContentLoaded)}`,
+        `- Load event: ${formatMetric("loadEvent", report.performance.metrics.loadEvent)}`,
+        `- FCP: ${formatMetric("fcp", report.performance.metrics.fcp)}`,
+        `- LCP: ${formatMetric("lcp", report.performance.metrics.lcp)}`,
+        `- CLS: ${formatMetric("cls", report.performance.metrics.cls)}`,
+        `- JS heap used: ${formatMetric("jsHeapUsed", report.performance.metrics.jsHeapUsed)}`,
+        `- Resource count: ${formatMetric("resourceCount", report.performance.metrics.resourceCount)}`,
+        `- Failed resource count: ${formatMetric("failedResourceCount", report.performance.metrics.failedResourceCount)}`,
+        report.artifacts.performanceJson ? `- Performance JSON: ${report.artifacts.performanceJson}` : "",
+        report.artifacts.performanceMarkdown ? `- Performance Markdown: ${report.artifacts.performanceMarkdown}` : "",
+      ].filter(Boolean).join("\n")
+    : "- Performance: not enabled";
 
   return `# QA Report
 
@@ -648,6 +997,14 @@ ${diffLines}
 ## Snapshot
 
 ${snapshotLine}
+
+## Accessibility
+
+${accessibilityLines}
+
+## Performance
+
+${performanceLines}
 `;
 }
 
@@ -836,7 +1193,7 @@ function createAnnotatedSnapshotArtifact(report: QaReport, snapshotEvidence: Sna
 function collectSnapshotEvidence(args: QaArgs): SnapshotEvidence | null {
   if (!args.snapshot) return null;
   if (args.updateSnapshot) {
-    const saved = runBrowse(["snapshot", args.url, args.snapshot, "--session", args.session]);
+    const saved = runBrowse(["snapshot", args.url, args.snapshot, "--session", args.session, "--device", args.device]);
     return {
       kind: "snapshot",
       command: "snapshot",
@@ -846,7 +1203,7 @@ function collectSnapshotEvidence(args: QaArgs): SnapshotEvidence | null {
     };
   }
 
-  const compared = runBrowse(["compare-snapshot", args.url, args.snapshot, "--session", args.session]);
+  const compared = runBrowse(["compare-snapshot", args.url, args.snapshot, "--session", args.session, "--device", args.device]);
   return {
     kind: "snapshot",
     command: "compare-snapshot",
@@ -858,7 +1215,7 @@ function collectSnapshotEvidence(args: QaArgs): SnapshotEvidence | null {
 
 function collectFlowEvidence(args: QaArgs): FlowEvidence[] {
   return args.flows.map((flowName) => {
-    const result = runBrowse(["run-flow", args.url, flowName, "--session", args.session]);
+    const result = runBrowse(["run-flow", args.url, flowName, "--session", args.session, "--device", args.device]);
     return {
       name: flowName,
       ok: result.ok,
@@ -910,7 +1267,7 @@ function collectRouteEvidence(args: QaArgs): { routeEvidence: RouteProbeEvidence
 
   for (const item of routeEvidence) {
     if (!item.url || item.dynamic) continue;
-    const result = runBrowse(["probe", item.url, "--session", args.session]);
+    const result = runBrowse(["probe", item.url, "--session", args.session, "--device", args.device]);
     if (!result.ok) {
       item.ok = false;
       item.status = "failed";
@@ -951,12 +1308,16 @@ function buildReport({
   flowEvidence,
   routeEvidence,
   diffSummary,
+  accessibility,
+  performance,
 }: {
   args: QaArgs;
   snapshotEvidence: SnapshotEvidence | null;
   flowEvidence: FlowEvidence[];
   routeEvidence: RouteProbeEvidence[];
   diffSummary: QaDiffSummary | null;
+  accessibility: QaAccessibilitySummary | null;
+  performance: QaPerformanceSummary | null;
 }): QaReport {
   const findings: QaFinding[] = [];
   const baselineDocument = snapshotEvidence
@@ -1090,6 +1451,61 @@ function buildReport({
     }
   }
 
+  if (accessibility?.enabled) {
+    for (const violation of accessibility.violations) {
+      const severity: FindingSeverity = violation.impact === "critical" || violation.impact === "serious"
+        ? "high"
+        : violation.impact === "moderate"
+          ? "medium"
+          : "low";
+      findings.push(
+        finding(
+          severity,
+          "accessibility",
+          `Accessibility violation: ${violation.id || violation.help}`,
+          `${violation.help || violation.description}${violation.nodeCount ? ` (${violation.nodeCount} affected node${violation.nodeCount === 1 ? "" : "s"})` : ""}`,
+          {
+            rule: violation.id,
+            impact: violation.impact,
+            selectors: violation.selectors.join(", "),
+            helpUrl: violation.helpUrl,
+          },
+        ),
+      );
+    }
+  }
+
+  if (performance?.enabled) {
+    for (const budget of performance.budgets.filter((item) => !item.passed)) {
+      findings.push(
+        finding(
+          budget.severity,
+          "performance",
+          `Performance budget exceeded: ${budget.label}`,
+          budget.detail,
+          {
+            metric: budget.metric,
+            threshold: String(budget.threshold),
+            value: budget.value === null ? "n/a" : String(budget.value),
+          },
+        ),
+      );
+    }
+    if (!performance.budgets.length && performance.metrics.failedResourceCount > 0) {
+      findings.push(
+        finding(
+          "medium",
+          "performance",
+          "Page failed to load resources",
+          `${performance.metrics.failedResourceCount} resource request(s) failed during the performance capture.`,
+          {
+            failedResourceCount: String(performance.metrics.failedResourceCount),
+          },
+        ),
+      );
+    }
+  }
+
   const healthScore = scoreFindings(findings);
   const status = statusFromFindings(findings);
   const generatedAt = new Date().toISOString();
@@ -1131,6 +1547,8 @@ function buildReport({
     })),
     diffSummary,
     snapshotResult,
+    accessibility,
+    performance,
     visualRisk,
     artifacts: snapshotEvidence?.result.visualPack ? { visualPack: snapshotEvidence.result.visualPack } : {},
   };
@@ -1221,6 +1639,15 @@ function rewriteEvidencePaths(report: QaReport, pathMap: Record<string, string>)
       }
     }
   }
+
+  if (report.accessibility) {
+    if (report.accessibility.artifactJson && pathMap[report.accessibility.artifactJson]) report.accessibility.artifactJson = pathMap[report.accessibility.artifactJson];
+    if (report.accessibility.artifactMarkdown && pathMap[report.accessibility.artifactMarkdown]) report.accessibility.artifactMarkdown = pathMap[report.accessibility.artifactMarkdown];
+  }
+  if (report.performance) {
+    if (report.performance.artifactJson && pathMap[report.performance.artifactJson]) report.performance.artifactJson = pathMap[report.performance.artifactJson];
+    if (report.performance.artifactMarkdown && pathMap[report.performance.artifactMarkdown]) report.performance.artifactMarkdown = pathMap[report.performance.artifactMarkdown];
+  }
 }
 
 function publishArtifacts(report: QaReport, publishDir: string): QaReport {
@@ -1237,6 +1664,10 @@ function publishArtifacts(report: QaReport, publishDir: string): QaReport {
     [report.snapshotResult?.screenshot || "", path.join(outputDir, "screenshot.png")],
     [report.snapshotResult?.current || "", path.join(outputDir, "current.json")],
     [report.snapshotResult?.baseline || "", path.join(outputDir, "baseline.json")],
+    [report.artifacts.accessibilityJson || "", path.join(outputDir, "a11y.json")],
+    [report.artifacts.accessibilityMarkdown || "", path.join(outputDir, "a11y.md")],
+    [report.artifacts.performanceJson || "", path.join(outputDir, "performance.json")],
+    [report.artifacts.performanceMarkdown || "", path.join(outputDir, "performance.md")],
   ];
 
   for (const [source, target] of copyTargets) {
@@ -1288,6 +1719,10 @@ function publishArtifacts(report: QaReport, publishDir: string): QaReport {
       screenshot: pathMap[report.snapshotResult?.screenshot || ""] || "",
       current: pathMap[report.snapshotResult?.current || ""] || "",
       baseline: pathMap[report.snapshotResult?.baseline || ""] || "",
+      accessibilityJson: pathMap[report.artifacts.accessibilityJson || ""] || "",
+      accessibilityMarkdown: pathMap[report.artifacts.accessibilityMarkdown || ""] || "",
+      performanceJson: pathMap[report.artifacts.performanceJson || ""] || "",
+      performanceMarkdown: pathMap[report.artifacts.performanceMarkdown || ""] || "",
       visualPack: publishedVisualPack,
     },
   };
@@ -1312,6 +1747,26 @@ function writeArtifacts(report: QaReport): QaReport {
     latestJson: relative(latestJsonPath),
     latestMarkdown: relative(latestMarkdownPath),
   };
+  if (report.accessibility?.enabled) {
+    const accessibilityJsonPath = path.join(QA_DIR, `${stamp}-a11y.json`);
+    const accessibilityMarkdownPath = path.join(QA_DIR, `${stamp}-a11y.md`);
+    report.artifacts.accessibilityJson = relative(accessibilityJsonPath);
+    report.artifacts.accessibilityMarkdown = relative(accessibilityMarkdownPath);
+    report.accessibility.artifactJson = report.artifacts.accessibilityJson;
+    report.accessibility.artifactMarkdown = report.artifacts.accessibilityMarkdown;
+    writeFile(accessibilityJsonPath, JSON.stringify(report.accessibility, null, 2));
+    writeFile(accessibilityMarkdownPath, buildAccessibilityMarkdown(report.accessibility));
+  }
+  if (report.performance?.enabled) {
+    const performanceJsonPath = path.join(QA_DIR, `${stamp}-performance.json`);
+    const performanceMarkdownPath = path.join(QA_DIR, `${stamp}-performance.md`);
+    report.artifacts.performanceJson = relative(performanceJsonPath);
+    report.artifacts.performanceMarkdown = relative(performanceMarkdownPath);
+    report.performance.artifactJson = report.artifacts.performanceJson;
+    report.performance.artifactMarkdown = report.artifacts.performanceMarkdown;
+    writeFile(performanceJsonPath, JSON.stringify(report.performance, null, 2));
+    writeFile(performanceMarkdownPath, buildPerformanceMarkdown(report.performance));
+  }
 
   const markdown = buildMarkdown(report);
   writeFile(jsonPath, JSON.stringify(report, null, 2));
@@ -1362,12 +1817,16 @@ if (args.fixture) {
       : [],
     routeEvidence: [],
     diffSummary: null,
+    accessibility: fixture.accessibility || null,
+    performance: fixture.performance || null,
   });
 } else {
   const snapshotEvidence = collectSnapshotEvidence(args);
   const flowEvidence = collectFlowEvidence(args);
   const { routeEvidence, diffSummary } = collectRouteEvidence(args);
-  report = buildReport({ args, snapshotEvidence, flowEvidence, routeEvidence, diffSummary });
+  const accessibility = collectAccessibilityEvidence(args);
+  const performance = collectPerformanceEvidence(args);
+  report = buildReport({ args, snapshotEvidence, flowEvidence, routeEvidence, diffSummary, accessibility, performance });
   report = attachSnapshotAnnotation(report, snapshotEvidence);
 }
 

--- a/scripts/render-pr-review.spec.ts
+++ b/scripts/render-pr-review.spec.ts
@@ -78,6 +78,24 @@ async function main(): Promise<void> {
     },
     qa: {
       healthScore: 60,
+      accessibility: {
+        enabled: true,
+        violationCount: 3,
+        minimumImpact: "serious",
+        topRules: ["color-contrast (2)", "label (1)"],
+        artifactMarkdown: "preview-artifacts/a11y.md",
+      },
+      performance: {
+        enabled: true,
+        budgetViolationCount: 2,
+        topViolations: ["LCP exceeded 2000 ms", "CLS exceeded 0.1"],
+        metrics: {
+          lcp: 2420,
+          cls: 0.18,
+          failedResourceCount: 1,
+        },
+        artifactMarkdown: "preview-artifacts/performance.md",
+      },
       findings: [
         {
           severity: "critical",
@@ -173,6 +191,13 @@ async function main(): Promise<void> {
   assert.match(stdout, /`changed` `score 68\.2` `ratio 0\.318` dashboard @ \//);
   assert.match(stdout, /1 stale baseline need review or refresh/);
   assert.match(stdout, /CRITICAL\/VISUAL/);
+  assert.match(stdout, /Accessibility: 3 violations \(min impact serious\)/);
+  assert.match(stdout, /Performance: 2 budget violations, 1 failed resources/);
+  assert.match(stdout, /### Accessibility summary/);
+  assert.match(stdout, /Top rules: color-contrast \(2\), label \(1\)/);
+  assert.match(stdout, /### Performance summary/);
+  assert.match(stdout, /LCP: 2420/);
+  assert.match(stdout, /CLS: 0.18/);
   assert.match(stdout, /annotation\.svg/);
   assert.match(stdout, /### Deploy checks/);
   assert.match(stdout, /baselineAge=43d-stale/);

--- a/scripts/render-pr-review.ts
+++ b/scripts/render-pr-review.ts
@@ -30,6 +30,24 @@ interface PreviewQaReport {
   healthScore?: number;
   recommendation?: string;
   findings?: PreviewFinding[];
+  accessibility?: {
+    enabled?: boolean;
+    violationCount?: number;
+    minimumImpact?: string;
+    topRules?: string[];
+    artifactMarkdown?: string;
+  } | null;
+  performance?: {
+    enabled?: boolean;
+    budgetViolationCount?: number;
+    topViolations?: string[];
+    metrics?: {
+      lcp?: number | null;
+      cls?: number | null;
+      failedResourceCount?: number;
+    };
+    artifactMarkdown?: string;
+  } | null;
   snapshotResult?: {
     name?: string;
     status?: string;
@@ -358,6 +376,8 @@ function renderPreviewSection(preview: PreviewReport | null, summary: ReviewSumm
   const hostedVisualPack = absoluteLink(previewPagesRoot, "visual/index.html");
   const hostedVisualManifest = absoluteLink(previewPagesRoot, "visual/manifest.json");
   const hostedScreenshotManifest = absoluteLink(previewPagesRoot, "screenshots.json");
+  const a11y = preview.qa?.accessibility;
+  const perf = preview.qa?.performance;
   return `
 ## Preview QA
 
@@ -379,6 +399,8 @@ ${preview.deploy?.screenshotManifest ? `- Screenshot manifest: \`${preview.deplo
 ${hostedScreenshotManifest ? `- Hosted screenshot manifest: ${hostedScreenshotManifest}` : ""}
 ${preview.deploy?.visualPack?.index ? `- Local visual pack: \`${preview.deploy.visualPack.index}\`` : ""}
 ${snapshot?.status ? `- Snapshot: ${snapshot.status}${snapshot.name ? ` (${snapshot.name})` : ""}` : ""}
+${a11y?.enabled ? `- Accessibility: ${a11y.violationCount ?? 0} violations${a11y.minimumImpact ? ` (min impact ${a11y.minimumImpact})` : ""}` : ""}
+${perf?.enabled ? `- Performance: ${perf.budgetViolationCount ?? 0} budget violations${typeof perf.metrics?.failedResourceCount === "number" ? `, ${perf.metrics.failedResourceCount} failed resources` : ""}` : ""}
 
 ### Preview findings
 
@@ -395,6 +417,23 @@ ${deploySnapshotLines(preview).join("\n")}
 ### Visual summary
 
 ${visualBadgeLines(preview, previewPagesRoot).join("\n")}
+
+${a11y?.enabled ? `### Accessibility summary
+
+- Violations: ${a11y.violationCount ?? 0}
+${a11y.topRules?.length ? `- Top rules: ${a11y.topRules.join(", ")}` : "- Top rules: none"}
+${a11y.artifactMarkdown ? `- Report: \`${a11y.artifactMarkdown}\`` : ""}
+` : ""}
+
+${perf?.enabled ? `### Performance summary
+
+- Budget violations: ${perf.budgetViolationCount ?? 0}
+${perf.topViolations?.length ? `- Top violations: ${perf.topViolations.join("; ")}` : "- Top violations: none"}
+- LCP: ${perf.metrics?.lcp ?? "n/a"}
+- CLS: ${perf.metrics?.cls ?? "n/a"}
+- Failed resources: ${perf.metrics?.failedResourceCount ?? 0}
+${perf.artifactMarkdown ? `- Report: \`${perf.artifactMarkdown}\`` : ""}
+` : ""}
 
 ${preview.visualRisk?.topDrivers?.length ? `### Visual risk drivers
 

--- a/scripts/render-qa-pages.spec.ts
+++ b/scripts/render-qa-pages.spec.ts
@@ -57,6 +57,22 @@ async function main(): Promise<void> {
       level: "medium",
       staleBaselines: 0,
     },
+    accessibility: {
+      enabled: true,
+      minimumImpact: "serious",
+      violationCount: 1,
+      topRules: ["color-contrast (1)"],
+    },
+    performance: {
+      enabled: true,
+      budgetViolationCount: 1,
+      topViolations: ["LCP exceeded 2000 ms"],
+      metrics: {
+        lcp: 1980,
+        cls: 0.08,
+        failedResourceCount: 0,
+      },
+    },
   });
 
   writeReport(reportB, {
@@ -90,6 +106,22 @@ async function main(): Promise<void> {
       level: "critical",
       staleBaselines: 1,
     },
+    accessibility: {
+      enabled: true,
+      minimumImpact: "serious",
+      violationCount: 4,
+      topRules: ["color-contrast (2)", "label (2)"],
+    },
+    performance: {
+      enabled: true,
+      budgetViolationCount: 2,
+      topViolations: ["LCP exceeded 2000 ms", "CLS exceeded 0.1"],
+      metrics: {
+        lcp: 2840,
+        cls: 0.19,
+        failedResourceCount: 2,
+      },
+    },
   });
 
   execFileSync(
@@ -117,29 +149,51 @@ async function main(): Promise<void> {
     imageDiffScore?: number;
     baselineAgeDays?: number;
     staleBaseline?: boolean;
+    accessibilityViolations?: number;
+    performanceBudgetViolations?: number;
+    largestContentfulPaint?: number;
+    cumulativeLayoutShift?: number;
   }>;
   const manifest = JSON.parse(fs.readFileSync(path.join(outDir, "manifest.json"), "utf8")) as {
     historyPath?: string;
-    reports?: Array<{ visualRiskScore?: number; staleBaseline?: boolean }>;
+    reports?: Array<{ visualRiskScore?: number; staleBaseline?: boolean; accessibilityViolations?: number; performanceBudgetViolations?: number }>;
   };
 
   assert.match(indexHtml, /Visual history/);
   assert.match(indexHtml, /Visual risk score/);
   assert.match(indexHtml, /Snapshot image diff score/);
+  assert.match(indexHtml, /Accessibility violations/);
+  assert.match(indexHtml, /Performance budget violations/);
+  assert.match(indexHtml, /Largest contentful paint \(ms\)/);
   assert.match(indexHtml, /Baseline age \(days\)/);
   assert.match(indexHtml, /Latest visual risk:<\/strong> CRITICAL \(86\/100\)/);
+  assert.match(indexHtml, /Latest accessibility violations:<\/strong> 4/);
+  assert.match(indexHtml, /Latest perf budget violations:<\/strong> 2/);
   assert.match(indexHtml, /Baseline age:<\/strong> 47d • stale/);
+  assert.match(indexHtml, /A11y violations:<\/strong> 4/);
+  assert.match(indexHtml, /Perf budget violations:<\/strong> 2/);
   assert.match(reportHtml, /Route:<\/strong> \/dashboard/);
   assert.match(reportHtml, /Baseline age:<\/strong> 47d • stale/);
+  assert.match(reportHtml, /Accessibility/);
+  assert.match(reportHtml, /Violations:<\/strong> 4/);
+  assert.match(reportHtml, /Performance/);
+  assert.match(reportHtml, /Budget violations:<\/strong> 2/);
+  assert.match(reportHtml, /LCP:<\/strong> 2840 ms/);
   assert.equal(history.length, 2);
   assert.equal(history[1]?.slug, "2026-03-15-dashboard");
   assert.equal(history[1]?.visualRiskScore, 86);
   assert.equal(history[1]?.imageDiffScore, 63.7);
   assert.equal(history[1]?.baselineAgeDays, 47);
   assert.equal(history[1]?.staleBaseline, true);
+  assert.equal(history[1]?.accessibilityViolations, 4);
+  assert.equal(history[1]?.performanceBudgetViolations, 2);
+  assert.equal(history[1]?.largestContentfulPaint, 2840);
+  assert.equal(history[1]?.cumulativeLayoutShift, 0.19);
   assert.equal(manifest.historyPath, "qa/history.json");
   assert.equal(manifest.reports?.[0]?.visualRiskScore, 86);
   assert.equal(manifest.reports?.[0]?.staleBaseline, true);
+  assert.equal(manifest.reports?.[0]?.accessibilityViolations, 4);
+  assert.equal(manifest.reports?.[0]?.performanceBudgetViolations, 2);
 
   console.log("render-qa-pages spec passed");
 }

--- a/scripts/render-qa-pages.ts
+++ b/scripts/render-qa-pages.ts
@@ -56,6 +56,24 @@ interface QaVisualRisk {
   topDrivers?: string[];
 }
 
+interface QaAccessibilitySummary {
+  enabled?: boolean;
+  minimumImpact?: string;
+  violationCount?: string | number;
+  topRules?: string[];
+}
+
+interface QaPerformanceSummary {
+  enabled?: boolean;
+  budgetViolationCount?: string | number;
+  topViolations?: string[];
+  metrics?: {
+    lcp?: string | number | null;
+    cls?: string | number | null;
+    failedResourceCount?: string | number;
+  };
+}
+
 interface QaReportData extends Record<string, unknown> {
   status?: string;
   recommendation?: string;
@@ -68,6 +86,8 @@ interface QaReportData extends Record<string, unknown> {
   flowResults?: QaFlowResult[];
   snapshotResult?: QaSnapshotResult;
   visualRisk?: QaVisualRisk;
+  accessibility?: QaAccessibilitySummary | null;
+  performance?: QaPerformanceSummary | null;
 }
 
 interface CollectedReport {
@@ -91,6 +111,10 @@ interface CollectedReport {
   imageDiffScore: number | null;
   baselineAgeDays: number | null;
   staleBaseline: boolean;
+  accessibilityViolations: number | null;
+  performanceBudgetViolations: number | null;
+  largestContentfulPaint: number | null;
+  cumulativeLayoutShift: number | null;
 }
 
 interface VisualHistoryPoint {
@@ -103,6 +127,10 @@ interface VisualHistoryPoint {
   imageDiffScore: number | null;
   baselineAgeDays: number | null;
   staleBaseline: boolean;
+  accessibilityViolations: number | null;
+  performanceBudgetViolations: number | null;
+  largestContentfulPaint: number | null;
+  cumulativeLayoutShift: number | null;
   stableUrl: string;
 }
 
@@ -304,6 +332,10 @@ function buildVisualHistory(reports: CollectedReport[]): VisualHistoryPoint[] {
       imageDiffScore: report.imageDiffScore,
       baselineAgeDays: report.baselineAgeDays,
       staleBaseline: report.staleBaseline,
+      accessibilityViolations: report.accessibilityViolations,
+      performanceBudgetViolations: report.performanceBudgetViolations,
+      largestContentfulPaint: report.largestContentfulPaint,
+      cumulativeLayoutShift: report.cumulativeLayoutShift,
       stableUrl: report.stableUrl,
     }))
     .sort((left, right) => (Date.parse(left.generatedAt || "0") || 0) - (Date.parse(right.generatedAt || "0") || 0));
@@ -365,6 +397,8 @@ function renderHistorySection(reports: CollectedReport[]): string {
   const summary = [
     `<span><strong>Reports:</strong> ${points.length}</span>`,
     latest.visualRiskScore !== null ? `<span><strong>Latest visual risk:</strong> ${latest.visualRiskLevel.toUpperCase()} (${latest.visualRiskScore}/100)</span>` : "",
+    latest.accessibilityViolations !== null ? `<span><strong>Latest accessibility violations:</strong> ${latest.accessibilityViolations}</span>` : "",
+    latest.performanceBudgetViolations !== null ? `<span><strong>Latest perf budget violations:</strong> ${latest.performanceBudgetViolations}</span>` : "",
     latest.imageDiffScore !== null ? `<span><strong>Latest image diff score:</strong> ${latest.imageDiffScore}</span>` : "",
     `<span><strong>Stale baselines:</strong> ${staleCount}</span>`,
   ].filter(Boolean).join("");
@@ -383,6 +417,24 @@ function renderHistorySection(reports: CollectedReport[]): string {
       title: "Snapshot image diff score",
       accessor: (point) => point.imageDiffScore,
       color: "#1d4ed8",
+    })}
+    ${renderHistoryChart(points, {
+      title: "Accessibility violations",
+      accessor: (point) => point.accessibilityViolations,
+      color: "#7c3aed",
+      maxValue: Math.max(10, ...points.map((item) => item.accessibilityViolations || 0)),
+    })}
+    ${renderHistoryChart(points, {
+      title: "Performance budget violations",
+      accessor: (point) => point.performanceBudgetViolations,
+      color: "#0f766e",
+      maxValue: Math.max(5, ...points.map((item) => item.performanceBudgetViolations || 0)),
+    })}
+    ${renderHistoryChart(points, {
+      title: "Largest contentful paint (ms)",
+      accessor: (point) => point.largestContentfulPaint,
+      color: "#9333ea",
+      maxValue: Math.max(2500, ...points.map((item) => item.largestContentfulPaint || 0)),
     })}
     ${renderHistoryChart(points, {
       title: "Baseline age (days)",
@@ -614,6 +666,9 @@ function renderIndex({ reports, baseUrl }: { reports: CollectedReport[]; baseUrl
         <div class="meta">
           <span><strong>Health score:</strong> ${escapeHtml(report.data.healthScore)}</span>
           ${report.visualRiskScore !== null ? `<span><strong>Visual risk:</strong> ${escapeHtml(`${report.visualRiskLevel.toUpperCase()} (${report.visualRiskScore}/100)`)}</span>` : ""}
+          ${report.accessibilityViolations !== null ? `<span><strong>A11y violations:</strong> ${escapeHtml(report.accessibilityViolations)}</span>` : ""}
+          ${report.performanceBudgetViolations !== null ? `<span><strong>Perf budget violations:</strong> ${escapeHtml(report.performanceBudgetViolations)}</span>` : ""}
+          ${report.largestContentfulPaint !== null ? `<span><strong>LCP:</strong> ${escapeHtml(`${report.largestContentfulPaint} ms`)}</span>` : ""}
           ${report.imageDiffScore !== null ? `<span><strong>Image diff:</strong> ${escapeHtml(report.imageDiffScore)}</span>` : ""}
           ${report.baselineAgeDays !== null ? `<span><strong>Baseline age:</strong> ${escapeHtml(`${report.baselineAgeDays}d${report.staleBaseline ? " • stale" : ""}`)}</span>` : ""}
           <span><strong>Generated:</strong> ${escapeHtml(formatDate(report.data.generatedAt))}</span>
@@ -675,6 +730,10 @@ function renderReport(report: CollectedReport, baseUrl: string): string {
             <span><strong>Session:</strong> ${escapeHtml(report.data.session || "n/a")}</span>
             <span><strong>Mode:</strong> ${escapeHtml(report.data.mode || "n/a")}</span>
             <span><strong>URL:</strong> ${escapeHtml(report.data.url || "fixture")}</span>
+            ${report.accessibilityViolations !== null ? `<span><strong>A11y violations:</strong> ${escapeHtml(report.accessibilityViolations)}</span>` : ""}
+            ${report.performanceBudgetViolations !== null ? `<span><strong>Perf budget violations:</strong> ${escapeHtml(report.performanceBudgetViolations)}</span>` : ""}
+            ${report.largestContentfulPaint !== null ? `<span><strong>LCP:</strong> ${escapeHtml(`${report.largestContentfulPaint} ms`)}</span>` : ""}
+            ${report.cumulativeLayoutShift !== null ? `<span><strong>CLS:</strong> ${escapeHtml(report.cumulativeLayoutShift)}</span>` : ""}
           </div>
           <div class="detail-links">${detailLinks.join("\n") || '<span class="empty">No report assets recorded.</span>'}</div>
         </article>
@@ -700,6 +759,27 @@ function renderReport(report: CollectedReport, baseUrl: string): string {
         <article class="card section">
           <h2>Flow results</h2>
           <ul class="clean">${flowRows(report)}</ul>
+        </article>
+      </section>
+      <section class="grid two" style="margin-top: 18px;">
+        <article class="card section">
+          <h2>Accessibility</h2>
+          <div class="meta">
+            <span><strong>Enabled:</strong> ${escapeHtml(report.data.accessibility?.enabled ? "yes" : "no")}</span>
+            ${report.accessibilityViolations !== null ? `<span><strong>Violations:</strong> ${escapeHtml(report.accessibilityViolations)}</span>` : ""}
+            ${report.data.accessibility?.minimumImpact ? `<span><strong>Minimum impact:</strong> ${escapeHtml(report.data.accessibility.minimumImpact)}</span>` : ""}
+          </div>
+          ${Array.isArray(report.data.accessibility?.topRules) && report.data.accessibility.topRules.length ? `<ul class="clean">${report.data.accessibility.topRules.map((item) => `<li>${escapeHtml(item)}</li>`).join("")}</ul>` : '<p class="empty">No accessibility summary recorded.</p>'}
+        </article>
+        <article class="card section">
+          <h2>Performance</h2>
+          <div class="meta">
+            <span><strong>Enabled:</strong> ${escapeHtml(report.data.performance?.enabled ? "yes" : "no")}</span>
+            ${report.performanceBudgetViolations !== null ? `<span><strong>Budget violations:</strong> ${escapeHtml(report.performanceBudgetViolations)}</span>` : ""}
+            ${report.largestContentfulPaint !== null ? `<span><strong>LCP:</strong> ${escapeHtml(`${report.largestContentfulPaint} ms`)}</span>` : ""}
+            ${report.cumulativeLayoutShift !== null ? `<span><strong>CLS:</strong> ${escapeHtml(report.cumulativeLayoutShift)}</span>` : ""}
+          </div>
+          ${Array.isArray(report.data.performance?.topViolations) && report.data.performance.topViolations.length ? `<ul class="clean">${report.data.performance.topViolations.map((item) => `<li>${escapeHtml(item)}</li>`).join("")}</ul>` : '<p class="empty">No performance summary recorded.</p>'}
         </article>
       </section>
       <section class="card section" style="margin-top: 18px;">
@@ -740,6 +820,10 @@ function collectReports(sourceDir: string, baseUrl: string): CollectedReport[] {
         imageDiffScore: asNumber(data.snapshotResult?.visualPack?.imageDiff?.score),
         baselineAgeDays: asNumber(data.snapshotResult?.baselineFreshness?.ageDays),
         staleBaseline: Boolean(data.snapshotResult?.baselineFreshness?.stale),
+        accessibilityViolations: asNumber(data.accessibility?.violationCount),
+        performanceBudgetViolations: asNumber(data.performance?.budgetViolationCount),
+        largestContentfulPaint: asNumber(data.performance?.metrics?.lcp),
+        cumulativeLayoutShift: asNumber(data.performance?.metrics?.cls),
       };
       report.stableUrl = reportLink(baseUrl, report);
       report.stableAnnotationUrl = report.annotationPath ? assetLink(baseUrl, report, "annotation.svg") : "";
@@ -800,6 +884,10 @@ function main(): void {
       imageDiffScore: report.imageDiffScore,
       baselineAgeDays: report.baselineAgeDays,
       staleBaseline: report.staleBaseline,
+      accessibilityViolations: report.accessibilityViolations,
+      performanceBudgetViolations: report.performanceBudgetViolations,
+      largestContentfulPaint: report.largestContentfulPaint,
+      cumulativeLayoutShift: report.cumulativeLayoutShift,
     })),
   };
   fs.writeFileSync(path.join(args.out, "qa", "history.json"), JSON.stringify(buildVisualHistory(reports), null, 2));

--- a/scripts/ship-branch.ts
+++ b/scripts/ship-branch.ts
@@ -37,6 +37,12 @@ interface ShipArgs {
   verifySnapshot: string;
   verifySession: string;
   verifyConsoleErrors: boolean;
+  verifyA11y: boolean;
+  verifyA11yScopes: string[];
+  verifyA11yImpact: string;
+  verifyPerf: boolean;
+  verifyPerfBudgets: string[];
+  verifyPerfWaitMs: number;
   updateVerifySnapshot: boolean;
 }
 
@@ -132,13 +138,46 @@ interface QaPublishedArtifacts {
   json?: string;
   annotation?: string;
   screenshot?: string;
+  accessibilityJson?: string;
+  accessibilityMarkdown?: string;
+  performanceJson?: string;
+  performanceMarkdown?: string;
 }
 
 interface QaArtifacts {
   markdown?: string;
   json?: string;
   annotation?: string;
+  accessibilityJson?: string;
+  accessibilityMarkdown?: string;
+  performanceJson?: string;
+  performanceMarkdown?: string;
   published?: QaPublishedArtifacts;
+}
+
+interface QaAccessibilitySummary {
+  enabled?: boolean;
+  minimumImpact?: string;
+  violationCount?: number;
+  topRules?: string[];
+  artifactJson?: string;
+  artifactMarkdown?: string;
+}
+
+interface QaPerformanceMetrics {
+  lcp?: number | null;
+  cls?: number | null;
+  failedResourceCount?: number;
+}
+
+interface QaPerformanceSummary {
+  enabled?: boolean;
+  waitMs?: number;
+  metrics?: QaPerformanceMetrics;
+  budgetViolationCount?: number;
+  topViolations?: string[];
+  artifactJson?: string;
+  artifactMarkdown?: string;
 }
 
 interface QaReportSummary {
@@ -202,6 +241,8 @@ interface DeployQaReport {
   findings?: QaFinding[];
   flowResults?: QaFlowResult[];
   snapshotResults?: DeploySnapshotResult[];
+  accessibility?: QaAccessibilitySummary | null;
+  performance?: QaPerformanceSummary | null;
   artifacts?: DeployArtifacts;
 }
 
@@ -245,6 +286,8 @@ interface VerificationSummary {
   visualRiskLevel: string;
   staleBaselines: number;
   consoleErrors: number;
+  accessibilityViolations: number;
+  performanceBudgetViolations: number;
   reportPath: string;
   stableReportUrl: string;
   publishDir: string;
@@ -285,7 +328,7 @@ function usage(): never {
   console.log(`ship-branch
 
 Usage:
-  bun scripts/ship-branch.ts [--dry-run] [--skip-tests] [--base <ref>] [--message <msg>] [--push] [--pr] [--title <title>] [--body <body>] [--body-file <path>] [--template <path>] [--reviewer <user>] [--team-reviewer <org/team>] [--assignee <user>] [--assign-self] [--project <title>] [--label <name>] [--milestone <title>] [--verify-url <url>] [--verify-path <path>] [--verify-device <desktop|tablet|mobile>] [--verify-flow <name>] [--verify-snapshot <name>] [--verify-session <name>] [--verify-console-errors] [--update-verify-snapshot] [--draft] [--no-auto-labels] [--no-auto-reviewers] [--json]
+  bun scripts/ship-branch.ts [--dry-run] [--skip-tests] [--base <ref>] [--message <msg>] [--push] [--pr] [--title <title>] [--body <body>] [--body-file <path>] [--template <path>] [--reviewer <user>] [--team-reviewer <org/team>] [--assignee <user>] [--assign-self] [--project <title>] [--label <name>] [--milestone <title>] [--verify-url <url>] [--verify-path <path>] [--verify-device <desktop|tablet|mobile>] [--verify-flow <name>] [--verify-snapshot <name>] [--verify-session <name>] [--verify-console-errors] [--verify-a11y] [--verify-a11y-scope <selector>] [--verify-a11y-impact <critical|serious|moderate|minor>] [--verify-perf] [--verify-perf-budget <metric=value>] [--verify-perf-wait-ms <n>] [--update-verify-snapshot] [--draft] [--no-auto-labels] [--no-auto-reviewers] [--json]
 `);
   process.exit(0);
 }
@@ -368,6 +411,12 @@ function parseArgs(argv: string[]): ShipArgs {
     verifySnapshot: "",
     verifySession: "",
     verifyConsoleErrors: false,
+    verifyA11y: false,
+    verifyA11yScopes: [],
+    verifyA11yImpact: "serious",
+    verifyPerf: false,
+    verifyPerfBudgets: [],
+    verifyPerfWaitMs: 250,
     updateVerifySnapshot: false,
   };
   for (let i = 0; i < argv.length; i += 1) {
@@ -430,6 +479,23 @@ function parseArgs(argv: string[]): ShipArgs {
       i += 1;
     } else if (arg === "--verify-console-errors") {
       out.verifyConsoleErrors = true;
+    } else if (arg === "--verify-a11y") {
+      out.verifyA11y = true;
+    } else if (arg === "--verify-a11y-scope") {
+      out.verifyA11yScopes.push(argv[i + 1] || "");
+      i += 1;
+    } else if (arg === "--verify-a11y-impact") {
+      out.verifyA11yImpact = argv[i + 1] || out.verifyA11yImpact;
+      i += 1;
+    } else if (arg === "--verify-perf") {
+      out.verifyPerf = true;
+    } else if (arg === "--verify-perf-budget") {
+      out.verifyPerfBudgets.push(argv[i + 1] || "");
+      i += 1;
+    } else if (arg === "--verify-perf-wait-ms") {
+      const raw = Number.parseInt(argv[i + 1] || "", 10);
+      out.verifyPerfWaitMs = Number.isFinite(raw) && raw >= 0 ? raw : out.verifyPerfWaitMs;
+      i += 1;
     } else if (arg === "--update-verify-snapshot") {
       out.updateVerifySnapshot = true;
     } else if (arg === "--label") {
@@ -451,6 +517,8 @@ function parseArgs(argv: string[]): ShipArgs {
   out.verifyPaths = uniq(out.verifyPaths);
   out.verifyDevices = uniq(out.verifyDevices);
   out.verifyFlows = uniq(out.verifyFlows);
+  out.verifyA11yScopes = uniq(out.verifyA11yScopes);
+  out.verifyPerfBudgets = uniq(out.verifyPerfBudgets);
   out.labels = uniq(out.labels);
   return out;
 }
@@ -944,6 +1012,8 @@ function shouldRunVerification(args: ShipArgs): boolean {
     || args.verifyFlows.length
     || args.verifySnapshot
     || args.verifyConsoleErrors
+    || args.verifyA11y
+    || args.verifyPerf
   );
 }
 
@@ -978,6 +1048,14 @@ function runDeployVerification(args: ShipArgs, branch: string): DeployVerificati
   }
   if (args.verifyConsoleErrors) {
     deployArgs.push("--strict-console");
+  }
+  if (args.verifyA11y) {
+    deployArgs.push("--a11y", "--a11y-impact", args.verifyA11yImpact);
+    for (const scope of args.verifyA11yScopes) deployArgs.push("--a11y-scope", scope);
+  }
+  if (args.verifyPerf) {
+    deployArgs.push("--perf", "--perf-wait-ms", String(args.verifyPerfWaitMs));
+    for (const budget of args.verifyPerfBudgets) deployArgs.push("--perf-budget", budget);
   }
 
   const child = spawnSync(BUN_RUNTIME, deployArgs, {
@@ -1122,6 +1200,28 @@ function deploySnapshotSummary(entries: DeploySnapshotResult[] | undefined, limi
   return lines;
 }
 
+function deployAccessibilitySummary(summary: QaAccessibilitySummary | null | undefined): string[] {
+  if (!summary?.enabled) return ["- Accessibility checks were not enabled."];
+  return [
+    `- Violations: ${summary.violationCount ?? 0}`,
+    `- Minimum impact: ${summary.minimumImpact || "serious"}`,
+    summary.topRules?.length ? `- Top rules: ${summary.topRules.join(", ")}` : "",
+    summary.artifactMarkdown ? `- Report: ${summary.artifactMarkdown}` : "",
+  ].filter(Boolean);
+}
+
+function deployPerformanceSummary(summary: QaPerformanceSummary | null | undefined): string[] {
+  if (!summary?.enabled) return ["- Performance checks were not enabled."];
+  return [
+    `- Budget violations: ${summary.budgetViolationCount ?? 0}`,
+    summary.topViolations?.length ? `- Top violations: ${summary.topViolations.join("; ")}` : "",
+    `- LCP: ${summary.metrics?.lcp ?? "n/a"}`,
+    `- CLS: ${summary.metrics?.cls ?? "n/a"}`,
+    `- Failed resources: ${summary.metrics?.failedResourceCount ?? 0}`,
+    summary.artifactMarkdown ? `- Report: ${summary.artifactMarkdown}` : "",
+  ].filter(Boolean);
+}
+
 function buildDeployPrComment({
   report,
   repo,
@@ -1185,6 +1285,17 @@ function buildDeployPrComment({
       ...deploySnapshotSummary(report.qa.snapshotResults)
     );
   }
+
+  sections.push(
+    "",
+    "### Accessibility",
+    "",
+    ...deployAccessibilitySummary(report.qa?.accessibility),
+    "",
+    "### Performance",
+    "",
+    ...deployPerformanceSummary(report.qa?.performance),
+  );
 
   if (trackedReportRef || stableReportRef || trackedAnnotationRef || trackedScreenshotRef || screenshotManifestRef) {
     sections.push("");
@@ -1272,6 +1383,12 @@ function printText(result: ShipResult): void {
   if (result.verification.consoleErrors) {
     console.log(`- Verification console errors: ${result.verification.consoleErrors}`);
   }
+  if (result.verification.accessibilityViolations) {
+    console.log(`- Verification accessibility violations: ${result.verification.accessibilityViolations}`);
+  }
+  if (result.verification.performanceBudgetViolations) {
+    console.log(`- Verification performance budget violations: ${result.verification.performanceBudgetViolations}`);
+  }
   if (result.verification.reportPath) {
     console.log(`- Verification report: ${result.verification.reportPath}`);
   }
@@ -1326,6 +1443,8 @@ const result: ShipResult = {
     visualRiskLevel: "",
     staleBaselines: 0,
     consoleErrors: 0,
+    accessibilityViolations: 0,
+    performanceBudgetViolations: 0,
     reportPath: "",
     stableReportUrl: "",
     publishDir: "",
@@ -1417,6 +1536,8 @@ if (shouldRunVerification(args)) {
   if (args.verifyFlows.length) verificationParts.push(`flows ${args.verifyFlows.join(", ")}`);
   if (args.verifySnapshot) verificationParts.push(`${args.updateVerifySnapshot ? "refresh" : "compare"} snapshot ${args.verifySnapshot}`);
   if (args.verifyConsoleErrors) verificationParts.push("strict console errors");
+  if (args.verifyA11y) verificationParts.push(`a11y impact ${args.verifyA11yImpact}${args.verifyA11yScopes.length ? ` scopes ${args.verifyA11yScopes.join(", ")}` : ""}`);
+  if (args.verifyPerf) verificationParts.push(`perf budgets ${args.verifyPerfBudgets.length ? args.verifyPerfBudgets.join(", ") : "capture only"}`);
   result.verification.session = result.verification.session || defaultVerifySession(result.branch);
   result.verification.publishDir = defaultVerifyPublishDir(result.branch);
   result.verification.paths = effectivePaths;
@@ -1443,6 +1564,8 @@ if (shouldRunVerification(args)) {
     result.verification.consoleErrors = (verification.report.pathResults || []).reduce((count: number, entry: DeployPathResult) => (
       count + (Array.isArray(entry.console?.errors) ? entry.console?.errors.length : 0)
     ), 0);
+    result.verification.accessibilityViolations = Number(verification.report.qa?.accessibility?.violationCount || 0);
+    result.verification.performanceBudgetViolations = Number(verification.report.qa?.performance?.budgetViolationCount || 0);
     result.verification.reportPath = verification.report.artifactRoot
       ? path.join(verification.report.artifactRoot, "report.md")
       : "";

--- a/skills/browse/SKILL.md
+++ b/skills/browse/SKILL.md
@@ -32,6 +32,8 @@ Give the agent eyes for QA and deployment checks.
 - `import-session <path>`
 - `import-cookies <path>`
 - `import-browser-cookies <browser>`
+- `a11y <url>`
+- `perf <url>`
 - `snapshot <url> [name]`
 - `compare-snapshot <url> <name>`
 - `probe <url>`
@@ -80,6 +82,8 @@ bun src/cli.ts browse export-flow portal-full-demo ./docs/portal-full-demo.yaml
 bun src/cli.ts browse export-session ./tmp/staging-session.json --session staging
 bun src/cli.ts browse import-session ./tmp/staging-session.json --session staging-copy
 bun src/cli.ts browse import-browser-cookies chrome --session staging --profile Default
+bun src/cli.ts browse a11y https://example.com/dashboard --scope main --impact serious --session staging
+bun src/cli.ts browse perf https://example.com/dashboard --budget lcp=2s --budget cls=0.1 --wait-ms 400 --session staging
 bun src/cli.ts browse probe https://example.com/settings --session staging
 bun src/cli.ts browse upload https://example.com/profile "input[type=file]" ./fixtures/avatar.png --session staging
 bun src/cli.ts browse dialog https://example.com/settings accept "#delete-confirm" --session staging
@@ -114,6 +118,7 @@ bun src/cli.ts browse sessions
 - Reuse named sessions for authenticated flows so login state persists.
 - Use `--device mobile|tablet|desktop` when the check is viewport-sensitive or when a bug only reproduces responsively.
 - Export/import session bundles when authenticated QA needs to move between machines or named sessions.
+- Use `a11y` and `perf` when you need raw browser evidence before turning it into a scored `qa` report.
 - Use `import-browser-cookies` on macOS when you already have a signed-in Chrome, Arc, Brave, or Edge profile and want to bootstrap a named Codex session quickly.
 - Use `dialog` before the click that triggers a modal or confirm prompt so the handler is armed in time.
 - Check in shared flows under `browse/flows/`; keep machine-specific experiments in `.codex-stack/browse/flows/`.

--- a/skills/deploy/SKILL.md
+++ b/skills/deploy/SKILL.md
@@ -21,14 +21,16 @@ Resolve the live deploy URL, wait for readiness, verify the important paths acro
 3. Wait for the target to become ready before running browser checks.
 4. Verify each configured path across the requested device presets.
 5. Capture screenshots and collect HTTP plus console evidence for each page check.
-6. Run any configured QA flows and snapshot comparisons.
-7. Publish markdown/json/comment artifacts plus a screenshot manifest under the publish directory.
-8. Mark the run as `critical`, `warning`, or `pass` based on HTTP failures, console drift, and QA findings.
+6. Add `--a11y` and `--perf` when the deploy also needs accessibility or performance evidence.
+7. Run any configured QA flows and snapshot comparisons.
+8. Publish markdown/json/comment artifacts plus a screenshot manifest under the publish directory.
+9. Mark the run as `critical`, `warning`, or `pass` based on HTTP failures, console drift, and QA findings.
 
 ## CLI
 
 ```bash
 bun src/cli.ts deploy --url-template "https://preview-{pr}.example.com" --pr 42 --branch feat/42-preview --sha abcdef123 --path / --path /dashboard --device desktop --device mobile --flow portal-dashboard --snapshot portal-dashboard
+bun src/cli.ts deploy --url https://staging.example.com --path /dashboard --device desktop --flow portal-dashboard --snapshot portal-dashboard --a11y --a11y-scope main --perf --perf-budget lcp=2s --perf-budget cls=0.1
 bun src/cli.ts deploy --url https://staging.example.com --path /dashboard --device desktop --flow portal-dashboard --session staging-auth --session-bundle .codex-stack/private/staging-auth.json --json
 bun src/cli.ts deploy --url http://127.0.0.1:4173 --path /dashboard --device desktop --publish-dir docs/qa/local-demo/deploy --strict-console --json
 ```
@@ -40,6 +42,7 @@ bun src/cli.ts deploy --url http://127.0.0.1:4173 --path /dashboard --device des
 - Page/device matrix with console counts and screenshot paths
 - QA status, health score, recommendation, and findings
 - Snapshot results and artifact paths
+- Accessibility and performance summaries when enabled
 - Screenshot manifest and workflow run link when available
 
 ## Guardrails

--- a/skills/preview/SKILL.md
+++ b/skills/preview/SKILL.md
@@ -20,7 +20,7 @@ Turn preview verification into a repeatable workflow that resolves the right pre
 2. Fill template placeholders from PR, branch, repo, and SHA context.
 3. Import `--session-bundle <path>` into the named preview session when the preview requires authentication.
 4. Poll the preview URL until it responds successfully or times out.
-5. Delegate the live checks to `deploy`, including path/device screenshots, flows, and snapshots.
+5. Delegate the live checks to `deploy`, including path/device screenshots, flows, snapshots, and optional a11y/perf checks.
 6. Publish markdown/json artifacts for the preview run.
 7. Write a PR-comment-ready markdown summary with findings, flow results, deploy checks, and evidence paths.
 8. Fail the verification job when readiness fails or deploy verification returns a critical status.
@@ -29,6 +29,7 @@ Turn preview verification into a repeatable workflow that resolves the right pre
 
 ```bash
 bun src/cli.ts preview --url-template "https://preview-{pr}.example.com" --pr 42 --branch feat/42-preview --sha abcdef123 --path / --path /dashboard --device desktop --device mobile --flow landing-smoke --snapshot landing-home
+bun src/cli.ts preview --url-template "https://preview-{pr}.example.com" --pr 42 --branch feat/42-preview --sha abcdef123 --path /dashboard --device desktop --flow landing-smoke --snapshot landing-home --a11y --a11y-scope main --perf --perf-budget lcp=2s
 bun src/cli.ts preview --url "https://anup4khandelwal.github.io/codex-stack/pr-preview/pr-42/" --pr 42 --branch feat/42-preview --sha abcdef123 --path /login --path /dashboard --device desktop --device mobile --flow portal-full-demo
 bun src/cli.ts preview --url "https://anup4khandelwal.github.io/codex-stack/pr-preview/pr-42/" --pr 42 --branch feat/42-preview --sha abcdef123 --path /dashboard --device desktop --flow portal-dashboard --session preview-auth --session-bundle .codex-stack/private/preview-auth.json
 bun src/cli.ts preview --url http://127.0.0.1:4173 --path /dashboard --device desktop --flow portal-dashboard --snapshot portal-dashboard --fixture /tmp/deploy-fixture.json --qa-fixture /tmp/qa-fixture.json --json
@@ -40,6 +41,7 @@ bun src/cli.ts preview --url http://127.0.0.1:4173 --path /dashboard --device de
 - Readiness status with attempt count and last HTTP status
 - QA status, health score, and recommendation
 - Deploy path/device matrix with screenshot evidence and console counts
+- Accessibility and performance summaries when enabled
 - Findings and flow results
 - Artifact paths and workflow run link when available
 

--- a/skills/qa/SKILL.md
+++ b/skills/qa/SKILL.md
@@ -20,17 +20,20 @@ Run repeatable browser verification, collect evidence, and turn it into a ship/n
 2. Import `--session-bundle <path>` first when the target requires authenticated state.
 3. Use `--mode diff-aware` plus `--base-ref` when the goal is to probe the pages changed by the current diff from a preview base URL.
 4. Run one or more checked-in flows when behavior needs end-to-end validation.
-5. Capture or compare a snapshot when visual/text drift matters.
-6. Score the result with categorized findings, severity, evidence, and a recommendation.
-7. Save the QA report under `.codex-stack/qa/`, including annotated screenshot evidence when snapshot failures occur.
-8. Refresh `.codex-stack/qa/trends.json` and `.codex-stack/qa/trends.md` so the operator can compare the latest run against prior QA history.
-9. Publish tracked copies into `docs/qa/` when the shipping workflow needs GitHub-linkable evidence.
-10. Render `docs/qa/` through `scripts/render-qa-pages.ts` when the operator needs a static review site.
+5. Add `--a11y` when accessibility regressions matter, and scope it with `--a11y-scope` plus `--a11y-impact` when needed.
+6. Add `--perf` with `--perf-budget` and `--perf-wait-ms` when user-perceived performance needs to be enforced.
+7. Capture or compare a snapshot when visual/text drift matters.
+8. Score the result with categorized findings, severity, evidence, and a recommendation.
+9. Save the QA report under `.codex-stack/qa/`, including annotated screenshot evidence when snapshot failures occur.
+10. Refresh `.codex-stack/qa/trends.json` and `.codex-stack/qa/trends.md` so the operator can compare the latest run against prior QA history.
+11. Publish tracked copies into `docs/qa/` when the shipping workflow needs GitHub-linkable evidence.
+12. Render `docs/qa/` through `scripts/render-qa-pages.ts` when the operator needs a static review site.
 
 ## CLI
 
 ```bash
 bun src/cli.ts qa http://127.0.0.1:4173/dashboard --flow portal-dashboard --snapshot portal-dashboard --session demo --json
+bun src/cli.ts qa http://127.0.0.1:4173/dashboard --flow portal-dashboard --snapshot portal-dashboard --a11y --a11y-scope main --perf --perf-budget lcp=2s --perf-budget cls=0.1 --session demo --json
 bun src/cli.ts qa http://127.0.0.1:4173/login --flow portal-full-demo --snapshot portal-login --session demo
 bun src/cli.ts qa https://preview.example.com/dashboard --flow portal-dashboard --session preview-auth --session-bundle .codex-stack/private/preview-auth.json --json
 bun src/cli.ts qa https://preview.example.com --mode diff-aware --base-ref origin/main --session preview --json
@@ -45,6 +48,7 @@ bun scripts/qa-trends.ts --dir .codex-stack/qa --json
 - Findings with category + severity
 - Diff-aware route probe summary
 - Snapshot evidence
+- Accessibility and performance summaries plus artifact paths
 - Flow pass/fail summary
 - Recommendation
 - Trend delta vs previous runs via `.codex-stack/qa/trends.json`

--- a/skills/ship/SKILL.md
+++ b/skills/ship/SKILL.md
@@ -23,7 +23,7 @@ Run the shipping checklist with minimal back-and-forth.
 4. Summarize failures or proceed.
 5. Build a PR title/body from the branch diff or merge the diff summary into a PR template if present.
 6. Infer labels from branch/files and reviewers from `CODEOWNERS` unless disabled.
-7. Run deploy verification first when the operator provides a verification URL, path, device, flow, or snapshot.
+7. Run deploy verification first when the operator provides a verification URL, path, device, flow, snapshot, accessibility, or performance flags.
 8. Apply assignee and project metadata when the operator requests it.
 9. If the branch follows `<prefix>/<issue-number>-slug`, include `Closes #<issue-number>` in the generated PR body.
 10. Create missing labels in GitHub if required, then stage, commit, push, open PR, apply metadata, publish tracked deploy evidence, and post the deploy summary comment with branch and post-merge Pages links when verification ran.
@@ -39,6 +39,7 @@ bun src/cli.ts ship --message "feat: ready for review" --push --pr
 bun src/cli.ts ship --message "feat: ready for review" --push --pr --template .github/pull_request_template.md
 bun src/cli.ts ship --message "feat: ready for review" --push --pr --reviewer octocat --assignee @me --project "Engineering Roadmap" --label release-candidate
 bun src/cli.ts ship --dry-run --pr --verify-url https://staging.example.com --verify-path /dashboard --verify-device mobile --verify-console-errors --verify-flow landing-smoke --verify-snapshot landing-home
+bun src/cli.ts ship --dry-run --pr --verify-url https://staging.example.com --verify-path /dashboard --verify-device mobile --verify-flow landing-smoke --verify-snapshot landing-home --verify-a11y --verify-a11y-scope main --verify-perf --verify-perf-budget lcp=2s
 ```
 
 ## Output format
@@ -47,6 +48,7 @@ bun src/cli.ts ship --dry-run --pr --verify-url https://staging.example.com --ve
 - Validation results
 - Shipping action taken
 - PR details
+- Deploy verification status including visual, accessibility, and performance evidence when enabled
 - Risks or blockers
 
 ## Guardrails


### PR DESCRIPTION
## Summary
- add opt-in accessibility and performance checks to `qa`
- thread a11y/perf through `deploy`, `preview`, `ship`, PR review, and QA Pages
- add focused specs, smoke coverage, and docs for the new evidence flow

## Validation
- bun run typecheck
- bun run smoke
