### PR TITLE
fix: harden fleet workspace rollout

### DIFF
--- a/scripts/fleet.spec.ts
+++ b/scripts/fleet.spec.ts
@@ -8,6 +8,7 @@ import { execFileSync } from "node:child_process";
 
 const rootDir = process.cwd();
 const bun = process.execPath || "bun";
+const fleetScript = path.join(rootDir, "scripts", "fleet.ts");
 const fixtureRoot = fs.mkdtempSync(path.join(os.tmpdir(), "codex-stack-fleet-"));
 const controlDir = path.join(fixtureRoot, "control");
 const repoDir = path.join(fixtureRoot, "repo-a");
@@ -48,12 +49,12 @@ fs.writeFileSync(path.join(policyDir, "default.json"), JSON.stringify({
 fs.writeFileSync(manifestPath, JSON.stringify({
   schemaVersion: 1,
   controlRepo: "acme/control-plane",
-  policyDir: "policies",
+  policyDir: "./policies",
   repos: [
     {
       repo: "acme/repo-a",
       branch: "main",
-      localPath: repoDir,
+      localPath: "../repo-a",
       team: "platform",
       policyPack: "default",
       enabledChecks: ["qa"],
@@ -90,14 +91,16 @@ fs.writeFileSync(path.join(repoDir, "docs", "qa", "latest", "report.json"), JSON
   },
 }, null, 2));
 
-const validateReport = JSON.parse(run(["scripts/fleet.ts", "validate", "--manifest", manifestPath, "--json"])) as {
+const validateReport = JSON.parse(run([fleetScript, "validate", "--manifest", manifestPath, "--json"], fixtureRoot)) as {
   controlRepo?: string;
-  repos?: Array<{ repo?: string; requiredChecks?: string[] }>;
+  repos?: Array<{ repo?: string; requiredChecks?: string[]; localPath?: string; localRepoDetected?: boolean }>;
 };
 assert.equal(validateReport.controlRepo, "acme/control-plane");
 assert.deepEqual(validateReport.repos?.[0]?.requiredChecks, ["fleet-status", "preview", "qa", "review"]);
+assert.equal(validateReport.repos?.[0]?.localPath, repoDir);
+assert.equal(validateReport.repos?.[0]?.localRepoDetected, false);
 
-const dryRunReport = JSON.parse(run(["scripts/fleet.ts", "sync", "--manifest", manifestPath, "--dry-run", "--json"])) as {
+const dryRunReport = JSON.parse(run([fleetScript, "sync", "--manifest", manifestPath, "--dry-run", "--json"], fixtureRoot)) as {
   results?: Array<{ repo?: string; action?: string; drift?: string; filesChanged?: string[] }>;
 };
 assert.equal(dryRunReport.results?.[0]?.repo, "acme/repo-a");
@@ -105,7 +108,7 @@ assert.equal(dryRunReport.results?.[0]?.action, "planned");
 assert.equal(dryRunReport.results?.[0]?.drift, "missing");
 assert.ok(dryRunReport.results?.[0]?.filesChanged?.includes(".codex-stack/fleet-member.json"));
 
-const syncReport = JSON.parse(run(["scripts/fleet.ts", "sync", "--manifest", manifestPath, "--json"])) as {
+const syncReport = JSON.parse(run([fleetScript, "sync", "--manifest", manifestPath, "--json"], fixtureRoot)) as {
   results?: Array<{ action?: string; filesChanged?: string[] }>;
 };
 assert.equal(syncReport.results?.[0]?.action, "written");
@@ -137,23 +140,45 @@ assert.equal(statusReport.status, "warning");
 assert.ok(Number(statusReport.riskScore) > 0);
 assert.equal(statusReport.latestReport?.unresolvedRegressions, 2);
 
-const collectReport = JSON.parse(run(["scripts/fleet.ts", "collect", "--manifest", manifestPath, "--json"])) as {
-  counts?: { repos?: number; warning?: number; drifted?: number };
-  repos?: Array<{ repo?: string; source?: string; status?: string; riskScore?: number }>;
+fs.writeFileSync(statusOut, JSON.stringify({
+  marker: "<!-- codex-stack:fleet-status -->",
+  generatedAt: "2026-03-15T10:00:00.000Z",
+  repo: "acme/repo-a",
+  branch: "main",
+  installed: true,
+  controlRepo: "acme/control-plane",
+  team: "platform",
+  policyPack: "default",
+  requiredChecks: ["fleet-status", "preview", "qa", "review"],
+  status: "critical",
+  riskScore: 91,
+  latestReport: {
+    generatedAt: "2026-03-15T10:00:00.000Z",
+    status: "critical",
+    unresolvedRegressions: 4,
+    visualRiskScore: 83,
+  },
+}, null, 2));
+
+const collectReport = JSON.parse(run([fleetScript, "collect", "--manifest", manifestPath, "--json"], fixtureRoot)) as {
+  counts?: { repos?: number; critical?: number; drifted?: number };
+  repos?: Array<{ repo?: string; source?: string; status?: string; riskScore?: number; repoUrl?: string }>;
 };
 assert.equal(collectReport.counts?.repos, 1);
-assert.equal(collectReport.counts?.warning, 1);
+assert.equal(collectReport.counts?.critical, 1);
 assert.equal(collectReport.counts?.drifted, 0);
 assert.equal(collectReport.repos?.[0]?.repo, "acme/repo-a");
-assert.equal(collectReport.repos?.[0]?.source, "local");
-assert.equal(collectReport.repos?.[0]?.status, "warning");
-assert.ok(Number(collectReport.repos?.[0]?.riskScore) > 0);
+assert.equal(collectReport.repos?.[0]?.source, "local-status");
+assert.equal(collectReport.repos?.[0]?.status, "critical");
+assert.equal(collectReport.repos?.[0]?.riskScore, 91);
+assert.equal(collectReport.repos?.[0]?.repoUrl, "https://github.com/acme/repo-a");
 
-run(["scripts/fleet.ts", "dashboard", "--manifest", manifestPath, "--out", dashboardDir], rootDir);
+run([fleetScript, "dashboard", "--manifest", manifestPath, "--out", dashboardDir], fixtureRoot);
 assert.ok(fs.existsSync(path.join(dashboardDir, "index.html")));
 assert.ok(fs.existsSync(path.join(dashboardDir, "manifest.json")));
 assert.ok(fs.existsSync(path.join(dashboardDir, "summary.md")));
 assert.match(fs.readFileSync(path.join(dashboardDir, "index.html"), "utf8"), /codex-stack fleet dashboard/);
+assert.match(fs.readFileSync(path.join(dashboardDir, "index.html"), "utf8"), /https:\/\/github.com\/acme\/repo-a/);
 assert.match(fs.readFileSync(path.join(dashboardDir, "manifest.json"), "utf8"), /acme\/repo-a/);
 
 fs.rmSync(fixtureRoot, { recursive: true, force: true });

--- a/scripts/fleet.ts
+++ b/scripts/fleet.ts
@@ -4,6 +4,9 @@ import os from "node:os";
 import path from "node:path";
 import process from "node:process";
 import { execSync, spawnSync, type ExecSyncOptionsWithStringEncoding } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
 
 const DEFAULT_STATUS_ARTIFACT = "codex-stack-fleet-status";
 const DEFAULT_BRANCH = "main";
@@ -200,6 +203,7 @@ interface FleetStatusReport {
 
 interface CollectedFleetRepo {
   repo: string;
+  repoUrl: string;
   branch: string;
   team: string;
   policyPack: string;
@@ -209,7 +213,7 @@ interface CollectedFleetRepo {
   riskScore: number;
   requiredChecks: string[];
   latestReport: FleetStatusReport["latestReport"];
-  source: "local" | "artifact" | "repo-files" | "missing";
+  source: "local-status" | "local" | "artifact" | "repo-files" | "missing";
 }
 
 interface FleetCollectReport {
@@ -320,6 +324,20 @@ function inferControlRef(): string {
   return clean(run("git rev-parse HEAD", { allowFailure: true })) || "local";
 }
 
+function repoUrl(repo: string): string {
+  return repo ? `https://github.com/${repo}` : "";
+}
+
+function resolveAgainstManifestDir(manifestDir: string, targetPath: string): string {
+  const raw = clean(targetPath);
+  if (!raw) return "";
+  return path.isAbsolute(raw) ? raw : path.resolve(manifestDir, raw);
+}
+
+function resolveFromManifest(context: FleetContext, targetPath: string): string {
+  return resolveAgainstManifestDir(context.manifestDir, targetPath);
+}
+
 function parseArgs(argv: string[]): ParsedArgs {
   const command = clean(argv[0]) as ParsedArgs["command"];
   if (!command || !(command === "validate" || command === "sync" || command === "collect" || command === "dashboard")) usage();
@@ -428,7 +446,7 @@ function loadFleetContext(manifestPath: string): FleetContext {
     controlRef: inferControlRef(),
     statusArtifactName: clean(manifest.statusArtifactName || "") || DEFAULT_STATUS_ARTIFACT,
     syncBranch: clean(manifest.syncBranch || "") || DEFAULT_SYNC_BRANCH,
-    policyDir: path.resolve(path.dirname(manifestPath), clean(manifest.policyDir || "") || DEFAULT_POLICY_DIR),
+    policyDir: resolveAgainstManifestDir(path.dirname(manifestPath), clean(manifest.policyDir || "") || DEFAULT_POLICY_DIR),
   };
   if (!context.controlRepo) throw new Error("Unable to infer control repo. Set controlRepo in the manifest.");
   return context;
@@ -530,7 +548,7 @@ function compileMemberConfig(context: FleetContext, target: FleetTarget): FleetM
 }
 
 function loadStatusScriptTemplate(): string {
-  const templatePath = path.resolve(process.cwd(), "templates", "fleet", "fleet-status.js");
+  const templatePath = path.resolve(SCRIPT_DIR, "..", "templates", "fleet", "fleet-status.js");
   return fs.readFileSync(templatePath, "utf8");
 }
 
@@ -645,7 +663,7 @@ function detectDrift(existing: Record<string, string>, generated: GeneratedFiles
 function planSync(context: FleetContext, target: FleetTarget): SyncPlan {
   const member = compileMemberConfig(context, target);
   const generated = generateFiles(member);
-  const localPath = clean(target.localPath || "");
+  const localPath = resolveFromManifest(context, clean(target.localPath || ""));
   const existing: Record<string, string> = {};
   const branch = member.branch || DEFAULT_BRANCH;
 
@@ -832,6 +850,16 @@ function latestQaReportFromRepoRoot(repoRoot: string): FleetStatusReport["latest
   };
 }
 
+function readLocalFleetStatus(repoRoot: string): FleetStatusReport | null {
+  const statusPath = path.join(repoRoot, FLEET_STATUS_JSON);
+  if (!fs.existsSync(statusPath)) return null;
+  try {
+    return readJsonFile<FleetStatusReport>(statusPath);
+  } catch {
+    return null;
+  }
+}
+
 function computeCollectedStatus(installed: boolean, drift: DriftState, latestReport: FleetStatusReport["latestReport"]): { status: RepoHealth; riskScore: number } {
   if (!installed) {
     return { status: "missing", riskScore: 85 };
@@ -902,20 +930,24 @@ function collectRepo(context: FleetContext, target: FleetTarget): CollectedFleet
   const plan = planSync(context, target);
   if (plan.localPath) {
     const member = readLocalMemberConfig(plan.localPath) || plan.memberConfig;
-    const latestReport = latestQaReportFromRepoRoot(plan.localPath);
+    const localStatus = readLocalFleetStatus(plan.localPath);
+    const latestReport = localStatus?.latestReport || latestQaReportFromRepoRoot(plan.localPath);
     const computed = computeCollectedStatus(Boolean(member), plan.drift, latestReport);
+    const status = localStatus?.status || computed.status;
+    const riskScore = localStatus?.riskScore ?? computed.riskScore;
     return {
       repo: plan.repo,
+      repoUrl: repoUrl(plan.repo),
       branch: plan.branch,
       team: member.team,
       policyPack: member.policyPack,
       installed: Boolean(member),
       drift: plan.drift,
-      status: computed.status,
-      riskScore: computed.riskScore,
+      status,
+      riskScore,
       requiredChecks: member.requiredChecks,
       latestReport,
-      source: latestReport ? "local" : "repo-files",
+      source: localStatus ? "local-status" : latestReport ? "local" : "repo-files",
     };
   }
 
@@ -925,6 +957,7 @@ function collectRepo(context: FleetContext, target: FleetTarget): CollectedFleet
   const computed = computeCollectedStatus(Boolean(member), plan.drift, latestReport);
   return {
     repo: plan.repo,
+    repoUrl: repoUrl(plan.repo),
     branch: plan.branch,
     team: member?.team || plan.team,
     policyPack: member?.policyPack || plan.policyPack,
@@ -994,7 +1027,7 @@ function renderFleetDashboard(report: FleetCollectReport, outDir: string): void 
   ensureDir(outDir);
   const repoRows = report.repos.map((repo) => `
       <tr>
-        <td><strong>${escapeHtml(repo.repo)}</strong><div class="muted">${escapeHtml(repo.team || "unassigned")}</div></td>
+        <td><strong><a href="${escapeHtml(repo.repoUrl)}">${escapeHtml(repo.repo)}</a></strong><div class="muted">${escapeHtml(repo.team || "unassigned")} • source=${escapeHtml(repo.source)}</div></td>
         <td>${escapeHtml(repo.status.toUpperCase())}</td>
         <td>${escapeHtml(repo.drift.toUpperCase())}</td>
         <td>${escapeHtml(repo.riskScore)}</td>
@@ -1035,7 +1068,7 @@ function renderFleetDashboard(report: FleetCollectReport, outDir: string): void 
   </div>
   <section class="top-risks">
     <h2>Top risks</h2>
-    <ul>${report.topRisks.map((repo) => `<li><strong>${escapeHtml(repo.repo)}</strong> — ${escapeHtml(repo.status.toUpperCase())} (${escapeHtml(repo.riskScore)}/100), drift=${escapeHtml(repo.drift)}, unresolved=${escapeHtml(repo.latestReport?.unresolvedRegressions ?? 0)}</li>`).join("")}</ul>
+    <ul>${report.topRisks.map((repo) => `<li><strong><a href="${escapeHtml(repo.repoUrl)}">${escapeHtml(repo.repo)}</a></strong> — ${escapeHtml(repo.status.toUpperCase())} (${escapeHtml(repo.riskScore)}/100), drift=${escapeHtml(repo.drift)}, unresolved=${escapeHtml(repo.latestReport?.unresolvedRegressions ?? 0)}</li>`).join("")}</ul>
   </section>
   <section>
     <h2>Repo status</h2>
@@ -1053,9 +1086,10 @@ function renderFleetDashboard(report: FleetCollectReport, outDir: string): void 
   writeFile(path.join(outDir, "summary.md"), renderFleetMarkdown(report));
 }
 
-function buildValidationReport(context: FleetContext): { marker: string; generatedAt: string; controlRepo: string; repos: Array<{ repo: string; policyPack: string; branch: string; valid: boolean; previewUrlTemplate: string; requiredChecks: string[] }> } {
+function buildValidationReport(context: FleetContext): { marker: string; generatedAt: string; controlRepo: string; repos: Array<{ repo: string; policyPack: string; branch: string; valid: boolean; previewUrlTemplate: string; requiredChecks: string[]; localPath: string; localRepoDetected: boolean }> } {
   const repos = asArray<FleetTarget>(context.manifest.repos).map((target) => {
     const member = compileMemberConfig(context, target);
+    const localPath = resolveFromManifest(context, clean(target.localPath || ""));
     return {
       repo: member.repo,
       policyPack: member.policyPack,
@@ -1063,6 +1097,8 @@ function buildValidationReport(context: FleetContext): { marker: string; generat
       valid: true,
       previewUrlTemplate: member.previewUrlTemplate,
       requiredChecks: member.requiredChecks,
+      localPath,
+      localRepoDetected: Boolean(localPath && fs.existsSync(path.join(localPath, ".git"))),
     };
   });
   return {


### PR DESCRIPTION
## Summary
- resolve fleet manifest paths relative to the control manifest instead of the current shell cwd
- prefer local fleet status payloads when collecting health from workspace repos
- add repo/source visibility to fleet validation and dashboard output

## Validation
- bun scripts/fleet.spec.ts
- bun run typecheck
- bun run smoke

Closes #62