### PR TITLE
feat: add fleet rollout control plane

### DIFF
--- a/.codex-stack/fleet.example.json
+++ b/.codex-stack/fleet.example.json
@@ -1,0 +1,26 @@
+{
+  "schemaVersion": 1,
+  "controlRepo": "anup4khandelwal/codex-stack",
+  "policyDir": "policies",
+  "syncBranch": "chore/codex-stack-fleet-sync",
+  "statusArtifactName": "codex-stack-fleet-status",
+  "repos": [
+    {
+      "repo": "anup4khandelwal/codex-stack",
+      "branch": "main",
+      "policyPack": "default",
+      "team": "platform",
+      "previewUrlTemplate": "https://anup4khandelwal.github.io/codex-stack/pr-preview/pr-{pr}/",
+      "enabledChecks": ["qa"],
+      "qa": {
+        "flows": ["portal-full-demo"],
+        "snapshots": ["portal-dashboard"]
+      },
+      "preview": {
+        "paths": ["/login", "/dashboard"],
+        "flows": ["portal-full-demo"],
+        "snapshots": ["portal-dashboard"]
+      }
+    }
+  ]
+}

--- a/.codex-stack/policies/default.json
+++ b/.codex-stack/policies/default.json
@@ -1,0 +1,26 @@
+{
+  "name": "default",
+  "description": "Baseline codex-stack rollout for GitHub-native review, preview, and QA workflows.",
+  "requiredChecks": ["review", "preview", "deploy", "fleet-status"],
+  "qa": {
+    "mode": "diff-aware",
+    "devices": ["desktop", "mobile"],
+    "a11y": true,
+    "perf": true,
+    "perfBudgets": ["lcp=2.5s", "cls=0.1"]
+  },
+  "preview": {
+    "paths": ["/", "/dashboard"],
+    "devices": ["desktop", "mobile"],
+    "waitTimeout": 300,
+    "strictConsole": false,
+    "strictHttp": true
+  },
+  "decisions": {
+    "staleAfterDays": 14,
+    "expiringSoonDays": 7
+  },
+  "schedule": {
+    "cron": "17 8 * * 1-5"
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@ browse/dist/.cache/
 .codex-stack/*
 !.codex-stack/baseline-decisions/
 !.codex-stack/baseline-decisions/**
+!.codex-stack/fleet.example.json
+!.codex-stack/policies/
+!.codex-stack/policies/**
 .site/
 coverage/
 *.log

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Use the repo in this order:
 - Tracked QA evidence published under `docs/qa/<branch>/` during shipping so PR comments can link to real files
 - GitHub Pages publishing for `docs/qa/` so merged QA reports keep a stable URL after branch cleanup
 - Issue-first workflow automation with PR review comments and opt-in auto-merge
+- Fleet rollout controls for multi-repo policy packs, drift detection, rollout PR planning, and org-level dashboard rendering
 - Retrospective analytics plus weekly digest publishing outputs for markdown, Slack, and email, including visual regression rollups from published QA evidence
 - Upgrade auditing via CLI plus a daily scheduled update-check workflow that syncs a stable issue
 
@@ -90,6 +91,7 @@ bun src/cli.ts list
 - `browse`
 - `retro`
 - `upgrade`
+- `fleet`
 
 If you want shell-level commands, link those wrappers into your `PATH`:
 
@@ -184,6 +186,10 @@ bun src/cli.ts deploy --url https://staging.example.com --path /dashboard --devi
 bun src/cli.ts ship --message "feat: ready for review" --push --pr --reviewer octocat --assignee @me --project "Engineering Roadmap"
 bun src/cli.ts ship --dry-run --pr --verify-url http://127.0.0.1:4173 --verify-path /dashboard --verify-device mobile --verify-console-errors --verify-flow portal-dashboard --verify-snapshot portal-dashboard
 bun src/cli.ts ship --dry-run --pr --verify-url http://127.0.0.1:4173 --verify-path /dashboard --verify-device mobile --verify-flow portal-dashboard --verify-snapshot portal-dashboard --verify-a11y --verify-a11y-scope main --verify-perf --verify-perf-budget lcp=2s
+bun src/cli.ts fleet validate --manifest .codex-stack/fleet.example.json
+bun src/cli.ts fleet sync --manifest .codex-stack/fleet.example.json --dry-run --json
+bun src/cli.ts fleet collect --manifest .codex-stack/fleet.example.json --json
+bun src/cli.ts fleet dashboard --manifest .codex-stack/fleet.example.json --out .fleet-site
 bun src/cli.ts retro --since "7 days ago" --repo anup4khandelwal/codex-stack
 bun src/cli.ts upgrade --offline --json
 bun src/cli.ts upgrade --offline --apply
@@ -225,6 +231,34 @@ bun run upgrade
 bun run upgrade:apply
 bun run weekly
 ```
+
+## Fleet rollout
+
+Use `fleet` when one repo needs to manage `codex-stack` policy across many repos.
+
+Example:
+
+```bash
+bun src/cli.ts fleet validate --manifest .codex-stack/fleet.example.json
+bun src/cli.ts fleet sync --manifest .codex-stack/fleet.example.json --dry-run --json
+bun src/cli.ts fleet collect --manifest .codex-stack/fleet.example.json --json
+bun src/cli.ts fleet dashboard --manifest .codex-stack/fleet.example.json --out .fleet-site
+```
+
+The control repo owns:
+
+- a fleet manifest listing managed repos
+- shared policy packs under `.codex-stack/policies/`
+- generated member config and fleet-status workflow for each target repo
+- an org-level dashboard that ranks rollout drift and unresolved risk across repos
+
+`fleet sync` generates three files in each managed repo:
+
+- `.codex-stack/fleet-member.json`
+- `.github/codex-stack/fleet-status.js`
+- `.github/workflows/codex-stack-fleet-status.yml`
+
+That workflow emits a normalized `codex-stack-fleet-status` artifact so `fleet collect` can aggregate repo health without inventing a new backend.
 
 ## Browser QA model
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -26,6 +26,10 @@ bun src/cli.ts ship --message "feat: ready for review" --push --pr --template .g
 bun src/cli.ts ship --message "feat: ready for review" --push --pr --reviewer octocat --team-reviewer acme/platform --assignee @me --project "Engineering Roadmap" --label release-candidate
 bun src/cli.ts ship --dry-run --pr --verify-url http://127.0.0.1:4173 --verify-path /dashboard --verify-device mobile --verify-console-errors --verify-flow portal-dashboard --verify-snapshot portal-dashboard
 bun src/cli.ts ship --dry-run --pr --verify-url http://127.0.0.1:4173 --verify-path /dashboard --verify-device mobile --verify-flow portal-dashboard --verify-snapshot portal-dashboard --verify-a11y --verify-a11y-scope main --verify-perf --verify-perf-budget lcp=2s
+bun src/cli.ts fleet validate --manifest .codex-stack/fleet.example.json
+bun src/cli.ts fleet sync --manifest .codex-stack/fleet.example.json --dry-run --json
+bun src/cli.ts fleet collect --manifest .codex-stack/fleet.example.json --json
+bun src/cli.ts fleet dashboard --manifest .codex-stack/fleet.example.json --out .fleet-site
 bun src/cli.ts retro --since "7 days ago"
 bun src/cli.ts retro --since "7 days ago" --artifact-dir .codex-stack/retros
 bun src/cli.ts retro --since "7 days ago" --repo anup4khandelwal/codex-stack
@@ -218,6 +222,24 @@ Notes:
 - Flow and snapshot checks are delegated to the existing QA runtime so the deploy report reuses the same finding model and artifacts.
 - The same runtime can also run accessibility and performance checks, and deploy reports now publish those summaries into both markdown and `visual/index.html`.
 - `--session-bundle <path>` validates the bundle up front, imports it into the named deploy session when live browser checks need it, and passes it through to `qa-run.ts`.
+
+## Fleet workflow
+
+```bash
+bun scripts/fleet.ts validate --manifest .codex-stack/fleet.example.json
+bun scripts/fleet.ts sync --manifest .codex-stack/fleet.example.json --dry-run --json
+bun scripts/fleet.ts collect --manifest .codex-stack/fleet.example.json --json
+bun scripts/fleet.ts dashboard --manifest .codex-stack/fleet.example.json --out .fleet-site
+```
+
+Notes:
+
+- `fleet validate` checks the manifest, policy-pack references, and required-check configuration.
+- `fleet sync` generates a compiled member config, a self-contained fleet-status script, and a status workflow for each managed repo.
+- Use `localPath` entries in the manifest for local testing. Use `--open-prs` to clone target repos, push a rollout branch, and open or update PRs remotely.
+- `fleet collect` reads normalized `codex-stack-fleet-status` outputs and ranks repos by rollout drift plus unresolved QA risk.
+- `fleet dashboard` writes `index.html`, `manifest.json`, and `summary.md` so the control repo can publish an org dashboard with the same data.
+- Start from `.codex-stack/fleet.example.json` and `.codex-stack/policies/default.json` when bootstrapping a new fleet.
 - The script writes `report.md`, `report.json`, `comment.md`, `screenshots.json`, and a visual review pack under `visual/index.html` and `visual/manifest.json`.
 - Deploy reports now include a single visual-risk score that combines path/device failures, console errors, snapshot drift, and stale baselines.
 

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "qa:trends": "bun scripts/qa-trends.ts",
     "preview": "bun scripts/preview-verify.ts",
     "deploy": "bun scripts/deploy-verify.ts",
+    "fleet": "bun scripts/fleet.ts",
     "ship:dry": "bun scripts/ship-branch.ts --dry-run",
     "retro": "bun scripts/retro-report.ts --since '7 days ago'",
     "upgrade": "bun scripts/upgrade-check.ts",
@@ -52,6 +53,7 @@
     "codex",
     "skills",
     "workflow",
+    "fleet",
     "review",
     "ship",
     "qa"

--- a/scripts/ci-check.sh
+++ b/scripts/ci-check.sh
@@ -108,11 +108,16 @@ run_ts scripts/retro-report.ts --help >/tmp/codex-stack-retro-help.log
 run_ts scripts/retro-report.spec.ts >/tmp/codex-stack-retro-spec.log
 run_ts scripts/upgrade-check.ts --offline --json >/tmp/codex-stack-upgrade.json
 run_ts scripts/upgrade-check.spec.ts >/tmp/codex-stack-upgrade-spec.log
+run_ts scripts/fleet.ts validate --manifest .codex-stack/fleet.example.json --json >/tmp/codex-stack-fleet-validate.json
+run_ts scripts/fleet.ts sync --manifest .codex-stack/fleet.example.json --dry-run --json >/tmp/codex-stack-fleet-sync.json
+run_ts scripts/fleet.spec.ts >/tmp/codex-stack-fleet-spec.log
 run_ts scripts/preview-verify.spec.ts >/tmp/codex-stack-preview-spec.log
 run_ts scripts/weekly-digest.spec.ts >/tmp/codex-stack-weekly-spec.log
 run_ts scripts/render-qa-pages.spec.ts >/tmp/codex-stack-render-qa-pages-spec.log
 grep -q '"overallStatus"' /tmp/codex-stack-upgrade.json
 grep -q '"offline": true' /tmp/codex-stack-upgrade.json
+grep -q '"controlRepo"' /tmp/codex-stack-fleet-validate.json
+grep -q '"results"' /tmp/codex-stack-fleet-sync.json
 run_ts scripts/retro-report.ts --since "1 day ago" --artifact-dir /tmp/codex-stack-retros --no-github >/tmp/codex-stack-retro.log
 run_ts scripts/weekly-digest.ts --since "1 day ago" --out /tmp/codex-stack-weekly.md --json-out /tmp/codex-stack-weekly.json --publish-dir /tmp/codex-stack-weekly-publish --no-github >/tmp/codex-stack-weekly.log
 mkdir -p .codex-stack/browse/snapshots .codex-stack/browse/artifacts

--- a/scripts/fleet.spec.ts
+++ b/scripts/fleet.spec.ts
@@ -1,0 +1,160 @@
+#!/usr/bin/env bun
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import process from "node:process";
+import { execFileSync } from "node:child_process";
+
+const rootDir = process.cwd();
+const bun = process.execPath || "bun";
+const fixtureRoot = fs.mkdtempSync(path.join(os.tmpdir(), "codex-stack-fleet-"));
+const controlDir = path.join(fixtureRoot, "control");
+const repoDir = path.join(fixtureRoot, "repo-a");
+const manifestPath = path.join(controlDir, "fleet.json");
+const policyDir = path.join(controlDir, "policies");
+const dashboardDir = path.join(fixtureRoot, "dashboard");
+
+function run(args: string[], cwd = rootDir): string {
+  return execFileSync(bun, args, {
+    cwd,
+    encoding: "utf8",
+  });
+}
+
+fs.mkdirSync(policyDir, { recursive: true });
+fs.mkdirSync(path.join(repoDir, "docs", "qa", "latest"), { recursive: true });
+fs.writeFileSync(path.join(policyDir, "default.json"), JSON.stringify({
+  name: "default",
+  requiredChecks: ["review", "preview", "fleet-status"],
+  qa: {
+    mode: "diff-aware",
+    devices: ["desktop"],
+    a11y: true,
+  },
+  preview: {
+    paths: ["/", "/dashboard"],
+    devices: ["desktop", "mobile"],
+    strictHttp: true,
+  },
+  decisions: {
+    staleAfterDays: 14,
+    expiringSoonDays: 7,
+  },
+  schedule: {
+    cron: "0 9 * * 1-5",
+  },
+}, null, 2));
+fs.writeFileSync(manifestPath, JSON.stringify({
+  schemaVersion: 1,
+  controlRepo: "acme/control-plane",
+  policyDir: "policies",
+  repos: [
+    {
+      repo: "acme/repo-a",
+      branch: "main",
+      localPath: repoDir,
+      team: "platform",
+      policyPack: "default",
+      enabledChecks: ["qa"],
+      previewUrlTemplate: "https://preview-{pr}.example.com",
+      qa: {
+        flows: ["portal-full-demo"],
+      },
+      preview: {
+        snapshots: ["portal-dashboard"],
+      },
+    },
+  ],
+}, null, 2));
+fs.writeFileSync(path.join(repoDir, "docs", "qa", "latest", "report.json"), JSON.stringify({
+  generatedAt: "2026-03-15T00:00:00.000Z",
+  status: "warning",
+  recommendation: "Investigate unresolved visual regression",
+  healthScore: 78,
+  visualRisk: {
+    score: 62,
+    level: "warning",
+    staleBaselines: 1,
+  },
+  decisionSummary: {
+    approvedCount: 1,
+    unresolvedCount: 2,
+    expiredCount: 1,
+  },
+  accessibility: {
+    violationCount: 3,
+  },
+  performance: {
+    budgetViolationCount: 1,
+  },
+}, null, 2));
+
+const validateReport = JSON.parse(run(["scripts/fleet.ts", "validate", "--manifest", manifestPath, "--json"])) as {
+  controlRepo?: string;
+  repos?: Array<{ repo?: string; requiredChecks?: string[] }>;
+};
+assert.equal(validateReport.controlRepo, "acme/control-plane");
+assert.deepEqual(validateReport.repos?.[0]?.requiredChecks, ["fleet-status", "preview", "qa", "review"]);
+
+const dryRunReport = JSON.parse(run(["scripts/fleet.ts", "sync", "--manifest", manifestPath, "--dry-run", "--json"])) as {
+  results?: Array<{ repo?: string; action?: string; drift?: string; filesChanged?: string[] }>;
+};
+assert.equal(dryRunReport.results?.[0]?.repo, "acme/repo-a");
+assert.equal(dryRunReport.results?.[0]?.action, "planned");
+assert.equal(dryRunReport.results?.[0]?.drift, "missing");
+assert.ok(dryRunReport.results?.[0]?.filesChanged?.includes(".codex-stack/fleet-member.json"));
+
+const syncReport = JSON.parse(run(["scripts/fleet.ts", "sync", "--manifest", manifestPath, "--json"])) as {
+  results?: Array<{ action?: string; filesChanged?: string[] }>;
+};
+assert.equal(syncReport.results?.[0]?.action, "written");
+assert.ok(fs.existsSync(path.join(repoDir, ".codex-stack", "fleet-member.json")));
+assert.ok(fs.existsSync(path.join(repoDir, ".github", "codex-stack", "fleet-status.js")));
+assert.ok(fs.existsSync(path.join(repoDir, ".github", "workflows", "codex-stack-fleet-status.yml")));
+
+const memberConfig = JSON.parse(fs.readFileSync(path.join(repoDir, ".codex-stack", "fleet-member.json"), "utf8")) as {
+  controlRepo?: string;
+  team?: string;
+  previewUrlTemplate?: string;
+  requiredChecks?: string[];
+};
+assert.equal(memberConfig.controlRepo, "acme/control-plane");
+assert.equal(memberConfig.team, "platform");
+assert.equal(memberConfig.previewUrlTemplate, "https://preview-{pr}.example.com");
+assert.deepEqual(memberConfig.requiredChecks, ["fleet-status", "preview", "qa", "review"]);
+
+const statusOut = path.join(repoDir, ".codex-stack", "fleet-status", "status.json");
+const statusJson = run([path.join(repoDir, ".github", "codex-stack", "fleet-status.js"), "--out", statusOut, "--json"], repoDir);
+const statusReport = JSON.parse(statusJson) as {
+  installed?: boolean;
+  status?: string;
+  riskScore?: number;
+  latestReport?: { unresolvedRegressions?: number } | null;
+};
+assert.equal(statusReport.installed, true);
+assert.equal(statusReport.status, "warning");
+assert.ok(Number(statusReport.riskScore) > 0);
+assert.equal(statusReport.latestReport?.unresolvedRegressions, 2);
+
+const collectReport = JSON.parse(run(["scripts/fleet.ts", "collect", "--manifest", manifestPath, "--json"])) as {
+  counts?: { repos?: number; warning?: number; drifted?: number };
+  repos?: Array<{ repo?: string; source?: string; status?: string; riskScore?: number }>;
+};
+assert.equal(collectReport.counts?.repos, 1);
+assert.equal(collectReport.counts?.warning, 1);
+assert.equal(collectReport.counts?.drifted, 0);
+assert.equal(collectReport.repos?.[0]?.repo, "acme/repo-a");
+assert.equal(collectReport.repos?.[0]?.source, "local");
+assert.equal(collectReport.repos?.[0]?.status, "warning");
+assert.ok(Number(collectReport.repos?.[0]?.riskScore) > 0);
+
+run(["scripts/fleet.ts", "dashboard", "--manifest", manifestPath, "--out", dashboardDir], rootDir);
+assert.ok(fs.existsSync(path.join(dashboardDir, "index.html")));
+assert.ok(fs.existsSync(path.join(dashboardDir, "manifest.json")));
+assert.ok(fs.existsSync(path.join(dashboardDir, "summary.md")));
+assert.match(fs.readFileSync(path.join(dashboardDir, "index.html"), "utf8"), /codex-stack fleet dashboard/);
+assert.match(fs.readFileSync(path.join(dashboardDir, "manifest.json"), "utf8"), /acme\/repo-a/);
+
+fs.rmSync(fixtureRoot, { recursive: true, force: true });
+console.log("fleet spec passed");

--- a/scripts/fleet.ts
+++ b/scripts/fleet.ts
@@ -1,0 +1,1165 @@
+#!/usr/bin/env bun
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import process from "node:process";
+import { execSync, spawnSync, type ExecSyncOptionsWithStringEncoding } from "node:child_process";
+
+const DEFAULT_STATUS_ARTIFACT = "codex-stack-fleet-status";
+const DEFAULT_BRANCH = "main";
+const DEFAULT_SYNC_BRANCH = "chore/codex-stack-fleet-sync";
+const DEFAULT_POLICY_DIR = ".codex-stack/policies";
+const FLEET_MEMBER_PATH = ".codex-stack/fleet-member.json";
+const FLEET_STATUS_SCRIPT_PATH = ".github/codex-stack/fleet-status.js";
+const FLEET_STATUS_WORKFLOW_PATH = ".github/workflows/codex-stack-fleet-status.yml";
+const FLEET_STATUS_DIR = ".codex-stack/fleet-status";
+const FLEET_STATUS_JSON = `${FLEET_STATUS_DIR}/status.json`;
+const FLEET_STATUS_MD = `${FLEET_STATUS_DIR}/summary.md`;
+const ALLOWED_CHECKS = new Set(["review", "qa", "preview", "deploy", "ship", "fleet-status"]);
+
+type FleetCheck = "review" | "qa" | "preview" | "deploy" | "ship" | "fleet-status";
+type DriftState = "healthy" | "missing" | "outdated" | "diverged";
+type RepoHealth = "healthy" | "warning" | "critical" | "missing" | "unknown";
+
+interface RunOptions extends Partial<ExecSyncOptionsWithStringEncoding> {
+  allowFailure?: boolean;
+}
+
+interface ParsedArgs {
+  command: "validate" | "sync" | "collect" | "dashboard";
+  manifestPath: string;
+  json: boolean;
+  jsonOut: string;
+  markdownOut: string;
+  outDir: string;
+  dryRun: boolean;
+  openPrs: boolean;
+  branchName: string;
+}
+
+interface FleetManifest {
+  schemaVersion?: number;
+  controlRepo?: string;
+  defaultBranch?: string;
+  policyDir?: string;
+  syncBranch?: string;
+  statusArtifactName?: string;
+  repos?: FleetTarget[];
+}
+
+interface FleetTarget {
+  repo: string;
+  branch?: string;
+  team?: string;
+  localPath?: string;
+  policyPack?: string;
+  previewUrlTemplate?: string;
+  enabledChecks?: string[];
+  qa?: FleetQaConfig;
+  preview?: FleetPreviewConfig;
+  decisions?: FleetDecisionConfig;
+  metadata?: Record<string, string>;
+}
+
+interface FleetQaConfig {
+  mode?: string;
+  paths?: string[];
+  devices?: string[];
+  flows?: string[];
+  snapshots?: string[];
+  a11y?: boolean;
+  perf?: boolean;
+  perfBudgets?: string[];
+}
+
+interface FleetPreviewConfig {
+  paths?: string[];
+  devices?: string[];
+  flows?: string[];
+  snapshots?: string[];
+  waitTimeout?: number;
+  waitInterval?: number;
+  strictConsole?: boolean;
+  strictHttp?: boolean;
+  urlTemplate?: string;
+}
+
+interface FleetDecisionConfig {
+  staleAfterDays?: number;
+  expiringSoonDays?: number;
+}
+
+interface FleetPolicyPack {
+  name?: string;
+  description?: string;
+  requiredChecks?: FleetCheck[];
+  qa?: FleetQaConfig;
+  preview?: FleetPreviewConfig;
+  decisions?: FleetDecisionConfig;
+  schedule?: {
+    cron?: string;
+  };
+}
+
+interface FleetContext {
+  manifestPath: string;
+  manifestDir: string;
+  manifest: FleetManifest;
+  controlRepo: string;
+  controlRef: string;
+  statusArtifactName: string;
+  syncBranch: string;
+  policyDir: string;
+}
+
+interface FleetMemberConfig {
+  schemaVersion: number;
+  generatedAt: string;
+  controlRepo: string;
+  controlRef: string;
+  sourceManifest: string;
+  repo: string;
+  branch: string;
+  team: string;
+  policyPack: string;
+  requiredChecks: FleetCheck[];
+  previewUrlTemplate: string;
+  metadata: Record<string, string>;
+  qa: FleetQaConfig;
+  preview: FleetPreviewConfig;
+  decisions: FleetDecisionConfig;
+  schedule: {
+    cron: string;
+  };
+  statusArtifactName: string;
+}
+
+interface GeneratedFiles {
+  memberConfigJson: string;
+  workflowYaml: string;
+  statusScriptJs: string;
+}
+
+interface SyncFilePlan {
+  path: string;
+  changed: boolean;
+}
+
+interface SyncPlan {
+  repo: string;
+  branch: string;
+  team: string;
+  policyPack: string;
+  localPath: string;
+  drift: DriftState;
+  files: SyncFilePlan[];
+  memberConfig: FleetMemberConfig;
+  generated: GeneratedFiles;
+  existing: Record<string, string>;
+  reasons: string[];
+}
+
+interface SyncResult {
+  repo: string;
+  drift: DriftState;
+  action: "planned" | "written" | "opened-pr" | "skipped";
+  branch: string;
+  localPath: string;
+  prUrl: string;
+  filesChanged: string[];
+}
+
+interface FleetStatusReport {
+  marker?: string;
+  generatedAt?: string;
+  repo?: string;
+  branch?: string;
+  installed?: boolean;
+  controlRepo?: string;
+  team?: string;
+  policyPack?: string;
+  requiredChecks?: string[];
+  status?: RepoHealth;
+  riskScore?: number;
+  latestReport?: {
+    generatedAt?: string;
+    status?: string;
+    recommendation?: string;
+    healthScore?: number;
+    visualRiskScore?: number | null;
+    visualRiskLevel?: string;
+    unresolvedRegressions?: number;
+    approvedRegressions?: number;
+    expiredDecisions?: number;
+    staleBaselines?: number;
+    accessibilityViolations?: number | null;
+    performanceBudgetViolations?: number | null;
+    reportPath?: string;
+  } | null;
+}
+
+interface CollectedFleetRepo {
+  repo: string;
+  branch: string;
+  team: string;
+  policyPack: string;
+  installed: boolean;
+  drift: DriftState;
+  status: RepoHealth;
+  riskScore: number;
+  requiredChecks: string[];
+  latestReport: FleetStatusReport["latestReport"];
+  source: "local" | "artifact" | "repo-files" | "missing";
+}
+
+interface FleetCollectReport {
+  marker: string;
+  generatedAt: string;
+  controlRepo: string;
+  manifestPath: string;
+  counts: {
+    repos: number;
+    healthy: number;
+    warning: number;
+    critical: number;
+    missing: number;
+    unknown: number;
+    drifted: number;
+  };
+  repos: CollectedFleetRepo[];
+  topRisks: CollectedFleetRepo[];
+}
+
+function normalizeMemberConfigText(text: string): string {
+  if (!clean(text)) return "";
+  try {
+    const parsed = JSON.parse(text) as Record<string, unknown>;
+    delete parsed.generatedAt;
+    return JSON.stringify(parsed, null, 2);
+  } catch {
+    return clean(text);
+  }
+}
+
+function usage(): never {
+  console.log(`fleet
+
+Usage:
+  bun scripts/fleet.ts validate --manifest <path> [--json] [--json-out <path>] [--markdown-out <path>]
+  bun scripts/fleet.ts sync --manifest <path> [--dry-run] [--open-prs] [--branch-name <name>] [--json] [--json-out <path>] [--markdown-out <path>]
+  bun scripts/fleet.ts collect --manifest <path> [--json] [--json-out <path>] [--markdown-out <path>]
+  bun scripts/fleet.ts dashboard --manifest <path> --out <dir> [--json] [--json-out <path>]
+`);
+  process.exit(0);
+}
+
+function clean(value: unknown): string {
+  return String(value || "").replace(/\s+/g, " ").trim();
+}
+
+function ensureDir(dirPath: string): void {
+  fs.mkdirSync(dirPath, { recursive: true });
+}
+
+function writeFile(targetPath: string, content: string): void {
+  ensureDir(path.dirname(targetPath));
+  fs.writeFileSync(targetPath, content);
+}
+
+function sortUnique(items: string[]): string[] {
+  return [...new Set(items.map((item) => clean(item)).filter(Boolean))].sort();
+}
+
+function uniqChecks(items: string[]): FleetCheck[] {
+  return sortUnique(items).filter((item): item is FleetCheck => ALLOWED_CHECKS.has(item as FleetCheck));
+}
+
+function asObject<T>(value: unknown): T {
+  return value && typeof value === "object" && !Array.isArray(value) ? (value as T) : ({} as T);
+}
+
+function asArray<T>(value: unknown): T[] {
+  return Array.isArray(value) ? (value as T[]) : [];
+}
+
+function run(cmd: string, options: RunOptions = {}): string {
+  try {
+    return execSync(cmd, {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+      ...options,
+    }).trim();
+  } catch (error: unknown) {
+    if (options.allowFailure) return "";
+    const stderr = typeof error === "object" && error && "stderr" in error ? String((error as { stderr?: unknown }).stderr || "") : "";
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(clean(stderr || message));
+  }
+}
+
+function runArgs(program: string, args: string[], cwd = process.cwd()): string {
+  const result = spawnSync(program, args, {
+    cwd,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  if ((result.status ?? 1) !== 0) {
+    throw new Error(clean(result.stderr || result.stdout || `${program} exited with status ${result.status ?? 1}`));
+  }
+  return clean(result.stdout || "");
+}
+
+function inferControlRepo(): string {
+  if (process.env.GITHUB_REPOSITORY) return clean(process.env.GITHUB_REPOSITORY);
+  const remote = run("git remote get-url origin", { allowFailure: true });
+  const match = remote.match(/github\.com[:/]([^/]+\/[^/.]+)(?:\.git)?$/i);
+  return match ? match[1] : "";
+}
+
+function inferControlRef(): string {
+  return clean(run("git rev-parse HEAD", { allowFailure: true })) || "local";
+}
+
+function parseArgs(argv: string[]): ParsedArgs {
+  const command = clean(argv[0]) as ParsedArgs["command"];
+  if (!command || !(command === "validate" || command === "sync" || command === "collect" || command === "dashboard")) usage();
+
+  const out: ParsedArgs = {
+    command,
+    manifestPath: "",
+    json: false,
+    jsonOut: "",
+    markdownOut: "",
+    outDir: path.resolve(process.cwd(), ".fleet-site"),
+    dryRun: false,
+    openPrs: false,
+    branchName: DEFAULT_SYNC_BRANCH,
+  };
+
+  for (let i = 1; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === "--manifest") {
+      out.manifestPath = path.resolve(process.cwd(), argv[i + 1] || "");
+      i += 1;
+    } else if (arg === "--json") {
+      out.json = true;
+    } else if (arg === "--json-out") {
+      out.jsonOut = path.resolve(process.cwd(), argv[i + 1] || "");
+      i += 1;
+    } else if (arg === "--markdown-out") {
+      out.markdownOut = path.resolve(process.cwd(), argv[i + 1] || "");
+      i += 1;
+    } else if (arg === "--out") {
+      out.outDir = path.resolve(process.cwd(), argv[i + 1] || ".fleet-site");
+      i += 1;
+    } else if (arg === "--dry-run") {
+      out.dryRun = true;
+    } else if (arg === "--open-prs") {
+      out.openPrs = true;
+    } else if (arg === "--branch-name") {
+      out.branchName = clean(argv[i + 1] || DEFAULT_SYNC_BRANCH) || DEFAULT_SYNC_BRANCH;
+      i += 1;
+    } else if (arg === "--help" || arg === "-h") {
+      usage();
+    }
+  }
+
+  if (!out.manifestPath) {
+    throw new Error("Pass --manifest <path>.");
+  }
+  return out;
+}
+
+function readJsonFile<T>(filePath: string): T {
+  return JSON.parse(fs.readFileSync(filePath, "utf8")) as T;
+}
+
+function normalizeQaConfig(value: unknown): FleetQaConfig {
+  const input = asObject<FleetQaConfig>(value);
+  return {
+    mode: clean(input.mode || "") || undefined,
+    paths: sortUnique(asArray<string>(input.paths)),
+    devices: sortUnique(asArray<string>(input.devices)),
+    flows: sortUnique(asArray<string>(input.flows)),
+    snapshots: sortUnique(asArray<string>(input.snapshots)),
+    a11y: Boolean(input.a11y),
+    perf: Boolean(input.perf),
+    perfBudgets: sortUnique(asArray<string>(input.perfBudgets)),
+  };
+}
+
+function normalizePreviewConfig(value: unknown): FleetPreviewConfig {
+  const input = asObject<FleetPreviewConfig>(value);
+  return {
+    paths: sortUnique(asArray<string>(input.paths)),
+    devices: sortUnique(asArray<string>(input.devices)),
+    flows: sortUnique(asArray<string>(input.flows)),
+    snapshots: sortUnique(asArray<string>(input.snapshots)),
+    waitTimeout: Number.isFinite(Number(input.waitTimeout)) ? Number(input.waitTimeout) : undefined,
+    waitInterval: Number.isFinite(Number(input.waitInterval)) ? Number(input.waitInterval) : undefined,
+    strictConsole: Boolean(input.strictConsole),
+    strictHttp: Boolean(input.strictHttp),
+    urlTemplate: clean(input.urlTemplate || "") || undefined,
+  };
+}
+
+function normalizeDecisionConfig(value: unknown): FleetDecisionConfig {
+  const input = asObject<FleetDecisionConfig>(value);
+  return {
+    staleAfterDays: Number.isFinite(Number(input.staleAfterDays)) ? Number(input.staleAfterDays) : undefined,
+    expiringSoonDays: Number.isFinite(Number(input.expiringSoonDays)) ? Number(input.expiringSoonDays) : undefined,
+  };
+}
+
+function loadFleetContext(manifestPath: string): FleetContext {
+  if (!fs.existsSync(manifestPath)) throw new Error(`Fleet manifest not found: ${manifestPath}`);
+  const manifest = readJsonFile<FleetManifest>(manifestPath);
+  if (Number(manifest.schemaVersion || 1) !== 1) {
+    throw new Error(`Unsupported fleet schemaVersion: ${manifest.schemaVersion}`);
+  }
+  const repos = asArray<FleetTarget>(manifest.repos);
+  if (!repos.length) throw new Error("Fleet manifest must declare at least one repo.");
+
+  const context: FleetContext = {
+    manifestPath,
+    manifestDir: path.dirname(manifestPath),
+    manifest,
+    controlRepo: clean(manifest.controlRepo || "") || inferControlRepo(),
+    controlRef: inferControlRef(),
+    statusArtifactName: clean(manifest.statusArtifactName || "") || DEFAULT_STATUS_ARTIFACT,
+    syncBranch: clean(manifest.syncBranch || "") || DEFAULT_SYNC_BRANCH,
+    policyDir: path.resolve(path.dirname(manifestPath), clean(manifest.policyDir || "") || DEFAULT_POLICY_DIR),
+  };
+  if (!context.controlRepo) throw new Error("Unable to infer control repo. Set controlRepo in the manifest.");
+  return context;
+}
+
+function loadPolicyPack(context: FleetContext, name: string): FleetPolicyPack {
+  const policyName = clean(name) || "default";
+  const policyPath = path.join(context.policyDir, `${policyName}.json`);
+  if (!fs.existsSync(policyPath)) {
+    throw new Error(`Policy pack not found: ${policyPath}`);
+  }
+  const raw = readJsonFile<FleetPolicyPack>(policyPath);
+  const requiredChecks = uniqChecks(asArray<string>(raw.requiredChecks));
+  if (!requiredChecks.length) {
+    throw new Error(`Policy pack ${policyName} must declare at least one required check.`);
+  }
+  return {
+    name: policyName,
+    description: clean(raw.description || "") || undefined,
+    requiredChecks,
+    qa: normalizeQaConfig(raw.qa),
+    preview: normalizePreviewConfig(raw.preview),
+    decisions: normalizeDecisionConfig(raw.decisions),
+    schedule: {
+      cron: clean(raw.schedule?.cron || "") || "17 8 * * 1-5",
+    },
+  };
+}
+
+function mergeQaConfig(base: FleetQaConfig, extra: FleetQaConfig): FleetQaConfig {
+  return {
+    mode: clean(extra.mode || "") || clean(base.mode || "") || undefined,
+    paths: sortUnique([...(base.paths || []), ...(extra.paths || [])]),
+    devices: sortUnique([...(base.devices || []), ...(extra.devices || [])]),
+    flows: sortUnique([...(base.flows || []), ...(extra.flows || [])]),
+    snapshots: sortUnique([...(base.snapshots || []), ...(extra.snapshots || [])]),
+    a11y: Boolean(base.a11y || extra.a11y),
+    perf: Boolean(base.perf || extra.perf),
+    perfBudgets: sortUnique([...(base.perfBudgets || []), ...(extra.perfBudgets || [])]),
+  };
+}
+
+function mergePreviewConfig(base: FleetPreviewConfig, extra: FleetPreviewConfig): FleetPreviewConfig {
+  return {
+    paths: sortUnique([...(base.paths || []), ...(extra.paths || [])]),
+    devices: sortUnique([...(base.devices || []), ...(extra.devices || [])]),
+    flows: sortUnique([...(base.flows || []), ...(extra.flows || [])]),
+    snapshots: sortUnique([...(base.snapshots || []), ...(extra.snapshots || [])]),
+    waitTimeout: Number.isFinite(Number(extra.waitTimeout)) ? Number(extra.waitTimeout) : base.waitTimeout,
+    waitInterval: Number.isFinite(Number(extra.waitInterval)) ? Number(extra.waitInterval) : base.waitInterval,
+    strictConsole: Boolean(base.strictConsole || extra.strictConsole),
+    strictHttp: Boolean(base.strictHttp || extra.strictHttp),
+    urlTemplate: clean(extra.urlTemplate || "") || clean(base.urlTemplate || "") || undefined,
+  };
+}
+
+function mergeDecisionConfig(base: FleetDecisionConfig, extra: FleetDecisionConfig): FleetDecisionConfig {
+  return {
+    staleAfterDays: Number.isFinite(Number(extra.staleAfterDays)) ? Number(extra.staleAfterDays) : base.staleAfterDays,
+    expiringSoonDays: Number.isFinite(Number(extra.expiringSoonDays)) ? Number(extra.expiringSoonDays) : base.expiringSoonDays,
+  };
+}
+
+function compileMemberConfig(context: FleetContext, target: FleetTarget): FleetMemberConfig {
+  const repo = clean(target.repo);
+  if (!repo || !repo.includes("/")) throw new Error(`Invalid repo entry: ${JSON.stringify(target.repo)}`);
+  const policyPackName = clean(target.policyPack || "") || "default";
+  const policyPack = loadPolicyPack(context, policyPackName);
+  const enabledChecks = uniqChecks([...(policyPack.requiredChecks || []), ...asArray<string>(target.enabledChecks)]);
+  if (!enabledChecks.length) {
+    throw new Error(`Repo ${repo} resolved to zero required checks.`);
+  }
+  const qa = mergeQaConfig(policyPack.qa || {}, normalizeQaConfig(target.qa));
+  const preview = mergePreviewConfig(policyPack.preview || {}, normalizePreviewConfig(target.preview));
+  const decisions = mergeDecisionConfig(policyPack.decisions || {}, normalizeDecisionConfig(target.decisions));
+  const previewUrlTemplate = clean(target.previewUrlTemplate || preview.urlTemplate || "");
+  const branch = clean(target.branch || "") || clean(context.manifest.defaultBranch || "") || DEFAULT_BRANCH;
+  return {
+    schemaVersion: 1,
+    generatedAt: new Date().toISOString(),
+    controlRepo: context.controlRepo,
+    controlRef: context.controlRef,
+    sourceManifest: path.relative(process.cwd(), context.manifestPath) || path.basename(context.manifestPath),
+    repo,
+    branch,
+    team: clean(target.team || ""),
+    policyPack: policyPackName,
+    requiredChecks: enabledChecks,
+    previewUrlTemplate,
+    metadata: asObject<Record<string, string>>(target.metadata),
+    qa,
+    preview,
+    decisions,
+    schedule: {
+      cron: clean(policyPack.schedule?.cron || "") || "17 8 * * 1-5",
+    },
+    statusArtifactName: context.statusArtifactName,
+  };
+}
+
+function loadStatusScriptTemplate(): string {
+  const templatePath = path.resolve(process.cwd(), "templates", "fleet", "fleet-status.js");
+  return fs.readFileSync(templatePath, "utf8");
+}
+
+function generateStatusWorkflow(member: FleetMemberConfig): string {
+  const branch = member.branch || DEFAULT_BRANCH;
+  return `name: codex-stack fleet status
+
+on:
+  push:
+    branches:
+      - ${branch}
+  workflow_dispatch:
+  schedule:
+    - cron: '${member.schedule.cron || "17 8 * * 1-5"}'
+
+jobs:
+  status:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6.0.2
+
+      - name: Build fleet status payload
+        run: |
+          node .github/codex-stack/fleet-status.js \
+            --out ${FLEET_STATUS_JSON} \
+            --markdown-out ${FLEET_STATUS_MD}
+
+      - name: Upload fleet status artifact
+        uses: actions/upload-artifact@v7.0.0
+        with:
+          name: ${member.statusArtifactName}
+          path: ${FLEET_STATUS_DIR}/
+          if-no-files-found: error
+`;
+}
+
+function generateFiles(member: FleetMemberConfig): GeneratedFiles {
+  return {
+    memberConfigJson: `${JSON.stringify(member, null, 2)}\n`,
+    workflowYaml: generateStatusWorkflow(member),
+    statusScriptJs: loadStatusScriptTemplate(),
+  };
+}
+
+function readLocalFile(root: string, relativePath: string): string {
+  const targetPath = path.join(root, relativePath);
+  return fs.existsSync(targetPath) ? fs.readFileSync(targetPath, "utf8") : "";
+}
+
+function readRemoteFile(repo: string, relativePath: string, ref: string): string {
+  const endpoint = `repos/${repo}/contents/${relativePath}?ref=${encodeURIComponent(ref)}`;
+  const result = spawnSync("gh", ["api", "-H", "Accept: application/vnd.github.raw", endpoint], {
+    cwd: process.cwd(),
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  if ((result.status ?? 1) !== 0) return "";
+  return clean(result.stdout || "");
+}
+
+function detectDrift(existing: Record<string, string>, generated: GeneratedFiles, member: FleetMemberConfig): { drift: DriftState; reasons: string[]; files: SyncFilePlan[] } {
+  const files = [
+    { path: FLEET_MEMBER_PATH, current: normalizeMemberConfigText(existing[FLEET_MEMBER_PATH] || ""), expected: normalizeMemberConfigText(generated.memberConfigJson) },
+    { path: FLEET_STATUS_SCRIPT_PATH, current: existing[FLEET_STATUS_SCRIPT_PATH] || "", expected: generated.statusScriptJs },
+    { path: FLEET_STATUS_WORKFLOW_PATH, current: existing[FLEET_STATUS_WORKFLOW_PATH] || "", expected: generated.workflowYaml },
+  ];
+  const changed = files.filter((file) => file.current !== file.expected);
+  if (!changed.length) {
+    return {
+      drift: "healthy",
+      reasons: [],
+      files: files.map((file) => ({ path: file.path, changed: false })),
+    };
+  }
+
+  const currentMember = existing[FLEET_MEMBER_PATH] ? (() => {
+    try {
+      return JSON.parse(existing[FLEET_MEMBER_PATH]) as Partial<FleetMemberConfig>;
+    } catch {
+      return null;
+    }
+  })() : null;
+
+  let drift: DriftState = "outdated";
+  const reasons: string[] = [];
+  const missingCount = files.filter((file) => !file.current).length;
+  if (missingCount === files.length) {
+    drift = "missing";
+    reasons.push("Required fleet files are missing.");
+  } else if (!currentMember || clean(currentMember.controlRepo || "") !== member.controlRepo) {
+    drift = "diverged";
+    reasons.push("Existing fleet member config is unmanaged or points at a different control repo.");
+  } else if (clean(currentMember.policyPack || "") !== member.policyPack) {
+    drift = "outdated";
+    reasons.push(`Policy pack drift detected (${clean(currentMember.policyPack || "unknown")} -> ${member.policyPack}).`);
+  } else {
+    drift = "outdated";
+    reasons.push("Generated fleet files differ from the desired control-plane state.");
+  }
+
+  return {
+    drift,
+    reasons,
+    files: files.map((file) => ({ path: file.path, changed: file.current !== file.expected })),
+  };
+}
+
+function planSync(context: FleetContext, target: FleetTarget): SyncPlan {
+  const member = compileMemberConfig(context, target);
+  const generated = generateFiles(member);
+  const localPath = clean(target.localPath || "");
+  const existing: Record<string, string> = {};
+  const branch = member.branch || DEFAULT_BRANCH;
+
+  if (localPath) {
+    existing[FLEET_MEMBER_PATH] = readLocalFile(localPath, FLEET_MEMBER_PATH);
+    existing[FLEET_STATUS_SCRIPT_PATH] = readLocalFile(localPath, FLEET_STATUS_SCRIPT_PATH);
+    existing[FLEET_STATUS_WORKFLOW_PATH] = readLocalFile(localPath, FLEET_STATUS_WORKFLOW_PATH);
+  } else {
+    existing[FLEET_MEMBER_PATH] = readRemoteFile(member.repo, FLEET_MEMBER_PATH, branch);
+    existing[FLEET_STATUS_SCRIPT_PATH] = readRemoteFile(member.repo, FLEET_STATUS_SCRIPT_PATH, branch);
+    existing[FLEET_STATUS_WORKFLOW_PATH] = readRemoteFile(member.repo, FLEET_STATUS_WORKFLOW_PATH, branch);
+  }
+
+  const drift = detectDrift(existing, generated, member);
+  return {
+    repo: member.repo,
+    branch,
+    team: member.team,
+    policyPack: member.policyPack,
+    localPath,
+    drift: drift.drift,
+    files: drift.files,
+    memberConfig: member,
+    generated,
+    existing,
+    reasons: drift.reasons,
+  };
+}
+
+function writeGeneratedFiles(root: string, plan: SyncPlan): string[] {
+  const changed: string[] = [];
+  const outputs: Array<{ path: string; content: string }> = [
+    { path: FLEET_MEMBER_PATH, content: plan.generated.memberConfigJson },
+    { path: FLEET_STATUS_SCRIPT_PATH, content: plan.generated.statusScriptJs },
+    { path: FLEET_STATUS_WORKFLOW_PATH, content: plan.generated.workflowYaml },
+  ];
+  for (const output of outputs) {
+    const absolute = path.join(root, output.path);
+    const current = fs.existsSync(absolute) ? fs.readFileSync(absolute, "utf8") : "";
+    if (output.path === FLEET_MEMBER_PATH) {
+      if (normalizeMemberConfigText(current) === normalizeMemberConfigText(output.content)) continue;
+    } else if (current === output.content) {
+      continue;
+    }
+    writeFile(absolute, output.content);
+    changed.push(output.path);
+  }
+  return changed;
+}
+
+function syncLocalRepo(plan: SyncPlan): SyncResult {
+  if (!plan.localPath) {
+    return {
+      repo: plan.repo,
+      drift: plan.drift,
+      action: "skipped",
+      branch: plan.branch,
+      localPath: "",
+      prUrl: "",
+      filesChanged: [],
+    };
+  }
+  const filesChanged = writeGeneratedFiles(plan.localPath, plan);
+  return {
+    repo: plan.repo,
+    drift: plan.drift,
+    action: filesChanged.length ? "written" : "skipped",
+    branch: plan.branch,
+    localPath: plan.localPath,
+    prUrl: "",
+    filesChanged,
+  };
+}
+
+function checkoutBranch(repoDir: string, branchName: string, baseRef: string): void {
+  runArgs("git", ["checkout", "-B", branchName, `origin/${baseRef}`], repoDir);
+}
+
+function maybeCreateOrUpdatePr(repo: string, branchName: string, baseRef: string): string {
+  const currentOwner = clean(runArgs("gh", ["api", "user", "--jq", ".login"], process.cwd()));
+  const existing = runArgs("gh", ["pr", "list", "--repo", repo, "--head", `${currentOwner}:${branchName}`, "--json", "number,url", "--jq", ".[] | .url"], process.cwd());
+  if (existing) return clean(existing.split(/\r?\n/)[0]);
+  return runArgs("gh", [
+    "pr",
+    "create",
+    "--repo",
+    repo,
+    "--base",
+    baseRef,
+    "--head",
+    branchName,
+    "--title",
+    "chore: sync codex-stack fleet rollout",
+    "--body",
+    `Sync codex-stack fleet rollout files.\n\n- refresh \`${FLEET_MEMBER_PATH}\`\n- refresh \`${FLEET_STATUS_SCRIPT_PATH}\`\n- refresh \`${FLEET_STATUS_WORKFLOW_PATH}\``,
+  ], process.cwd());
+}
+
+function openPrSync(plan: SyncPlan, syncBranch: string): SyncResult {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "codex-stack-fleet-sync-"));
+  const repoDir = path.join(tempDir, plan.repo.replace(/\//g, "-"));
+  try {
+    runArgs("gh", ["repo", "clone", plan.repo, repoDir, "--", "-q"], process.cwd());
+    checkoutBranch(repoDir, syncBranch, plan.branch);
+    const filesChanged = writeGeneratedFiles(repoDir, plan);
+    if (!filesChanged.length) {
+      return {
+        repo: plan.repo,
+        drift: "healthy",
+        action: "skipped",
+        branch: plan.branch,
+        localPath: repoDir,
+        prUrl: "",
+        filesChanged: [],
+      };
+    }
+    runArgs("git", ["add", FLEET_MEMBER_PATH, FLEET_STATUS_SCRIPT_PATH, FLEET_STATUS_WORKFLOW_PATH], repoDir);
+    runArgs("git", ["commit", "-m", "chore: sync codex-stack fleet rollout"], repoDir);
+    runArgs("git", ["push", "-u", "origin", syncBranch, "--force-with-lease"], repoDir);
+    const prUrl = maybeCreateOrUpdatePr(plan.repo, syncBranch, plan.branch);
+    return {
+      repo: plan.repo,
+      drift: plan.drift,
+      action: "opened-pr",
+      branch: plan.branch,
+      localPath: repoDir,
+      prUrl,
+      filesChanged,
+    };
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+}
+
+function latestQaReportFromRepoRoot(repoRoot: string): FleetStatusReport["latestReport"] {
+  const docsQa = path.join(repoRoot, "docs", "qa");
+  if (!fs.existsSync(docsQa)) return null;
+  const reportPaths: string[] = [];
+  const stack = [docsQa];
+  while (stack.length) {
+    const current = stack.pop() as string;
+    for (const entry of fs.readdirSync(current, { withFileTypes: true })) {
+      const absolute = path.join(current, entry.name);
+      if (entry.isDirectory()) stack.push(absolute);
+      else if (entry.isFile() && entry.name === "report.json") reportPaths.push(absolute);
+    }
+  }
+  let bestPath = "";
+  let bestScore = 0;
+  let bestData: Record<string, unknown> | null = null;
+  for (const reportPath of reportPaths) {
+    try {
+      const data = readJsonFile<Record<string, unknown>>(reportPath);
+      const generatedAt = clean(data.generatedAt || data.timestamp || "");
+      const score = generatedAt ? Date.parse(generatedAt) : fs.statSync(reportPath).mtimeMs;
+      if (!bestPath || score > bestScore) {
+        bestPath = reportPath;
+        bestScore = score;
+        bestData = data;
+      }
+    } catch {
+      // Ignore malformed files.
+    }
+  }
+  if (!bestData) return null;
+  const visualRisk = asObject<Record<string, unknown>>(bestData.visualRisk);
+  const decisions = asObject<Record<string, unknown>>(bestData.decisionSummary);
+  const accessibility = asObject<Record<string, unknown>>(bestData.accessibility);
+  const performance = asObject<Record<string, unknown>>(bestData.performance);
+  return {
+    generatedAt: clean(bestData.generatedAt || ""),
+    status: clean(bestData.status || ""),
+    recommendation: clean(bestData.recommendation || ""),
+    healthScore: Number(bestData.healthScore || 0) || 0,
+    visualRiskScore: Number(visualRisk.score || 0) || null,
+    visualRiskLevel: clean(visualRisk.level || "") || "none",
+    unresolvedRegressions: Number(decisions.unresolvedCount || 0),
+    approvedRegressions: Number(decisions.approvedCount || 0),
+    expiredDecisions: Number(decisions.expiredCount || 0),
+    staleBaselines: Number(visualRisk.staleBaselines || 0),
+    accessibilityViolations: Number(accessibility.violationCount || 0) || 0,
+    performanceBudgetViolations: Number(performance.budgetViolationCount || 0) || 0,
+    reportPath: bestPath,
+  };
+}
+
+function computeCollectedStatus(installed: boolean, drift: DriftState, latestReport: FleetStatusReport["latestReport"]): { status: RepoHealth; riskScore: number } {
+  if (!installed) {
+    return { status: "missing", riskScore: 85 };
+  }
+  let riskScore = 0;
+  if (drift === "diverged") riskScore += 45;
+  if (drift === "missing") riskScore += 35;
+  if (drift === "outdated") riskScore += 20;
+  if (!latestReport) riskScore += 15;
+  if (latestReport?.status === "critical") riskScore += 40;
+  if (latestReport?.status === "warning") riskScore += 20;
+  riskScore += Math.min(24, Number(latestReport?.unresolvedRegressions || 0) * 8);
+  riskScore += Math.min(12, Number(latestReport?.expiredDecisions || 0) * 4);
+  riskScore += Math.min(12, Number(latestReport?.staleBaselines || 0) * 3);
+  riskScore += Math.min(25, Math.round(Number(latestReport?.visualRiskScore || 0) * 0.25));
+  riskScore += Math.min(10, Number(latestReport?.accessibilityViolations || 0) * 2);
+  riskScore += Math.min(12, Number(latestReport?.performanceBudgetViolations || 0) * 4);
+  riskScore = Math.min(100, riskScore);
+
+  if (latestReport?.status === "critical" || drift === "diverged") {
+    return { status: "critical", riskScore };
+  }
+  if (latestReport?.status === "warning" || drift === "outdated" || drift === "missing" || Number(latestReport?.unresolvedRegressions || 0) > 0 || Number(latestReport?.expiredDecisions || 0) > 0) {
+    return { status: "warning", riskScore };
+  }
+  return { status: "healthy", riskScore };
+}
+
+function readRemoteMemberConfig(repo: string, branch: string): FleetMemberConfig | null {
+  const raw = readRemoteFile(repo, FLEET_MEMBER_PATH, branch);
+  if (!raw) return null;
+  try {
+    return JSON.parse(raw) as FleetMemberConfig;
+  } catch {
+    return null;
+  }
+}
+
+function readLocalMemberConfig(repoRoot: string): FleetMemberConfig | null {
+  const filePath = path.join(repoRoot, FLEET_MEMBER_PATH);
+  if (!fs.existsSync(filePath)) return null;
+  try {
+    return readJsonFile<FleetMemberConfig>(filePath);
+  } catch {
+    return null;
+  }
+}
+
+function downloadLatestArtifactStatus(repo: string, branch: string, artifactName: string): FleetStatusReport | null {
+  const runsJson = runArgs("gh", ["api", `repos/${repo}/actions/workflows/${path.basename(FLEET_STATUS_WORKFLOW_PATH)}/runs?branch=${encodeURIComponent(branch)}&status=completed&per_page=10`], process.cwd());
+  const runs = JSON.parse(runsJson) as { workflow_runs?: Array<{ id: number; conclusion?: string }> };
+  const runId = asArray<{ id: number; conclusion?: string }>(runs.workflow_runs).find((item) => item.conclusion === "success")?.id;
+  if (!runId) return null;
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "codex-stack-fleet-artifact-"));
+  try {
+    runArgs("gh", ["run", "download", String(runId), "-R", repo, "-n", artifactName, "-D", tempDir], process.cwd());
+    const statusPath = path.join(tempDir, "status.json");
+    if (!fs.existsSync(statusPath)) return null;
+    return readJsonFile<FleetStatusReport>(statusPath);
+  } catch {
+    return null;
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+}
+
+function collectRepo(context: FleetContext, target: FleetTarget): CollectedFleetRepo {
+  const plan = planSync(context, target);
+  if (plan.localPath) {
+    const member = readLocalMemberConfig(plan.localPath) || plan.memberConfig;
+    const latestReport = latestQaReportFromRepoRoot(plan.localPath);
+    const computed = computeCollectedStatus(Boolean(member), plan.drift, latestReport);
+    return {
+      repo: plan.repo,
+      branch: plan.branch,
+      team: member.team,
+      policyPack: member.policyPack,
+      installed: Boolean(member),
+      drift: plan.drift,
+      status: computed.status,
+      riskScore: computed.riskScore,
+      requiredChecks: member.requiredChecks,
+      latestReport,
+      source: latestReport ? "local" : "repo-files",
+    };
+  }
+
+  const member = readRemoteMemberConfig(plan.repo, plan.branch) || (plan.drift === "healthy" ? plan.memberConfig : null);
+  const statusReport = member ? downloadLatestArtifactStatus(plan.repo, plan.branch, member.statusArtifactName || context.statusArtifactName) : null;
+  const latestReport = statusReport?.latestReport || null;
+  const computed = computeCollectedStatus(Boolean(member), plan.drift, latestReport);
+  return {
+    repo: plan.repo,
+    branch: plan.branch,
+    team: member?.team || plan.team,
+    policyPack: member?.policyPack || plan.policyPack,
+    installed: Boolean(member),
+    drift: plan.drift,
+    status: statusReport?.status || computed.status,
+    riskScore: statusReport?.riskScore ?? computed.riskScore,
+    requiredChecks: asArray<string>(member?.requiredChecks || []),
+    latestReport,
+    source: statusReport ? "artifact" : member ? "repo-files" : "missing",
+  };
+}
+
+function collectFleet(context: FleetContext): FleetCollectReport {
+  const repos = asArray<FleetTarget>(context.manifest.repos).map((target) => collectRepo(context, target));
+  repos.sort((left, right) => right.riskScore - left.riskScore || left.repo.localeCompare(right.repo));
+  const counts = {
+    repos: repos.length,
+    healthy: repos.filter((repo) => repo.status === "healthy").length,
+    warning: repos.filter((repo) => repo.status === "warning").length,
+    critical: repos.filter((repo) => repo.status === "critical").length,
+    missing: repos.filter((repo) => repo.status === "missing").length,
+    unknown: repos.filter((repo) => repo.status === "unknown").length,
+    drifted: repos.filter((repo) => repo.drift !== "healthy").length,
+  };
+  return {
+    marker: "<!-- codex-stack:fleet-report -->",
+    generatedAt: new Date().toISOString(),
+    controlRepo: context.controlRepo,
+    manifestPath: context.manifestPath,
+    counts,
+    repos,
+    topRisks: repos.slice(0, 5),
+  };
+}
+
+function renderFleetMarkdown(report: FleetCollectReport): string {
+  const lines = [
+    "# codex-stack fleet report",
+    "",
+    `- Control repo: ${report.controlRepo}`,
+    `- Generated: ${report.generatedAt}`,
+    `- Repos: ${report.counts.repos}`,
+    `- Healthy: ${report.counts.healthy}`,
+    `- Warning: ${report.counts.warning}`,
+    `- Critical: ${report.counts.critical}`,
+    `- Missing: ${report.counts.missing}`,
+    `- Drifted: ${report.counts.drifted}`,
+    "",
+    "## Top risks",
+    "",
+    ...report.topRisks.map((repo) => `- ${repo.repo}: ${repo.status.toUpperCase()} (${repo.riskScore}/100) • drift=${repo.drift} • unresolved=${repo.latestReport?.unresolvedRegressions ?? 0}`),
+  ];
+  return `${lines.join("\n")}\n`;
+}
+
+function escapeHtml(value: unknown): string {
+  return String(value || "")
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/\"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+function renderFleetDashboard(report: FleetCollectReport, outDir: string): void {
+  ensureDir(outDir);
+  const repoRows = report.repos.map((repo) => `
+      <tr>
+        <td><strong>${escapeHtml(repo.repo)}</strong><div class="muted">${escapeHtml(repo.team || "unassigned")}</div></td>
+        <td>${escapeHtml(repo.status.toUpperCase())}</td>
+        <td>${escapeHtml(repo.drift.toUpperCase())}</td>
+        <td>${escapeHtml(repo.riskScore)}</td>
+        <td>${escapeHtml(repo.latestReport?.status || "missing")}</td>
+        <td>${escapeHtml(repo.latestReport?.unresolvedRegressions ?? 0)}</td>
+        <td>${escapeHtml(repo.latestReport?.visualRiskScore ?? "-")}</td>
+      </tr>`).join("");
+  const html = `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>codex-stack fleet dashboard</title>
+  <style>
+    body { font-family: ui-sans-serif, system-ui, sans-serif; margin: 0; padding: 32px; background: #0b1020; color: #f7f9fc; }
+    .cards { display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: 16px; margin-bottom: 24px; }
+    .card { background: #151d35; border: 1px solid #263355; border-radius: 16px; padding: 18px; }
+    .card strong { display: block; font-size: 1.6rem; }
+    table { width: 100%; border-collapse: collapse; background: #151d35; border-radius: 16px; overflow: hidden; }
+    th, td { padding: 14px 16px; border-bottom: 1px solid #263355; text-align: left; }
+    th { background: #10172b; }
+    .muted { color: #93a3c7; font-size: 0.9rem; margin-top: 4px; }
+    .top-risks { margin: 24px 0; }
+    ul { padding-left: 20px; }
+    a { color: #7cd4ff; }
+  </style>
+</head>
+<body>
+  <h1>codex-stack fleet dashboard</h1>
+  <p>Control repo: ${escapeHtml(report.controlRepo)}</p>
+  <div class="cards">
+    <div class="card"><span>Repos</span><strong>${report.counts.repos}</strong></div>
+    <div class="card"><span>Healthy</span><strong>${report.counts.healthy}</strong></div>
+    <div class="card"><span>Warning</span><strong>${report.counts.warning}</strong></div>
+    <div class="card"><span>Critical</span><strong>${report.counts.critical}</strong></div>
+    <div class="card"><span>Missing</span><strong>${report.counts.missing}</strong></div>
+    <div class="card"><span>Drifted</span><strong>${report.counts.drifted}</strong></div>
+  </div>
+  <section class="top-risks">
+    <h2>Top risks</h2>
+    <ul>${report.topRisks.map((repo) => `<li><strong>${escapeHtml(repo.repo)}</strong> — ${escapeHtml(repo.status.toUpperCase())} (${escapeHtml(repo.riskScore)}/100), drift=${escapeHtml(repo.drift)}, unresolved=${escapeHtml(repo.latestReport?.unresolvedRegressions ?? 0)}</li>`).join("")}</ul>
+  </section>
+  <section>
+    <h2>Repo status</h2>
+    <table>
+      <thead>
+        <tr><th>Repo</th><th>Status</th><th>Drift</th><th>Risk</th><th>Latest QA</th><th>Unresolved</th><th>Visual risk</th></tr>
+      </thead>
+      <tbody>${repoRows}</tbody>
+    </table>
+  </section>
+</body>
+</html>`;
+  writeFile(path.join(outDir, "index.html"), html);
+  writeFile(path.join(outDir, "manifest.json"), `${JSON.stringify(report, null, 2)}\n`);
+  writeFile(path.join(outDir, "summary.md"), renderFleetMarkdown(report));
+}
+
+function buildValidationReport(context: FleetContext): { marker: string; generatedAt: string; controlRepo: string; repos: Array<{ repo: string; policyPack: string; branch: string; valid: boolean; previewUrlTemplate: string; requiredChecks: string[] }> } {
+  const repos = asArray<FleetTarget>(context.manifest.repos).map((target) => {
+    const member = compileMemberConfig(context, target);
+    return {
+      repo: member.repo,
+      policyPack: member.policyPack,
+      branch: member.branch,
+      valid: true,
+      previewUrlTemplate: member.previewUrlTemplate,
+      requiredChecks: member.requiredChecks,
+    };
+  });
+  return {
+    marker: "<!-- codex-stack:fleet-validate -->",
+    generatedAt: new Date().toISOString(),
+    controlRepo: context.controlRepo,
+    repos,
+  };
+}
+
+function renderSyncMarkdown(results: SyncResult[]): string {
+  const lines = ["# codex-stack fleet sync", ""];
+  for (const result of results) {
+    lines.push(`- ${result.repo}: ${result.action} (${result.drift})${result.prUrl ? ` • ${result.prUrl}` : ""}`);
+  }
+  return `${lines.join("\n")}\n`;
+}
+
+function handleValidate(args: ParsedArgs, context: FleetContext): void {
+  const report = buildValidationReport(context);
+  const jsonText = `${JSON.stringify(report, null, 2)}\n`;
+  const markdown = [
+    "# codex-stack fleet validation",
+    "",
+    `- Control repo: ${report.controlRepo}`,
+    `- Repos: ${report.repos.length}`,
+    "",
+    ...report.repos.map((repo) => `- ${repo.repo} (${repo.branch}) • pack=${repo.policyPack} • checks=${repo.requiredChecks.join(", ") || "none"}`),
+  ].join("\n") + "\n";
+  if (args.jsonOut) writeFile(args.jsonOut, jsonText);
+  if (args.markdownOut) writeFile(args.markdownOut, markdown);
+  process.stdout.write(args.json ? jsonText : markdown);
+}
+
+function handleSync(args: ParsedArgs, context: FleetContext): void {
+  const plans = asArray<FleetTarget>(context.manifest.repos).map((target) => planSync(context, target));
+  const results: SyncResult[] = [];
+  for (const plan of plans) {
+    if (args.dryRun) {
+      results.push({
+        repo: plan.repo,
+        drift: plan.drift,
+        action: "planned",
+        branch: plan.branch,
+        localPath: plan.localPath,
+        prUrl: "",
+        filesChanged: plan.files.filter((item) => item.changed).map((item) => item.path),
+      });
+      continue;
+    }
+    if (args.openPrs) {
+      results.push(openPrSync(plan, args.branchName || context.syncBranch));
+      continue;
+    }
+    results.push(syncLocalRepo(plan));
+  }
+
+  const payload = {
+    marker: "<!-- codex-stack:fleet-sync -->",
+    generatedAt: new Date().toISOString(),
+    controlRepo: context.controlRepo,
+    dryRun: args.dryRun,
+    openPrs: args.openPrs,
+    results,
+  };
+  const jsonText = `${JSON.stringify(payload, null, 2)}\n`;
+  const markdown = renderSyncMarkdown(results);
+  if (args.jsonOut) writeFile(args.jsonOut, jsonText);
+  if (args.markdownOut) writeFile(args.markdownOut, markdown);
+  process.stdout.write(args.json ? jsonText : markdown);
+}
+
+function handleCollect(args: ParsedArgs, context: FleetContext): void {
+  const report = collectFleet(context);
+  const jsonText = `${JSON.stringify(report, null, 2)}\n`;
+  const markdown = renderFleetMarkdown(report);
+  if (args.jsonOut) writeFile(args.jsonOut, jsonText);
+  if (args.markdownOut) writeFile(args.markdownOut, markdown);
+  process.stdout.write(args.json ? jsonText : markdown);
+}
+
+function handleDashboard(args: ParsedArgs, context: FleetContext): void {
+  const report = collectFleet(context);
+  renderFleetDashboard(report, args.outDir);
+  const jsonText = `${JSON.stringify(report, null, 2)}\n`;
+  if (args.jsonOut) writeFile(args.jsonOut, jsonText);
+  process.stdout.write(args.json ? jsonText : `fleet dashboard written to ${args.outDir}\n`);
+}
+
+function main(): void {
+  const args = parseArgs(process.argv.slice(2));
+  const context = loadFleetContext(args.manifestPath);
+  if (args.command === "validate") return handleValidate(args, context);
+  if (args.command === "sync") return handleSync(args, context);
+  if (args.command === "collect") return handleCollect(args, context);
+  if (args.command === "dashboard") return handleDashboard(args, context);
+  usage();
+}
+
+main();

--- a/setup
+++ b/setup
@@ -70,11 +70,12 @@ write_wrapper "browse" "browse"
 write_wrapper "setup-browser-cookies" "show setup-browser-cookies"
 write_wrapper "retro" "retro"
 write_wrapper "upgrade" "upgrade"
+write_wrapper "fleet" "fleet"
 
 echo "[codex-stack] local wrappers ready:"
 echo "  $LOCAL_BIN/codex-stack"
 echo "  $LOCAL_BIN/codex-stack-browse"
-echo "  $LOCAL_BIN/{product,tech,review,qa,qa-decide,preview,deploy,ship,browse,setup-browser-cookies,retro,upgrade}"
+echo "  $LOCAL_BIN/{product,tech,review,qa,qa-decide,preview,deploy,ship,browse,setup-browser-cookies,retro,upgrade,fleet}"
 echo
 echo "Next steps:"
 echo "  1. bun src/cli.ts list"

--- a/skills/fleet/SKILL.md
+++ b/skills/fleet/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: fleet
+description: Roll out codex-stack policy packs across multiple repositories and aggregate org-level health.
+---
+
+# /fleet
+
+## Objective
+
+Operate codex-stack as a multi-repo platform instead of a single-repo tool.
+
+## Workflow
+
+1. Validate the fleet manifest and policy-pack references.
+2. Plan rollout drift per target repo.
+3. Sync generated fleet files locally or open rollout PRs remotely.
+4. Collect normalized fleet-status reports from target repos.
+5. Render a dashboard that ranks rollout health and unresolved risks.
+
+## CLI
+
+```bash
+bun src/cli.ts fleet validate --manifest .codex-stack/fleet.example.json
+bun src/cli.ts fleet sync --manifest .codex-stack/fleet.example.json --dry-run --json
+bun src/cli.ts fleet collect --manifest .codex-stack/fleet.example.json --json
+bun src/cli.ts fleet dashboard --manifest .codex-stack/fleet.example.json --out .fleet-site
+```
+
+## Output format
+
+- `validate`: control-plane summary of repos, policy packs, and required checks
+- `sync`: deterministic rollout plan or write/PR results per repo
+- `collect`: normalized multi-repo health report with ranked risks
+- `dashboard`: static HTML + JSON summary for Pages or local review
+
+## Guardrails
+
+- Treat policy packs as the source of truth for required checks.
+- Prefer `--dry-run` before `--open-prs`.
+- Use `localPath` targets for local testing and fixtures.
+- Do not weaken required checks in repo-local overrides.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -26,6 +26,7 @@ Usage:
   codex-stack preview [--url <url> | --url-template <template>] [--pr <number>] [--branch <ref>] [--sha <sha>] [--repo <owner/name>] [--path <path>] [--device <desktop|tablet|mobile>] [--flow <name>] [--snapshot <name>] [--session <name>] [--session-bundle <path>] [--publish-dir <path>] [--markdown-out <path>] [--json-out <path>] [--comment-out <path>] [--wait-timeout <seconds>] [--wait-interval <seconds>] [--strict-console] [--strict-http] [--fixture <path>] [--qa-fixture <path>] [--readiness-fixture <path>] [--json]
   codex-stack deploy [--url <url> | --url-template <template>] [--pr <number>] [--branch <ref>] [--sha <sha>] [--repo <owner/name>] [--path <path>] [--device <desktop|tablet|mobile>] [--flow <name>] [--snapshot <name>] [--session <name>] [--session-bundle <path>] [--publish-dir <path>] [--markdown-out <path>] [--json-out <path>] [--comment-out <path>] [--strict-console] [--strict-http] [--wait-timeout <seconds>] [--wait-interval <seconds>] [--fixture <path>] [--qa-fixture <path>] [--readiness-fixture <path>] [--json]
   codex-stack ship [--dry-run] [--message <msg>] [--push] [--pr] [--template <path>] [--reviewer <user>] [--team-reviewer <org/team>] [--assignee <user>] [--assign-self] [--project <title>] [--label <name>] [--milestone <title>] [--verify-url <url>] [--verify-path <path>] [--verify-device <desktop|tablet|mobile>] [--verify-flow <name>] [--verify-snapshot <name>] [--verify-session <name>] [--verify-console-errors] [--update-verify-snapshot] [--draft]
+  codex-stack fleet <validate|sync|collect|dashboard> --manifest <path> [args...]
   codex-stack retro [--since <range>] [--out <path>] [--json] [--artifact-dir <path>] [--no-artifacts] [--repo <owner/name>] [--no-github]
   codex-stack upgrade [--json] [--json-out <path>] [--markdown-out <path>] [--repo <owner/name>] [--offline] [--apply]
   codex-stack show setup-browser-cookies
@@ -117,6 +118,10 @@ if (command === "deploy") {
 
 if (command === "ship") {
   runScript(path.join("scripts", "ship-branch.ts"), rest);
+}
+
+if (command === "fleet") {
+  runScript(path.join("scripts", "fleet.ts"), rest);
 }
 
 if (command === "retro") {

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -79,6 +79,12 @@ export const modeRegistry: ModeDefinition[] = [
     summary: "Audit install health and update drift across dependencies, skills, and workflows.",
     skillPath: path.join(rootDir, "skills", "upgrade", "SKILL.md"),
   },
+  {
+    name: "fleet",
+    role: "Platform engineer",
+    summary: "Roll out codex-stack policies across multiple repos and aggregate org-level health.",
+    skillPath: path.join(rootDir, "skills", "fleet", "SKILL.md"),
+  },
 ];
 
 export function findMode(name: string): ModeDefinition | undefined {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-export type ModeName = "product" | "tech" | "review" | "qa" | "qa-decide" | "preview" | "deploy" | "ship" | "browse" | "setup-browser-cookies" | "retro" | "upgrade";
+export type ModeName = "product" | "tech" | "review" | "qa" | "qa-decide" | "preview" | "deploy" | "ship" | "browse" | "setup-browser-cookies" | "retro" | "upgrade" | "fleet";
 
 export interface ModeDefinition {
   name: ModeName;

--- a/templates/fleet/fleet-status.js
+++ b/templates/fleet/fleet-status.js
@@ -1,0 +1,178 @@
+#!/usr/bin/env node
+const fs = require('node:fs');
+const path = require('node:path');
+
+function clean(value) {
+  return String(value || '').replace(/\s+/g, ' ').trim();
+}
+
+function ensureDir(dirPath) {
+  fs.mkdirSync(dirPath, { recursive: true });
+}
+
+function asNumber(value) {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function findJsonFiles(rootDir) {
+  const results = [];
+  if (!fs.existsSync(rootDir)) return results;
+  const stack = [rootDir];
+  while (stack.length) {
+    const current = stack.pop();
+    const entries = fs.readdirSync(current, { withFileTypes: true });
+    for (const entry of entries) {
+      const absolute = path.join(current, entry.name);
+      if (entry.isDirectory()) {
+        stack.push(absolute);
+      } else if (entry.isFile() && entry.name === 'report.json') {
+        results.push(absolute);
+      }
+    }
+  }
+  return results;
+}
+
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+function pickLatestReport(reportPaths) {
+  let best = null;
+  for (const reportPath of reportPaths) {
+    try {
+      const data = readJson(reportPath);
+      const generatedAt = clean(data.generatedAt || data.timestamp || '');
+      const score = generatedAt ? Date.parse(generatedAt) : fs.statSync(reportPath).mtimeMs;
+      if (!best || score > best.score) {
+        best = { path: reportPath, data, score };
+      }
+    } catch {
+      // Ignore malformed reports.
+    }
+  }
+  return best;
+}
+
+function parseArgs(argv) {
+  const out = {
+    out: path.resolve(process.cwd(), '.codex-stack', 'fleet-status', 'status.json'),
+    markdownOut: path.resolve(process.cwd(), '.codex-stack', 'fleet-status', 'summary.md'),
+    json: false,
+  };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === '--out') {
+      out.out = path.resolve(process.cwd(), argv[i + 1] || out.out);
+      i += 1;
+    } else if (arg === '--markdown-out') {
+      out.markdownOut = path.resolve(process.cwd(), argv[i + 1] || out.markdownOut);
+      i += 1;
+    } else if (arg === '--json') {
+      out.json = true;
+    }
+  }
+  return out;
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const memberPath = path.resolve(process.cwd(), '.codex-stack', 'fleet-member.json');
+  const repo = clean(process.env.GITHUB_REPOSITORY || path.basename(process.cwd()));
+  const branch = clean(process.env.GITHUB_REF_NAME || '');
+  const member = fs.existsSync(memberPath) ? readJson(memberPath) : null;
+  const latest = pickLatestReport(findJsonFiles(path.resolve(process.cwd(), 'docs', 'qa')));
+  const latestData = latest ? latest.data : null;
+
+  const unresolved = asNumber(latestData && latestData.decisionSummary && latestData.decisionSummary.unresolvedCount) || 0;
+  const expired = asNumber(latestData && latestData.decisionSummary && latestData.decisionSummary.expiredCount) || 0;
+  const staleBaselines = asNumber(latestData && latestData.visualRisk && latestData.visualRisk.staleBaselines) || 0;
+  const visualRiskScore = asNumber(latestData && latestData.visualRisk && latestData.visualRisk.score);
+  const accessibilityViolations = asNumber(latestData && latestData.accessibility && latestData.accessibility.violationCount);
+  const performanceBudgetViolations = asNumber(latestData && latestData.performance && latestData.performance.budgetViolationCount);
+  const baseStatus = clean(latestData && latestData.status || '');
+
+  let status = 'healthy';
+  if (!member) {
+    status = 'missing';
+  } else if (!latestData) {
+    status = 'warning';
+  } else if (baseStatus === 'critical') {
+    status = 'critical';
+  } else if (baseStatus === 'warning' || unresolved > 0 || expired > 0 || staleBaselines > 0) {
+    status = 'warning';
+  }
+
+  let riskScore = 0;
+  if (!member) riskScore += 80;
+  if (!latestData) riskScore += 20;
+  if (baseStatus === 'critical') riskScore += 40;
+  if (baseStatus === 'warning') riskScore += 20;
+  riskScore += Math.min(24, unresolved * 8);
+  riskScore += Math.min(12, expired * 4);
+  riskScore += Math.min(12, staleBaselines * 3);
+  riskScore += Math.min(25, Math.round((visualRiskScore || 0) * 0.25));
+  riskScore += Math.min(10, (accessibilityViolations || 0) * 2);
+  riskScore += Math.min(12, (performanceBudgetViolations || 0) * 4);
+  riskScore = Math.min(100, riskScore);
+
+  const payload = {
+    marker: '<!-- codex-stack:fleet-status -->',
+    generatedAt: new Date().toISOString(),
+    repo,
+    branch: branch || clean(member && member.branch || ''),
+    installed: Boolean(member),
+    controlRepo: clean(member && member.controlRepo || ''),
+    team: clean(member && member.team || ''),
+    policyPack: clean(member && member.policyPack || ''),
+    requiredChecks: Array.isArray(member && member.requiredChecks) ? member.requiredChecks : [],
+    status,
+    riskScore,
+    latestReport: latestData ? {
+      generatedAt: clean(latestData.generatedAt || ''),
+      status: baseStatus || 'unknown',
+      recommendation: clean(latestData.recommendation || ''),
+      healthScore: asNumber(latestData.healthScore),
+      visualRiskScore,
+      visualRiskLevel: clean(latestData.visualRisk && latestData.visualRisk.level || ''),
+      unresolvedRegressions: unresolved,
+      approvedRegressions: asNumber(latestData.decisionSummary && latestData.decisionSummary.approvedCount) || 0,
+      expiredDecisions: expired,
+      staleBaselines,
+      accessibilityViolations,
+      performanceBudgetViolations,
+      reportPath: latest.path,
+    } : null,
+  };
+
+  const markdownLines = [
+    '# codex-stack fleet status',
+    '',
+    `- Repo: ${payload.repo}`,
+    `- Branch: ${payload.branch || 'unknown'}`,
+    `- Installed: ${payload.installed ? 'yes' : 'no'}`,
+    `- Status: ${payload.status.toUpperCase()}`,
+    `- Risk score: ${payload.riskScore}/100`,
+    payload.team ? `- Team: ${payload.team}` : '',
+    payload.policyPack ? `- Policy pack: ${payload.policyPack}` : '',
+    payload.latestReport ? `- Latest QA status: ${payload.latestReport.status}` : '- Latest QA status: missing',
+    payload.latestReport && payload.latestReport.visualRiskScore !== null ? `- Visual risk: ${payload.latestReport.visualRiskLevel || 'none'} (${payload.latestReport.visualRiskScore}/100)` : '',
+    payload.latestReport ? `- Unresolved regressions: ${payload.latestReport.unresolvedRegressions}` : '',
+    payload.latestReport && payload.latestReport.accessibilityViolations !== null ? `- Accessibility violations: ${payload.latestReport.accessibilityViolations}` : '',
+    payload.latestReport && payload.latestReport.performanceBudgetViolations !== null ? `- Perf budget violations: ${payload.latestReport.performanceBudgetViolations}` : '',
+  ].filter(Boolean);
+
+  ensureDir(path.dirname(args.out));
+  ensureDir(path.dirname(args.markdownOut));
+  fs.writeFileSync(args.out, JSON.stringify(payload, null, 2));
+  fs.writeFileSync(args.markdownOut, `${markdownLines.join('\n')}\n`);
+
+  if (args.json) {
+    process.stdout.write(`${JSON.stringify(payload, null, 2)}\n`);
+  } else {
+    process.stdout.write(`${markdownLines.join('\n')}\n`);
+  }
+}
+
+main();


### PR DESCRIPTION
## Summary
- add a new `fleet` control plane for multi-repo rollout, collection, and dashboarding
- introduce shared fleet policy packs plus generated member config and status workflow assets
- add fleet docs, skill docs, examples, and validation coverage

## Validation
- `bun run typecheck`
- `bun run smoke`
- `bun scripts/fleet.spec.ts`

## Issue
Closes #60