### PR TITLE
fix: harden fleet live repo rollout

### DIFF
--- a/scripts/fleet.spec.ts
+++ b/scripts/fleet.spec.ts
@@ -25,6 +25,7 @@ function run(args: string[], cwd = rootDir): string {
 
 fs.mkdirSync(policyDir, { recursive: true });
 fs.mkdirSync(path.join(repoDir, "docs", "qa", "latest"), { recursive: true });
+execFileSync("git", ["init", "-q", "-b", "main", repoDir]);
 fs.writeFileSync(path.join(policyDir, "default.json"), JSON.stringify({
   name: "default",
   requiredChecks: ["review", "preview", "fleet-status"],
@@ -93,12 +94,40 @@ fs.writeFileSync(path.join(repoDir, "docs", "qa", "latest", "report.json"), JSON
 
 const validateReport = JSON.parse(run([fleetScript, "validate", "--manifest", manifestPath, "--json"], fixtureRoot)) as {
   controlRepo?: string;
-  repos?: Array<{ repo?: string; requiredChecks?: string[]; localPath?: string; localRepoDetected?: boolean }>;
+  repos?: Array<{ repo?: string; requiredChecks?: string[]; localPath?: string; localRepoDetected?: boolean; valid?: boolean }>;
 };
 assert.equal(validateReport.controlRepo, "acme/control-plane");
 assert.deepEqual(validateReport.repos?.[0]?.requiredChecks, ["fleet-status", "preview", "qa", "review"]);
 assert.equal(validateReport.repos?.[0]?.localPath, repoDir);
-assert.equal(validateReport.repos?.[0]?.localRepoDetected, false);
+assert.equal(validateReport.repos?.[0]?.localRepoDetected, true);
+assert.equal(validateReport.repos?.[0]?.valid, true);
+
+const invalidManifestPath = path.join(controlDir, "fleet-invalid.json");
+fs.writeFileSync(invalidManifestPath, JSON.stringify({
+  schemaVersion: 1,
+  controlRepo: "acme/control-plane",
+  policyDir: "./policies",
+  repos: [
+    {
+      repo: "acme/missing-repo",
+      branch: "main",
+      localPath: "../missing-repo",
+      policyPack: "default",
+    },
+  ],
+}, null, 2));
+
+const invalidValidateReport = JSON.parse(run([fleetScript, "validate", "--manifest", invalidManifestPath, "--json"], fixtureRoot)) as {
+  repos?: Array<{ valid?: boolean; localRepoDetected?: boolean; localPath?: string }>;
+};
+assert.equal(invalidValidateReport.repos?.[0]?.localRepoDetected, false);
+assert.equal(invalidValidateReport.repos?.[0]?.valid, false);
+
+const invalidSyncReport = JSON.parse(run([fleetScript, "sync", "--manifest", invalidManifestPath, "--dry-run", "--json"], fixtureRoot)) as {
+  results?: Array<{ action?: string; notes?: string[] }>;
+};
+assert.equal(invalidSyncReport.results?.[0]?.action, "invalid");
+assert.equal(invalidSyncReport.results?.[0]?.notes?.[0], "Configured localPath is not a Git repo root.");
 
 const dryRunReport = JSON.parse(run([fleetScript, "sync", "--manifest", manifestPath, "--dry-run", "--json"], fixtureRoot)) as {
   results?: Array<{ repo?: string; action?: string; drift?: string; filesChanged?: string[] }>;
@@ -107,6 +136,14 @@ assert.equal(dryRunReport.results?.[0]?.repo, "acme/repo-a");
 assert.equal(dryRunReport.results?.[0]?.action, "planned");
 assert.equal(dryRunReport.results?.[0]?.drift, "missing");
 assert.ok(dryRunReport.results?.[0]?.filesChanged?.includes(".codex-stack/fleet-member.json"));
+
+const preSyncCollectReport = JSON.parse(run([fleetScript, "collect", "--manifest", manifestPath, "--json"], fixtureRoot)) as {
+  counts?: { missing?: number };
+  repos?: Array<{ installed?: boolean; source?: string }>;
+};
+assert.equal(preSyncCollectReport.counts?.missing, 1);
+assert.equal(preSyncCollectReport.repos?.[0]?.installed, false);
+assert.equal(preSyncCollectReport.repos?.[0]?.source, "local");
 
 const syncReport = JSON.parse(run([fleetScript, "sync", "--manifest", manifestPath, "--json"], fixtureRoot)) as {
   results?: Array<{ action?: string; filesChanged?: string[] }>;
@@ -128,14 +165,16 @@ assert.equal(memberConfig.previewUrlTemplate, "https://preview-{pr}.example.com"
 assert.deepEqual(memberConfig.requiredChecks, ["fleet-status", "preview", "qa", "review"]);
 
 const statusOut = path.join(repoDir, ".codex-stack", "fleet-status", "status.json");
-const statusJson = run([path.join(repoDir, ".github", "codex-stack", "fleet-status.js"), "--out", statusOut, "--json"], repoDir);
+const statusJson = run([path.join(repoDir, ".github", "codex-stack", "fleet-status.js"), "--out", statusOut, "--json"], fixtureRoot);
 const statusReport = JSON.parse(statusJson) as {
   installed?: boolean;
+  repo?: string;
   status?: string;
   riskScore?: number;
   latestReport?: { unresolvedRegressions?: number } | null;
 };
 assert.equal(statusReport.installed, true);
+assert.equal(statusReport.repo, "acme/repo-a");
 assert.equal(statusReport.status, "warning");
 assert.ok(Number(statusReport.riskScore) > 0);
 assert.equal(statusReport.latestReport?.unresolvedRegressions, 2);

--- a/scripts/fleet.ts
+++ b/scripts/fleet.ts
@@ -154,6 +154,7 @@ interface SyncPlan {
   team: string;
   policyPack: string;
   localPath: string;
+  localRepoDetected: boolean;
   drift: DriftState;
   files: SyncFilePlan[];
   memberConfig: FleetMemberConfig;
@@ -165,11 +166,12 @@ interface SyncPlan {
 interface SyncResult {
   repo: string;
   drift: DriftState;
-  action: "planned" | "written" | "opened-pr" | "skipped";
+  action: "planned" | "written" | "opened-pr" | "skipped" | "invalid";
   branch: string;
   localPath: string;
   prUrl: string;
   filesChanged: string[];
+  notes?: string[];
 }
 
 interface FleetStatusReport {
@@ -336,6 +338,17 @@ function resolveAgainstManifestDir(manifestDir: string, targetPath: string): str
 
 function resolveFromManifest(context: FleetContext, targetPath: string): string {
   return resolveAgainstManifestDir(context.manifestDir, targetPath);
+}
+
+function isGitRepoRoot(repoPath: string): boolean {
+  const candidate = clean(repoPath);
+  if (!candidate || !fs.existsSync(candidate)) return false;
+  const result = spawnSync("git", ["-C", candidate, "rev-parse", "--show-toplevel"], {
+    cwd: process.cwd(),
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  return (result.status ?? 1) === 0;
 }
 
 function parseArgs(argv: string[]): ParsedArgs {
@@ -664,10 +677,11 @@ function planSync(context: FleetContext, target: FleetTarget): SyncPlan {
   const member = compileMemberConfig(context, target);
   const generated = generateFiles(member);
   const localPath = resolveFromManifest(context, clean(target.localPath || ""));
+  const localRepoDetected = isGitRepoRoot(localPath);
   const existing: Record<string, string> = {};
   const branch = member.branch || DEFAULT_BRANCH;
 
-  if (localPath) {
+  if (localPath && localRepoDetected) {
     existing[FLEET_MEMBER_PATH] = readLocalFile(localPath, FLEET_MEMBER_PATH);
     existing[FLEET_STATUS_SCRIPT_PATH] = readLocalFile(localPath, FLEET_STATUS_SCRIPT_PATH);
     existing[FLEET_STATUS_WORKFLOW_PATH] = readLocalFile(localPath, FLEET_STATUS_WORKFLOW_PATH);
@@ -684,6 +698,7 @@ function planSync(context: FleetContext, target: FleetTarget): SyncPlan {
     team: member.team,
     policyPack: member.policyPack,
     localPath,
+    localRepoDetected,
     drift: drift.drift,
     files: drift.files,
     memberConfig: member,
@@ -724,6 +739,18 @@ function syncLocalRepo(plan: SyncPlan): SyncResult {
       localPath: "",
       prUrl: "",
       filesChanged: [],
+    };
+  }
+  if (!plan.localRepoDetected) {
+    return {
+      repo: plan.repo,
+      drift: plan.drift,
+      action: "invalid",
+      branch: plan.branch,
+      localPath: plan.localPath,
+      prUrl: "",
+      filesChanged: [],
+      notes: ["Configured localPath is not a Git repo root."],
     };
   }
   const filesChanged = writeGeneratedFiles(plan.localPath, plan);
@@ -928,26 +955,27 @@ function downloadLatestArtifactStatus(repo: string, branch: string, artifactName
 
 function collectRepo(context: FleetContext, target: FleetTarget): CollectedFleetRepo {
   const plan = planSync(context, target);
-  if (plan.localPath) {
-    const member = readLocalMemberConfig(plan.localPath) || plan.memberConfig;
+  if (plan.localPath && plan.localRepoDetected) {
+    const member = readLocalMemberConfig(plan.localPath);
     const localStatus = readLocalFleetStatus(plan.localPath);
     const latestReport = localStatus?.latestReport || latestQaReportFromRepoRoot(plan.localPath);
-    const computed = computeCollectedStatus(Boolean(member), plan.drift, latestReport);
+    const installed = Boolean(member || localStatus);
+    const computed = computeCollectedStatus(installed, plan.drift, latestReport);
     const status = localStatus?.status || computed.status;
     const riskScore = localStatus?.riskScore ?? computed.riskScore;
     return {
       repo: plan.repo,
       repoUrl: repoUrl(plan.repo),
       branch: plan.branch,
-      team: member.team,
-      policyPack: member.policyPack,
-      installed: Boolean(member),
+      team: member?.team || plan.team,
+      policyPack: member?.policyPack || plan.policyPack,
+      installed,
       drift: plan.drift,
       status,
       riskScore,
-      requiredChecks: member.requiredChecks,
+      requiredChecks: member?.requiredChecks || plan.memberConfig.requiredChecks,
       latestReport,
-      source: localStatus ? "local-status" : latestReport ? "local" : "repo-files",
+      source: localStatus ? "local-status" : latestReport ? "local" : installed ? "repo-files" : "missing",
     };
   }
 
@@ -1090,15 +1118,16 @@ function buildValidationReport(context: FleetContext): { marker: string; generat
   const repos = asArray<FleetTarget>(context.manifest.repos).map((target) => {
     const member = compileMemberConfig(context, target);
     const localPath = resolveFromManifest(context, clean(target.localPath || ""));
+    const localRepoDetected = isGitRepoRoot(localPath);
     return {
       repo: member.repo,
       policyPack: member.policyPack,
       branch: member.branch,
-      valid: true,
+      valid: !localPath || localRepoDetected,
       previewUrlTemplate: member.previewUrlTemplate,
       requiredChecks: member.requiredChecks,
       localPath,
-      localRepoDetected: Boolean(localPath && fs.existsSync(path.join(localPath, ".git"))),
+      localRepoDetected,
     };
   });
   return {
@@ -1112,7 +1141,7 @@ function buildValidationReport(context: FleetContext): { marker: string; generat
 function renderSyncMarkdown(results: SyncResult[]): string {
   const lines = ["# codex-stack fleet sync", ""];
   for (const result of results) {
-    lines.push(`- ${result.repo}: ${result.action} (${result.drift})${result.prUrl ? ` • ${result.prUrl}` : ""}`);
+    lines.push(`- ${result.repo}: ${result.action} (${result.drift})${result.prUrl ? ` • ${result.prUrl}` : ""}${result.notes?.length ? ` • ${result.notes.join("; ")}` : ""}`);
   }
   return `${lines.join("\n")}\n`;
 }
@@ -1126,7 +1155,7 @@ function handleValidate(args: ParsedArgs, context: FleetContext): void {
     `- Control repo: ${report.controlRepo}`,
     `- Repos: ${report.repos.length}`,
     "",
-    ...report.repos.map((repo) => `- ${repo.repo} (${repo.branch}) • pack=${repo.policyPack} • checks=${repo.requiredChecks.join(", ") || "none"}`),
+    ...report.repos.map((repo) => `- ${repo.repo} (${repo.branch}) • pack=${repo.policyPack} • checks=${repo.requiredChecks.join(", ") || "none"}${repo.localPath ? ` • local=${repo.localPath} • localRepo=${repo.localRepoDetected ? "yes" : "no"}` : ""}${repo.valid ? "" : " • INVALID"}`),
   ].join("\n") + "\n";
   if (args.jsonOut) writeFile(args.jsonOut, jsonText);
   if (args.markdownOut) writeFile(args.markdownOut, markdown);
@@ -1141,11 +1170,12 @@ function handleSync(args: ParsedArgs, context: FleetContext): void {
       results.push({
         repo: plan.repo,
         drift: plan.drift,
-        action: "planned",
+        action: plan.localPath && !plan.localRepoDetected && !args.openPrs ? "invalid" : "planned",
         branch: plan.branch,
         localPath: plan.localPath,
         prUrl: "",
         filesChanged: plan.files.filter((item) => item.changed).map((item) => item.path),
+        notes: plan.localPath && !plan.localRepoDetected && !args.openPrs ? ["Configured localPath is not a Git repo root."] : [],
       });
       continue;
     }

--- a/templates/fleet/fleet-status.js
+++ b/templates/fleet/fleet-status.js
@@ -1,6 +1,8 @@
 #!/usr/bin/env node
 const fs = require('node:fs');
 const path = require('node:path');
+const SCRIPT_DIR = __dirname;
+const REPO_ROOT = path.resolve(SCRIPT_DIR, '..', '..');
 
 function clean(value) {
   return String(value || '').replace(/\s+/g, ' ').trim();
@@ -57,17 +59,17 @@ function pickLatestReport(reportPaths) {
 
 function parseArgs(argv) {
   const out = {
-    out: path.resolve(process.cwd(), '.codex-stack', 'fleet-status', 'status.json'),
-    markdownOut: path.resolve(process.cwd(), '.codex-stack', 'fleet-status', 'summary.md'),
+    out: path.resolve(REPO_ROOT, '.codex-stack', 'fleet-status', 'status.json'),
+    markdownOut: path.resolve(REPO_ROOT, '.codex-stack', 'fleet-status', 'summary.md'),
     json: false,
   };
   for (let i = 0; i < argv.length; i += 1) {
     const arg = argv[i];
     if (arg === '--out') {
-      out.out = path.resolve(process.cwd(), argv[i + 1] || out.out);
+      out.out = path.resolve(REPO_ROOT, argv[i + 1] || out.out);
       i += 1;
     } else if (arg === '--markdown-out') {
-      out.markdownOut = path.resolve(process.cwd(), argv[i + 1] || out.markdownOut);
+      out.markdownOut = path.resolve(REPO_ROOT, argv[i + 1] || out.markdownOut);
       i += 1;
     } else if (arg === '--json') {
       out.json = true;
@@ -78,11 +80,11 @@ function parseArgs(argv) {
 
 function main() {
   const args = parseArgs(process.argv.slice(2));
-  const memberPath = path.resolve(process.cwd(), '.codex-stack', 'fleet-member.json');
-  const repo = clean(process.env.GITHUB_REPOSITORY || path.basename(process.cwd()));
-  const branch = clean(process.env.GITHUB_REF_NAME || '');
+  const memberPath = path.resolve(REPO_ROOT, '.codex-stack', 'fleet-member.json');
   const member = fs.existsSync(memberPath) ? readJson(memberPath) : null;
-  const latest = pickLatestReport(findJsonFiles(path.resolve(process.cwd(), 'docs', 'qa')));
+  const repo = clean(member && member.repo || process.env.GITHUB_REPOSITORY || path.basename(REPO_ROOT));
+  const branch = clean(process.env.GITHUB_REF_NAME || '');
+  const latest = pickLatestReport(findJsonFiles(path.resolve(REPO_ROOT, 'docs', 'qa')));
   const latestData = latest ? latest.data : null;
 
   const unresolved = asNumber(latestData && latestData.decisionSummary && latestData.decisionSummary.unresolvedCount) || 0;


### PR DESCRIPTION
## Summary
- validate and guard invalid local repo paths before local fleet writes
- treat local fleet installation as files/status actually present instead of desired config
- make the generated fleet-status script repo-root aware and member-repo aware for local runs

## Live Probe
- exercised fleet validate/sync/collect/dashboard against 3 clean local repos
- cleaned the temporary rollout files back out of those repos after probing

## Validation
- bun scripts/fleet.spec.ts
- bun run typecheck
- bun run smoke

Closes #64