### PR TITLE
feat: add real fleet manifest

### DIFF
--- a/.codex-stack/fleet.anup4khandelwal.json
+++ b/.codex-stack/fleet.anup4khandelwal.json
@@ -1,0 +1,27 @@
+{
+  "schemaVersion": 1,
+  "controlRepo": "anup4khandelwal/codex-stack",
+  "policyDir": "policies",
+  "syncBranch": "chore/codex-stack-fleet-sync",
+  "statusArtifactName": "codex-stack-fleet-status",
+  "repos": [
+    {
+      "repo": "anup4khandelwal/autopilot-multi-agent-loop",
+      "branch": "main",
+      "team": "reviewops",
+      "policyPack": "default"
+    },
+    {
+      "repo": "anup4khandelwal/awesome-codex-skills",
+      "branch": "main",
+      "team": "ai-platform",
+      "policyPack": "review-only"
+    },
+    {
+      "repo": "anup4khandelwal/anup4khandelwal",
+      "branch": "main",
+      "team": "profile",
+      "policyPack": "review-only"
+    }
+  ]
+}

--- a/.codex-stack/policies/review-only.json
+++ b/.codex-stack/policies/review-only.json
@@ -1,0 +1,20 @@
+{
+  "name": "review-only",
+  "description": "Minimal codex-stack rollout for repos that only need review gating and fleet health reporting.",
+  "requiredChecks": ["review", "fleet-status"],
+  "qa": {
+    "mode": "diff-aware",
+    "devices": ["desktop"]
+  },
+  "preview": {
+    "paths": [],
+    "devices": []
+  },
+  "decisions": {
+    "staleAfterDays": 30,
+    "expiringSoonDays": 7
+  },
+  "schedule": {
+    "cron": "17 8 * * 1-5"
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ browse/dist/.cache/
 !.codex-stack/baseline-decisions/
 !.codex-stack/baseline-decisions/**
 !.codex-stack/fleet.example.json
+!.codex-stack/fleet.anup4khandelwal.json
 !.codex-stack/policies/
 !.codex-stack/policies/**
 .site/

--- a/README.md
+++ b/README.md
@@ -245,6 +245,14 @@ bun src/cli.ts fleet collect --manifest .codex-stack/fleet.example.json --json
 bun src/cli.ts fleet dashboard --manifest .codex-stack/fleet.example.json --out .fleet-site
 ```
 
+Checked-in real control plane for this workspace:
+
+```bash
+bun src/cli.ts fleet validate --manifest .codex-stack/fleet.anup4khandelwal.json
+bun src/cli.ts fleet sync --manifest .codex-stack/fleet.anup4khandelwal.json --dry-run --json
+bun src/cli.ts fleet sync --manifest .codex-stack/fleet.anup4khandelwal.json --open-prs
+```
+
 The control repo owns:
 
 - a fleet manifest listing managed repos
@@ -259,6 +267,12 @@ The control repo owns:
 - `.github/workflows/codex-stack-fleet-status.yml`
 
 That workflow emits a normalized `codex-stack-fleet-status` artifact so `fleet collect` can aggregate repo health without inventing a new backend.
+
+Current checked-in targets:
+
+- `anup4khandelwal/autopilot-multi-agent-loop` via `default`
+- `anup4khandelwal/awesome-codex-skills` via `review-only`
+- `anup4khandelwal/anup4khandelwal` via `review-only`
 
 ## Browser QA model
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -230,6 +230,8 @@ bun scripts/fleet.ts validate --manifest .codex-stack/fleet.example.json
 bun scripts/fleet.ts sync --manifest .codex-stack/fleet.example.json --dry-run --json
 bun scripts/fleet.ts collect --manifest .codex-stack/fleet.example.json --json
 bun scripts/fleet.ts dashboard --manifest .codex-stack/fleet.example.json --out .fleet-site
+bun scripts/fleet.ts validate --manifest .codex-stack/fleet.anup4khandelwal.json
+bun scripts/fleet.ts sync --manifest .codex-stack/fleet.anup4khandelwal.json --open-prs
 ```
 
 Notes:
@@ -240,6 +242,7 @@ Notes:
 - `fleet collect` reads normalized `codex-stack-fleet-status` outputs and ranks repos by rollout drift plus unresolved QA risk.
 - `fleet dashboard` writes `index.html`, `manifest.json`, and `summary.md` so the control repo can publish an org dashboard with the same data.
 - Start from `.codex-stack/fleet.example.json` and `.codex-stack/policies/default.json` when bootstrapping a new fleet.
+- Use `.codex-stack/fleet.anup4khandelwal.json` for the current checked-in rollout targeting `autopilot-multi-agent-loop`, `awesome-codex-skills`, and the profile repo.
 - The script writes `report.md`, `report.json`, `comment.md`, `screenshots.json`, and a visual review pack under `visual/index.html` and `visual/manifest.json`.
 - Deploy reports now include a single visual-risk score that combines path/device failures, console errors, snapshot drift, and stale baselines.
 

--- a/scripts/fleet.ts
+++ b/scripts/fleet.ts
@@ -993,7 +993,7 @@ function collectRepo(context: FleetContext, target: FleetTarget): CollectedFleet
     drift: plan.drift,
     status: statusReport?.status || computed.status,
     riskScore: statusReport?.riskScore ?? computed.riskScore,
-    requiredChecks: asArray<string>(member?.requiredChecks || []),
+    requiredChecks: asArray<string>(member?.requiredChecks || plan.memberConfig.requiredChecks || []),
     latestReport,
     source: statusReport ? "artifact" : member ? "repo-files" : "missing",
   };


### PR DESCRIPTION
## Summary
- add a checked-in fleet manifest for the current repo set under .codex-stack/fleet.anup4khandelwal.json
- add a review-only policy pack for low-complexity repos
- document the real control-plane commands and fix required-check fallback in fleet collect

## Validation
- bun src/cli.ts fleet validate --manifest .codex-stack/fleet.anup4khandelwal.json --json
- bun src/cli.ts fleet sync --manifest .codex-stack/fleet.anup4khandelwal.json --dry-run --json
- bun src/cli.ts fleet collect --manifest .codex-stack/fleet.anup4khandelwal.json --json
- bun scripts/fleet.spec.ts
- bun run typecheck
- bun run smoke

Closes #66