### PR TITLE
fix: make fleet health policy-aware

### DIFF
--- a/.codex-stack/fleet.anup4khandelwal.json
+++ b/.codex-stack/fleet.anup4khandelwal.json
@@ -9,7 +9,7 @@
       "repo": "anup4khandelwal/autopilot-multi-agent-loop",
       "branch": "main",
       "team": "reviewops",
-      "policyPack": "default"
+      "policyPack": "review-only"
     },
     {
       "repo": "anup4khandelwal/awesome-codex-skills",

--- a/.codex-stack/policies/default.json
+++ b/.codex-stack/policies/default.json
@@ -20,6 +20,9 @@
     "staleAfterDays": 14,
     "expiringSoonDays": 7
   },
+  "status": {
+    "requiresLatestReport": true
+  },
   "schedule": {
     "cron": "17 8 * * 1-5"
   }

--- a/.codex-stack/policies/review-only.json
+++ b/.codex-stack/policies/review-only.json
@@ -14,6 +14,9 @@
     "staleAfterDays": 30,
     "expiringSoonDays": 7
   },
+  "status": {
+    "requiresLatestReport": false
+  },
   "schedule": {
     "cron": "17 8 * * 1-5"
   }

--- a/README.md
+++ b/README.md
@@ -268,6 +268,8 @@ The control repo owns:
 
 That workflow emits a normalized `codex-stack-fleet-status` artifact so `fleet collect` can aggregate repo health without inventing a new backend.
 
+Policy packs also define whether a repo is expected to publish a codex-stack QA/deploy report. `review-only` repos are considered healthy when they are installed and in sync even if they do not publish `docs/qa/` artifacts. Full rollout packs can still require a latest report before fleet health turns green.
+
 Current checked-in targets:
 
 - `anup4khandelwal/autopilot-multi-agent-loop` via `default`

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -240,6 +240,7 @@ Notes:
 - `fleet sync` generates a compiled member config, a self-contained fleet-status script, and a status workflow for each managed repo.
 - Use `localPath` entries in the manifest for local testing. Use `--open-prs` to clone target repos, push a rollout branch, and open or update PRs remotely.
 - `fleet collect` reads normalized `codex-stack-fleet-status` outputs and ranks repos by rollout drift plus unresolved QA risk.
+- Policy packs define whether a repo must publish a latest codex-stack QA/deploy report. Review-only repos can still be healthy without `docs/qa/` artifacts when rollout drift is zero.
 - `fleet dashboard` writes `index.html`, `manifest.json`, and `summary.md` so the control repo can publish an org dashboard with the same data.
 - Start from `.codex-stack/fleet.example.json` and `.codex-stack/policies/default.json` when bootstrapping a new fleet.
 - Use `.codex-stack/fleet.anup4khandelwal.json` for the current checked-in rollout targeting `autopilot-multi-agent-loop`, `awesome-codex-skills`, and the profile repo.

--- a/scripts/fleet.spec.ts
+++ b/scripts/fleet.spec.ts
@@ -52,6 +52,9 @@ fs.writeFileSync(path.join(policyDir, "default.json"), JSON.stringify({
     staleAfterDays: 14,
     expiringSoonDays: 7,
   },
+  status: {
+    requiresLatestReport: true,
+  },
   schedule: {
     cron: "0 9 * * 1-5",
   },
@@ -167,11 +170,13 @@ const memberConfig = JSON.parse(fs.readFileSync(path.join(repoDir, ".codex-stack
   team?: string;
   previewUrlTemplate?: string;
   requiredChecks?: string[];
+  status?: { requiresLatestReport?: boolean };
 };
 assert.equal(memberConfig.controlRepo, "acme/control-plane");
 assert.equal(memberConfig.team, "platform");
 assert.equal(memberConfig.previewUrlTemplate, "https://preview-{pr}.example.com");
 assert.deepEqual(memberConfig.requiredChecks, ["fleet-status", "preview", "qa", "review"]);
+assert.equal(memberConfig.status?.requiresLatestReport, true);
 
 const statusOut = path.join(repoDir, ".codex-stack", "fleet-status", "status.json");
 const statusJson = run([path.join(repoDir, ".github", "codex-stack", "fleet-status.js"), "--out", statusOut, "--json"], fixtureRoot);
@@ -220,6 +225,69 @@ assert.equal(collectReport.repos?.[0]?.source, "local-status");
 assert.equal(collectReport.repos?.[0]?.status, "critical");
 assert.equal(collectReport.repos?.[0]?.riskScore, 91);
 assert.equal(collectReport.repos?.[0]?.repoUrl, "https://github.com/acme/repo-a");
+
+const reviewOnlyFixtureRoot = fs.mkdtempSync(path.join(os.tmpdir(), "codex-stack-fleet-review-only-"));
+const reviewOnlyControlDir = path.join(reviewOnlyFixtureRoot, "control");
+const reviewOnlyRepoDir = path.join(reviewOnlyFixtureRoot, "repo-b");
+const reviewOnlyManifestPath = path.join(reviewOnlyControlDir, "fleet.json");
+const reviewOnlyPolicyDir = path.join(reviewOnlyControlDir, "policies");
+fs.mkdirSync(reviewOnlyPolicyDir, { recursive: true });
+execFileSync("git", ["init", "-q", "-b", "main", reviewOnlyRepoDir]);
+fs.writeFileSync(path.join(reviewOnlyPolicyDir, "review-only.json"), JSON.stringify({
+  name: "review-only",
+  requiredChecks: ["review", "fleet-status"],
+  qa: {
+    mode: "diff-aware",
+    devices: ["desktop"],
+  },
+  preview: {
+    paths: [],
+    devices: [],
+  },
+  status: {
+    requiresLatestReport: false,
+  },
+}, null, 2));
+fs.writeFileSync(reviewOnlyManifestPath, JSON.stringify({
+  schemaVersion: 1,
+  controlRepo: "acme/control-plane",
+  policyDir: "./policies",
+  repos: [
+    {
+      repo: "acme/repo-b",
+      branch: "main",
+      localPath: "../repo-b",
+      team: "docs",
+      policyPack: "review-only",
+    },
+  ],
+}, null, 2));
+
+run([fleetScript, "sync", "--manifest", reviewOnlyManifestPath, "--json"], reviewOnlyFixtureRoot);
+const reviewOnlyStatusOut = path.join(reviewOnlyRepoDir, ".codex-stack", "fleet-status", "status.json");
+const reviewOnlyStatusJson = run([path.join(reviewOnlyRepoDir, ".github", "codex-stack", "fleet-status.js"), "--out", reviewOnlyStatusOut, "--json"], reviewOnlyFixtureRoot);
+const reviewOnlyStatus = JSON.parse(reviewOnlyStatusJson) as {
+  status?: string;
+  riskScore?: number;
+  requiresLatestReport?: boolean;
+  latestReport?: unknown;
+};
+assert.equal(reviewOnlyStatus.requiresLatestReport, false);
+assert.equal(reviewOnlyStatus.status, "healthy");
+assert.equal(reviewOnlyStatus.riskScore, 0);
+assert.equal(reviewOnlyStatus.latestReport, null);
+
+const reviewOnlyCollect = JSON.parse(run([fleetScript, "collect", "--manifest", reviewOnlyManifestPath, "--json"], reviewOnlyFixtureRoot)) as {
+  counts?: { healthy?: number; warning?: number; drifted?: number };
+  repos?: Array<{ repo?: string; status?: string; drift?: string; riskScore?: number }>;
+};
+assert.equal(reviewOnlyCollect.counts?.healthy, 1);
+assert.equal(reviewOnlyCollect.counts?.warning, 0);
+assert.equal(reviewOnlyCollect.counts?.drifted, 0);
+assert.equal(reviewOnlyCollect.repos?.[0]?.repo, "acme/repo-b");
+assert.equal(reviewOnlyCollect.repos?.[0]?.status, "healthy");
+assert.equal(reviewOnlyCollect.repos?.[0]?.drift, "healthy");
+assert.equal(reviewOnlyCollect.repos?.[0]?.riskScore, 0);
 
 run([fleetScript, "dashboard", "--manifest", manifestPath, "--out", dashboardDir], fixtureRoot);
 assert.ok(fs.existsSync(path.join(dashboardDir, "index.html")));
@@ -290,5 +358,6 @@ assert.equal(remoteDrift.drift, "healthy");
 assert.deepEqual(remoteDrift.files.filter((item) => item.changed), []);
 
 fs.rmSync(fixtureRoot, { recursive: true, force: true });
+fs.rmSync(reviewOnlyFixtureRoot, { recursive: true, force: true });
 fs.rmSync(remoteFixtureRoot, { recursive: true, force: true });
 console.log("fleet spec passed");

--- a/scripts/fleet.ts
+++ b/scripts/fleet.ts
@@ -99,6 +99,9 @@ interface FleetPolicyPack {
   qa?: FleetQaConfig;
   preview?: FleetPreviewConfig;
   decisions?: FleetDecisionConfig;
+  status?: {
+    requiresLatestReport?: boolean;
+  };
   schedule?: {
     cron?: string;
   };
@@ -131,6 +134,9 @@ interface FleetMemberConfig {
   qa: FleetQaConfig;
   preview: FleetPreviewConfig;
   decisions: FleetDecisionConfig;
+  status: {
+    requiresLatestReport: boolean;
+  };
   schedule: {
     cron: string;
   };
@@ -184,6 +190,7 @@ interface FleetStatusReport {
   team?: string;
   policyPack?: string;
   requiredChecks?: string[];
+  requiresLatestReport?: boolean;
   status?: RepoHealth;
   riskScore?: number;
   latestReport?: {
@@ -495,6 +502,9 @@ function loadPolicyPack(context: FleetContext, name: string): FleetPolicyPack {
     qa: normalizeQaConfig(raw.qa),
     preview: normalizePreviewConfig(raw.preview),
     decisions: normalizeDecisionConfig(raw.decisions),
+    status: {
+      requiresLatestReport: raw.status?.requiresLatestReport !== false,
+    },
     schedule: {
       cron: clean(raw.schedule?.cron || "") || "17 8 * * 1-5",
     },
@@ -565,6 +575,9 @@ function compileMemberConfig(context: FleetContext, target: FleetTarget): FleetM
     qa,
     preview,
     decisions,
+    status: {
+      requiresLatestReport: policyPack.status?.requiresLatestReport !== false,
+    },
     schedule: {
       cron: clean(policyPack.schedule?.cron || "") || "17 8 * * 1-5",
     },
@@ -898,7 +911,7 @@ function readLocalFleetStatus(repoRoot: string): FleetStatusReport | null {
   }
 }
 
-function computeCollectedStatus(installed: boolean, drift: DriftState, latestReport: FleetStatusReport["latestReport"]): { status: RepoHealth; riskScore: number } {
+function computeCollectedStatus(installed: boolean, drift: DriftState, latestReport: FleetStatusReport["latestReport"], requiresLatestReport: boolean): { status: RepoHealth; riskScore: number } {
   if (!installed) {
     return { status: "missing", riskScore: 85 };
   }
@@ -906,7 +919,7 @@ function computeCollectedStatus(installed: boolean, drift: DriftState, latestRep
   if (drift === "diverged") riskScore += 45;
   if (drift === "missing") riskScore += 35;
   if (drift === "outdated") riskScore += 20;
-  if (!latestReport) riskScore += 15;
+  if (!latestReport && requiresLatestReport) riskScore += 15;
   if (latestReport?.status === "critical") riskScore += 40;
   if (latestReport?.status === "warning") riskScore += 20;
   riskScore += Math.min(24, Number(latestReport?.unresolvedRegressions || 0) * 8);
@@ -920,7 +933,7 @@ function computeCollectedStatus(installed: boolean, drift: DriftState, latestRep
   if (latestReport?.status === "critical" || drift === "diverged") {
     return { status: "critical", riskScore };
   }
-  if (latestReport?.status === "warning" || drift === "outdated" || drift === "missing" || Number(latestReport?.unresolvedRegressions || 0) > 0 || Number(latestReport?.expiredDecisions || 0) > 0) {
+  if (latestReport?.status === "warning" || drift === "outdated" || drift === "missing" || Number(latestReport?.unresolvedRegressions || 0) > 0 || Number(latestReport?.expiredDecisions || 0) > 0 || (!latestReport && requiresLatestReport)) {
     return { status: "warning", riskScore };
   }
   return { status: "healthy", riskScore };
@@ -971,7 +984,8 @@ function collectRepo(context: FleetContext, target: FleetTarget): CollectedFleet
     const localStatus = readLocalFleetStatus(plan.localPath);
     const latestReport = localStatus?.latestReport || latestQaReportFromRepoRoot(plan.localPath);
     const installed = Boolean(member || localStatus);
-    const computed = computeCollectedStatus(installed, plan.drift, latestReport);
+    const requiresLatestReport = localStatus?.requiresLatestReport ?? member?.status?.requiresLatestReport ?? true;
+    const computed = computeCollectedStatus(installed, plan.drift, latestReport, requiresLatestReport);
     const status = localStatus?.status || computed.status;
     const riskScore = localStatus?.riskScore ?? computed.riskScore;
     return {
@@ -993,7 +1007,8 @@ function collectRepo(context: FleetContext, target: FleetTarget): CollectedFleet
   const member = readRemoteMemberConfig(plan.repo, plan.branch) || (plan.drift === "healthy" ? plan.memberConfig : null);
   const statusReport = member ? downloadLatestArtifactStatus(plan.repo, plan.branch, member.statusArtifactName || context.statusArtifactName) : null;
   const latestReport = statusReport?.latestReport || null;
-  const computed = computeCollectedStatus(Boolean(member), plan.drift, latestReport);
+  const requiresLatestReport = statusReport?.requiresLatestReport ?? member?.status?.requiresLatestReport ?? true;
+  const computed = computeCollectedStatus(Boolean(member), plan.drift, latestReport, requiresLatestReport);
   return {
     repo: plan.repo,
     repoUrl: repoUrl(plan.repo),

--- a/templates/fleet/fleet-status.js
+++ b/templates/fleet/fleet-status.js
@@ -86,6 +86,7 @@ function main() {
   const branch = clean(process.env.GITHUB_REF_NAME || '');
   const latest = pickLatestReport(findJsonFiles(path.resolve(REPO_ROOT, 'docs', 'qa')));
   const latestData = latest ? latest.data : null;
+  const requiresLatestReport = member ? member.status?.requiresLatestReport !== false : true;
 
   const unresolved = asNumber(latestData && latestData.decisionSummary && latestData.decisionSummary.unresolvedCount) || 0;
   const expired = asNumber(latestData && latestData.decisionSummary && latestData.decisionSummary.expiredCount) || 0;
@@ -98,7 +99,7 @@ function main() {
   let status = 'healthy';
   if (!member) {
     status = 'missing';
-  } else if (!latestData) {
+  } else if (!latestData && requiresLatestReport) {
     status = 'warning';
   } else if (baseStatus === 'critical') {
     status = 'critical';
@@ -108,7 +109,7 @@ function main() {
 
   let riskScore = 0;
   if (!member) riskScore += 80;
-  if (!latestData) riskScore += 20;
+  if (!latestData && requiresLatestReport) riskScore += 20;
   if (baseStatus === 'critical') riskScore += 40;
   if (baseStatus === 'warning') riskScore += 20;
   riskScore += Math.min(24, unresolved * 8);
@@ -129,6 +130,7 @@ function main() {
     team: clean(member && member.team || ''),
     policyPack: clean(member && member.policyPack || ''),
     requiredChecks: Array.isArray(member && member.requiredChecks) ? member.requiredChecks : [],
+    requiresLatestReport,
     status,
     riskScore,
     latestReport: latestData ? {
@@ -158,7 +160,7 @@ function main() {
     `- Risk score: ${payload.riskScore}/100`,
     payload.team ? `- Team: ${payload.team}` : '',
     payload.policyPack ? `- Policy pack: ${payload.policyPack}` : '',
-    payload.latestReport ? `- Latest QA status: ${payload.latestReport.status}` : '- Latest QA status: missing',
+    payload.latestReport ? `- Latest QA status: ${payload.latestReport.status}` : `- Latest QA status: ${requiresLatestReport ? 'missing' : 'not required'}`,
     payload.latestReport && payload.latestReport.visualRiskScore !== null ? `- Visual risk: ${payload.latestReport.visualRiskLevel || 'none'} (${payload.latestReport.visualRiskScore}/100)` : '',
     payload.latestReport ? `- Unresolved regressions: ${payload.latestReport.unresolvedRegressions}` : '',
     payload.latestReport && payload.latestReport.accessibilityViolations !== null ? `- Accessibility violations: ${payload.latestReport.accessibilityViolations}` : '',


### PR DESCRIPTION
Closes #70

## Summary
- make fleet status honor policy-level report expectations
- allow review-only repos to become healthy without codex-stack QA artifacts
- move autopilot-multi-agent-loop onto the current review-only rollout scope

## Validation
- bun scripts/fleet.spec.ts
- bun run typecheck
- bun run smoke