### PR TITLE
feat: refresh release-readiness demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Because the command contracts are shared, those agents stay aligned on the same 
 
 ## Demo the sample app
 
-The repo includes a small demo app at `examples/customer-portal-demo/` so you can show a full workflow without a backend.
+The repo includes a release-readiness demo app at `examples/customer-portal-demo/`. It is built for technical evaluators who need to see whether `codex-stack` can support a real merge decision, not just automate a toy page.
 
 Start it:
 
@@ -124,20 +124,23 @@ Start it:
 bun run demo:start
 ```
 
-Then run a realistic sequence:
+Then run the core live sequence:
 
 ```bash
-bun src/cli.ts browse run-flow http://127.0.0.1:4173/login portal-full-demo --session friend-demo
-bun src/cli.ts browse snapshot http://127.0.0.1:4173/dashboard portal-dashboard --session friend-demo
-bun src/cli.ts qa http://127.0.0.1:4173/dashboard --flow portal-dashboard --snapshot portal-dashboard --session friend-demo
-bun src/cli.ts deploy --url http://127.0.0.1:4173 --path /dashboard --device desktop --flow portal-dashboard --snapshot portal-dashboard --publish-dir docs/qa/demo/deploy
-bun src/cli.ts ship --dry-run --pr --verify-url http://127.0.0.1:4173 --verify-path /dashboard --verify-device desktop --verify-flow portal-dashboard --verify-snapshot portal-dashboard
-bun src/cli.ts retro --since "30 days ago" --no-github
-bun run weekly
-bun run qa:site
+bun src/cli.ts browse run-flow http://127.0.0.1:4173/login release-full-demo --session friend-demo
+bun src/cli.ts browse snapshot http://127.0.0.1:4173/dashboard release-dashboard --session friend-demo
+bun src/cli.ts qa http://127.0.0.1:4173/dashboard --flow release-dashboard --snapshot release-dashboard --session friend-demo
+bun src/cli.ts deploy --url http://127.0.0.1:4173 --path /dashboard --path /changes --device desktop --device mobile --flow release-dashboard --flow release-changes --snapshot release-dashboard --publish-dir docs/qa/demo/deploy
+bun src/cli.ts ship --dry-run --pr --verify-url http://127.0.0.1:4173 --verify-path /dashboard --verify-path /changes --verify-device desktop --verify-device mobile --verify-flow release-dashboard --verify-flow release-changes --verify-snapshot release-dashboard
 ```
 
-The checked-in `portal-login` flow clears the demo app's stored login state before navigation so you can re-run it safely on the same named browser session.
+What that sequence demonstrates:
+- authenticated browser automation
+- QA evidence tied to release confidence
+- page and device verification against a believable change-impact surface
+- shipping decisions backed by the same evidence
+
+The checked-in `release-login` flow clears the demo app's stored login state before navigation so you can re-run it safely on the same named browser session.
 
 ## Issue to merge flow
 
@@ -172,21 +175,21 @@ Branch naming matters: when the branch follows `<prefix>/<issue-number>-slug`, `
 bun src/cli.ts list
 bun src/cli.ts show qa
 bun src/cli.ts review --json --base origin/main
-bun src/cli.ts qa http://127.0.0.1:4173/dashboard --flow portal-dashboard --snapshot portal-dashboard --session demo --json
-bun src/cli.ts qa http://127.0.0.1:4173/dashboard --flow portal-dashboard --snapshot portal-dashboard --a11y --a11y-scope main --perf --perf-budget lcp=2s --perf-budget cls=0.1 --session demo --json
+bun src/cli.ts qa http://127.0.0.1:4173/dashboard --flow release-dashboard --snapshot release-dashboard --session demo --json
+bun src/cli.ts qa http://127.0.0.1:4173/dashboard --flow release-dashboard --snapshot release-dashboard --a11y --a11y-scope main --perf --perf-budget lcp=2s --perf-budget cls=0.1 --session demo --json
 bun src/cli.ts qa https://preview.example.com --mode diff-aware --base-ref origin/main --session preview --json
-bun src/cli.ts qa https://preview.example.com/dashboard --flow portal-dashboard --session preview-auth --session-bundle .codex-stack/private/preview-auth.json --json
-bun src/cli.ts qa-decide approve --snapshot portal-dashboard --route /dashboard --device desktop --kind snapshot-drift --reason "Intentional redesign approved in PR #123"
+bun src/cli.ts qa https://preview.example.com/dashboard --flow release-dashboard --session preview-auth --session-bundle .codex-stack/private/preview-auth.json --json
+bun src/cli.ts qa-decide approve --snapshot release-dashboard --route /dashboard --device desktop --kind snapshot-drift --reason "Intentional redesign approved in PR #123"
 bun src/cli.ts qa-decide suppress --category accessibility --kind accessibility-rule --route /checkout --device desktop --rule color-contrast --reason "Vendor widget pending upstream fix" --expires-at 2026-03-29T00:00:00Z
-bun src/cli.ts preview --url "https://anup4khandelwal.github.io/codex-stack/pr-preview/pr-42/" --pr 42 --branch feat/42-preview --sha abcdef123 --path /login --path /dashboard --device desktop --device mobile --flow portal-full-demo
+bun src/cli.ts preview --url "https://anup4khandelwal.github.io/codex-stack/pr-preview/pr-42/" --pr 42 --branch feat/42-preview --sha abcdef123 --path /login --path /dashboard --device desktop --device mobile --flow release-full-demo
 bun src/cli.ts preview --url-template "https://preview-{pr}.example.com" --pr 42 --branch feat/42-preview --sha abcdef123 --path / --path /dashboard --device desktop --device mobile --flow landing-smoke --snapshot landing-home
-bun src/cli.ts preview --url "https://anup4khandelwal.github.io/codex-stack/pr-preview/pr-42/" --pr 42 --branch feat/42-preview --sha abcdef123 --path /dashboard --device desktop --flow portal-dashboard --session preview-auth --session-bundle .codex-stack/private/preview-auth.json
-bun src/cli.ts deploy --url https://staging.example.com --path / --path /dashboard --device desktop --device mobile --flow portal-dashboard --snapshot portal-dashboard
-bun src/cli.ts deploy --url https://staging.example.com --path /dashboard --device desktop --flow portal-dashboard --snapshot portal-dashboard --a11y --a11y-scope main --perf --perf-budget lcp=2s --perf-budget cls=0.1
-bun src/cli.ts deploy --url https://staging.example.com --path /dashboard --device desktop --flow portal-dashboard --session staging-auth --session-bundle .codex-stack/private/staging-auth.json
+bun src/cli.ts preview --url "https://anup4khandelwal.github.io/codex-stack/pr-preview/pr-42/" --pr 42 --branch feat/42-preview --sha abcdef123 --path /dashboard --device desktop --flow release-dashboard --session preview-auth --session-bundle .codex-stack/private/preview-auth.json
+bun src/cli.ts deploy --url https://staging.example.com --path / --path /dashboard --path /changes --device desktop --device mobile --flow release-dashboard --flow release-changes --snapshot release-dashboard
+bun src/cli.ts deploy --url https://staging.example.com --path /dashboard --device desktop --flow release-dashboard --snapshot release-dashboard --a11y --a11y-scope main --perf --perf-budget lcp=2s --perf-budget cls=0.1
+bun src/cli.ts deploy --url https://staging.example.com --path /dashboard --device desktop --flow release-dashboard --session staging-auth --session-bundle .codex-stack/private/staging-auth.json
 bun src/cli.ts ship --message "feat: ready for review" --push --pr --reviewer octocat --assignee @me --project "Engineering Roadmap"
-bun src/cli.ts ship --dry-run --pr --verify-url http://127.0.0.1:4173 --verify-path /dashboard --verify-device mobile --verify-console-errors --verify-flow portal-dashboard --verify-snapshot portal-dashboard
-bun src/cli.ts ship --dry-run --pr --verify-url http://127.0.0.1:4173 --verify-path /dashboard --verify-device mobile --verify-flow portal-dashboard --verify-snapshot portal-dashboard --verify-a11y --verify-a11y-scope main --verify-perf --verify-perf-budget lcp=2s
+bun src/cli.ts ship --dry-run --pr --verify-url http://127.0.0.1:4173 --verify-path /dashboard --verify-path /changes --verify-device mobile --verify-console-errors --verify-flow release-dashboard --verify-flow release-changes --verify-snapshot release-dashboard
+bun src/cli.ts ship --dry-run --pr --verify-url http://127.0.0.1:4173 --verify-path /dashboard --verify-path /changes --verify-device mobile --verify-flow release-dashboard --verify-flow release-changes --verify-snapshot release-dashboard --verify-a11y --verify-a11y-scope main --verify-perf --verify-perf-budget lcp=2s
 bun src/cli.ts fleet validate --manifest .codex-stack/fleet.example.json
 bun src/cli.ts fleet sync --manifest .codex-stack/fleet.example.json --dry-run --json
 bun src/cli.ts fleet collect --manifest .codex-stack/fleet.example.json --json
@@ -223,10 +226,10 @@ bun run smoke
 bun run demo:start
 bun run demo:smoke
 bun run review
-bun run qa -- http://127.0.0.1:4173/dashboard --flow portal-dashboard --snapshot portal-dashboard --session demo
+bun run qa -- http://127.0.0.1:4173/dashboard --flow release-dashboard --snapshot release-dashboard --session demo
 bun src/cli.ts qa-decide list --active-only
 bun run preview -- --url-template "https://preview-{pr}.example.com" --pr 42 --branch feat/42-preview --sha abcdef123 --path / --device desktop --flow landing-smoke --snapshot landing-home
-bun run deploy -- --url https://staging.example.com --path /dashboard --device desktop --flow portal-dashboard --snapshot portal-dashboard
+bun run deploy -- --url https://staging.example.com --path /dashboard --device desktop --flow release-dashboard --snapshot release-dashboard
 bun run ship:dry
 bun run retro
 bun run upgrade
@@ -332,7 +335,7 @@ bun src/cli.ts preview \
   --path /dashboard \
   --device desktop \
   --device mobile \
-  --flow portal-full-demo \
+  --flow release-full-demo \
   --a11y \
   --a11y-scope main \
   --perf \
@@ -353,7 +356,7 @@ bun src/cli.ts preview \
   --sha abcdef1234567890 \
   --path /dashboard \
   --device desktop \
-  --flow portal-dashboard \
+  --flow release-dashboard \
   --session preview-auth \
   --session-bundle .codex-stack/private/preview-auth.json
 ```
@@ -433,7 +436,7 @@ The same `gh-pages` branch also hosts PR previews under `pr-preview/pr-<number>/
 
 - `CODEX_STACK_PREVIEW_PATHS=/login,/dashboard`
 - `CODEX_STACK_PREVIEW_DEVICES=desktop,mobile`
-- `CODEX_STACK_PREVIEW_FLOW=portal-full-demo`
+- `CODEX_STACK_PREVIEW_FLOW=release-full-demo`
 - `CODEX_STACK_PREVIEW_SNAPSHOT=<optional snapshot name>`
 - `CODEX_STACK_PREVIEW_WAIT_TIMEOUT=300`
 

--- a/browse/flows/portal-dashboard.json
+++ b/browse/flows/portal-dashboard.json
@@ -1,20 +1,6 @@
 [
   {
-    "action": "assert-visible",
-    "selector": "h1"
-  },
-  {
-    "action": "assert-text",
-    "selector": "h1",
-    "value": "Daily portfolio health"
-  },
-  {
-    "action": "assert-count",
-    "selector": "[data-qa=metric-card]",
-    "count": 4
-  },
-  {
-    "action": "assert-visible",
-    "selector": "[data-signout]"
+    "action": "use-flow",
+    "name": "release-dashboard"
   }
 ]

--- a/browse/flows/portal-full-demo.json
+++ b/browse/flows/portal-full-demo.json
@@ -1,10 +1,6 @@
 [
   {
     "action": "use-flow",
-    "name": "portal-login"
-  },
-  {
-    "action": "use-flow",
-    "name": "portal-dashboard"
+    "name": "release-full-demo"
   }
 ]

--- a/browse/flows/portal-login.json
+++ b/browse/flows/portal-login.json
@@ -1,34 +1,6 @@
 [
   {
-    "action": "clear-storage",
-    "scope": "local",
-    "key": "codexStackDemoSession"
-  },
-  {
-    "action": "fill",
-    "selector": "input[name=email]",
-    "value": "ops-demo@acme.dev"
-  },
-  {
-    "action": "fill",
-    "selector": "input[name=password]",
-    "value": "demo-password"
-  },
-  {
-    "action": "click",
-    "selector": "button[type=submit]"
-  },
-  {
-    "action": "wait",
-    "loadState": "load"
-  },
-  {
-    "action": "assert-url",
-    "value": "/dashboard"
-  },
-  {
-    "action": "assert-text",
-    "selector": "[data-user-email]",
-    "value": "ops-demo@acme.dev"
+    "action": "use-flow",
+    "name": "release-login"
   }
 ]

--- a/browse/flows/release-changes.json
+++ b/browse/flows/release-changes.json
@@ -1,0 +1,21 @@
+[
+  {
+    "action": "assert-visible",
+    "selector": "h1"
+  },
+  {
+    "action": "assert-text",
+    "selector": "h1",
+    "value": "Change impact and preview evidence"
+  },
+  {
+    "action": "assert-count",
+    "selector": "[data-qa=impact-row]",
+    "count": 3
+  },
+  {
+    "action": "assert-count",
+    "selector": "[data-qa=device-card]",
+    "count": 3
+  }
+]

--- a/browse/flows/release-dashboard.json
+++ b/browse/flows/release-dashboard.json
@@ -1,0 +1,25 @@
+[
+  {
+    "action": "assert-visible",
+    "selector": "h1"
+  },
+  {
+    "action": "assert-text",
+    "selector": "h1",
+    "value": "Release readiness dashboard"
+  },
+  {
+    "action": "assert-text",
+    "selector": "[data-merge-status]",
+    "value": "Hold merge"
+  },
+  {
+    "action": "assert-count",
+    "selector": "[data-qa=gate-card]",
+    "count": 4
+  },
+  {
+    "action": "assert-visible",
+    "selector": "[data-open-evidence]"
+  }
+]

--- a/browse/flows/release-full-demo.json
+++ b/browse/flows/release-full-demo.json
@@ -1,0 +1,26 @@
+[
+  {
+    "action": "use-flow",
+    "name": "release-login"
+  },
+  {
+    "action": "use-flow",
+    "name": "release-dashboard"
+  },
+  {
+    "action": "click",
+    "selector": "[data-open-evidence]"
+  },
+  {
+    "action": "wait",
+    "loadState": "load"
+  },
+  {
+    "action": "assert-url",
+    "value": "/changes"
+  },
+  {
+    "action": "use-flow",
+    "name": "release-changes"
+  }
+]

--- a/browse/flows/release-login.json
+++ b/browse/flows/release-login.json
@@ -1,0 +1,34 @@
+[
+  {
+    "action": "clear-storage",
+    "scope": "local",
+    "key": "codexStackDemoSession"
+  },
+  {
+    "action": "fill",
+    "selector": "input[name=email]",
+    "value": "release-owner@acme.dev"
+  },
+  {
+    "action": "fill",
+    "selector": "input[name=password]",
+    "value": "demo-password"
+  },
+  {
+    "action": "click",
+    "selector": "button[type=submit]"
+  },
+  {
+    "action": "wait",
+    "loadState": "load"
+  },
+  {
+    "action": "assert-url",
+    "value": "/dashboard"
+  },
+  {
+    "action": "assert-text",
+    "selector": "[data-user-email]",
+    "value": "release-owner@acme.dev"
+  }
+]

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -10,22 +10,22 @@ bun src/cli.ts issue start --title "Add PR workflow" --label automation --prefix
 bun src/cli.ts issue branch 42 --title "Add PR workflow" --prefix feat
 bun src/cli.ts review
 bun src/cli.ts review --json
-bun src/cli.ts qa http://127.0.0.1:4173/dashboard --flow portal-dashboard --snapshot portal-dashboard --session demo --json
-bun src/cli.ts qa http://127.0.0.1:4173/dashboard --flow portal-dashboard --snapshot portal-dashboard --a11y --a11y-scope main --perf --perf-budget lcp=2s --perf-budget cls=0.1 --session demo --json
+bun src/cli.ts qa http://127.0.0.1:4173/dashboard --flow release-dashboard --snapshot release-dashboard --session demo --json
+bun src/cli.ts qa http://127.0.0.1:4173/dashboard --flow release-dashboard --snapshot release-dashboard --a11y --a11y-scope main --perf --perf-budget lcp=2s --perf-budget cls=0.1 --session demo --json
 bun src/cli.ts qa https://preview.example.com --mode diff-aware --base-ref origin/main --session preview --json
-bun src/cli.ts qa-decide approve --snapshot portal-dashboard --route /dashboard --device desktop --kind snapshot-drift --reason "Intentional redesign approved in PR #123"
+bun src/cli.ts qa-decide approve --snapshot release-dashboard --route /dashboard --device desktop --kind snapshot-drift --reason "Intentional redesign approved in PR #123"
 bun src/cli.ts qa-decide suppress --category accessibility --kind accessibility-rule --route /checkout --device desktop --rule color-contrast --reason "Vendor widget pending upstream fix" --expires-at 2026-03-29T00:00:00Z
 bun src/cli.ts qa-decide list --active-only
 bun src/cli.ts qa-decide prune-expired
 bun src/cli.ts preview --url-template "https://preview-{pr}.example.com" --pr 42 --branch feat/42-preview --sha abcdef1234567890 --path / --path /dashboard --device desktop --device mobile --flow landing-smoke --snapshot landing-home
 bun src/cli.ts preview --url-template "https://preview-{pr}.example.com" --pr 42 --branch feat/42-preview --sha abcdef1234567890 --path /dashboard --device desktop --flow landing-smoke --snapshot landing-home --a11y --a11y-scope main --perf --perf-budget lcp=2s
-bun src/cli.ts deploy --url https://staging.example.com --path / --path /dashboard --device desktop --device mobile --flow portal-dashboard --snapshot portal-dashboard
-bun src/cli.ts deploy --url https://staging.example.com --path /dashboard --device desktop --flow portal-dashboard --snapshot portal-dashboard --a11y --a11y-scope main --perf --perf-budget lcp=2s --perf-budget cls=0.1
+bun src/cli.ts deploy --url https://staging.example.com --path / --path /dashboard --path /changes --device desktop --device mobile --flow release-dashboard --flow release-changes --snapshot release-dashboard
+bun src/cli.ts deploy --url https://staging.example.com --path /dashboard --device desktop --flow release-dashboard --snapshot release-dashboard --a11y --a11y-scope main --perf --perf-budget lcp=2s --perf-budget cls=0.1
 bun src/cli.ts ship --dry-run
 bun src/cli.ts ship --message "feat: ready for review" --push --pr --template .github/pull_request_template.md
 bun src/cli.ts ship --message "feat: ready for review" --push --pr --reviewer octocat --team-reviewer acme/platform --assignee @me --project "Engineering Roadmap" --label release-candidate
-bun src/cli.ts ship --dry-run --pr --verify-url http://127.0.0.1:4173 --verify-path /dashboard --verify-device mobile --verify-console-errors --verify-flow portal-dashboard --verify-snapshot portal-dashboard
-bun src/cli.ts ship --dry-run --pr --verify-url http://127.0.0.1:4173 --verify-path /dashboard --verify-device mobile --verify-flow portal-dashboard --verify-snapshot portal-dashboard --verify-a11y --verify-a11y-scope main --verify-perf --verify-perf-budget lcp=2s
+bun src/cli.ts ship --dry-run --pr --verify-url http://127.0.0.1:4173 --verify-path /dashboard --verify-path /changes --verify-device mobile --verify-console-errors --verify-flow release-dashboard --verify-flow release-changes --verify-snapshot release-dashboard
+bun src/cli.ts ship --dry-run --pr --verify-url http://127.0.0.1:4173 --verify-path /dashboard --verify-path /changes --verify-device mobile --verify-flow release-dashboard --verify-flow release-changes --verify-snapshot release-dashboard --verify-a11y --verify-a11y-scope main --verify-perf --verify-perf-budget lcp=2s
 bun src/cli.ts fleet validate --manifest .codex-stack/fleet.example.json
 bun src/cli.ts fleet sync --manifest .codex-stack/fleet.example.json --dry-run --json
 bun src/cli.ts fleet collect --manifest .codex-stack/fleet.example.json --json
@@ -62,7 +62,7 @@ bun src/cli.ts browse save-flow login-local '[{"action":"fill","selector":"input
 bun src/cli.ts browse save-repo-flow landing-smoke '[{"action":"assert-visible","selector":"main"}]'
 bun src/cli.ts browse import-flow login-local ./docs/login-flow.md
 bun src/cli.ts browse import-repo-flow landing-smoke ./docs/landing-smoke.yaml
-bun src/cli.ts browse export-flow portal-full-demo ./docs/portal-full-demo.md
+bun src/cli.ts browse export-flow release-full-demo ./docs/release-full-demo.md
 bun src/cli.ts browse snapshot https://example.com marketing-home --session staging
 bun src/cli.ts browse compare-snapshot https://example.com marketing-home --session staging
 bun src/cli.ts browse login https://example.com/login login-local --session staging
@@ -80,7 +80,7 @@ bun src/cli.ts browse assert-editable https://example.com "textarea" --session s
 bun src/cli.ts browse assert-focused https://example.com "input[name=email]" --session staging
 bun src/cli.ts browse assert-text https://example.com "h1" "Example Domain" --session staging
 bun src/cli.ts browse assert-count https://example.com "a" 1 --session staging
-bun src/cli.ts browse run-flow http://127.0.0.1:4173/login portal-full-demo --session friend-demo
+bun src/cli.ts browse run-flow http://127.0.0.1:4173/login release-full-demo --session friend-demo
 bun src/cli.ts browse sessions
 bun src/cli.ts browse clear-session staging
 bun src/cli.ts browse screenshot https://example.com /tmp/example.png
@@ -119,8 +119,8 @@ bun scripts/ship-branch.ts --message "feat: ready for review" --push
 bun scripts/ship-branch.ts --message "feat: ready for review" --push --pr
 bun scripts/ship-branch.ts --message "feat: ready for review" --push --pr --template .github/pull_request_template.md
 bun scripts/ship-branch.ts --message "feat: ready for review" --push --pr --reviewer octocat --team-reviewer acme/platform --assignee @me --project "Engineering Roadmap" --label release-candidate
-bun scripts/ship-branch.ts --dry-run --pr --verify-url http://127.0.0.1:4173 --verify-path /dashboard --verify-device mobile --verify-console-errors --verify-flow portal-dashboard --verify-snapshot portal-dashboard
-bun scripts/ship-branch.ts --dry-run --pr --verify-url http://127.0.0.1:4173 --verify-path /dashboard --verify-device mobile --verify-flow portal-dashboard --verify-snapshot portal-dashboard --verify-a11y --verify-a11y-scope main --verify-perf --verify-perf-budget lcp=2s
+bun scripts/ship-branch.ts --dry-run --pr --verify-url http://127.0.0.1:4173 --verify-path /dashboard --verify-path /changes --verify-device mobile --verify-console-errors --verify-flow release-dashboard --verify-flow release-changes --verify-snapshot release-dashboard
+bun scripts/ship-branch.ts --dry-run --pr --verify-url http://127.0.0.1:4173 --verify-path /dashboard --verify-path /changes --verify-device mobile --verify-flow release-dashboard --verify-flow release-changes --verify-snapshot release-dashboard --verify-a11y --verify-a11y-scope main --verify-perf --verify-perf-budget lcp=2s
 bun scripts/ship-branch.ts --message "feat: ready for review" --push --pr --draft
 ```
 
@@ -143,11 +143,11 @@ Notes:
 ## QA workflow
 
 ```bash
-bun scripts/qa-run.ts http://127.0.0.1:4173/dashboard --flow portal-dashboard --snapshot portal-dashboard --session demo --json
-bun scripts/qa-run.ts http://127.0.0.1:4173/dashboard --flow portal-dashboard --snapshot portal-dashboard --a11y --a11y-scope main --perf --perf-budget lcp=2s --perf-budget cls=0.1 --json
-bun scripts/qa-run.ts http://127.0.0.1:4173/login --flow portal-full-demo --snapshot portal-login --session demo
+bun scripts/qa-run.ts http://127.0.0.1:4173/dashboard --flow release-dashboard --snapshot release-dashboard --session demo --json
+bun scripts/qa-run.ts http://127.0.0.1:4173/dashboard --flow release-dashboard --snapshot release-dashboard --a11y --a11y-scope main --perf --perf-budget lcp=2s --perf-budget cls=0.1 --json
+bun scripts/qa-run.ts http://127.0.0.1:4173/login --flow release-full-demo --snapshot release-login --session demo
 bun scripts/qa-run.ts https://preview.example.com --mode diff-aware --base-ref origin/main --session preview --json
-bun scripts/qa-decide.ts approve --snapshot portal-dashboard --route /dashboard --device desktop --kind snapshot-drift --reason "Intentional redesign approved in PR #123"
+bun scripts/qa-decide.ts approve --snapshot release-dashboard --route /dashboard --device desktop --kind snapshot-drift --reason "Intentional redesign approved in PR #123"
 bun scripts/qa-decide.ts suppress --category accessibility --kind accessibility-rule --route /checkout --device desktop --rule color-contrast --reason "Vendor widget pending upstream fix" --expires-at 2026-03-29T00:00:00Z
 bun scripts/qa-decide.ts list --active-only
 bun scripts/qa-decide.ts prune-expired
@@ -187,10 +187,10 @@ Notes:
 ## Preview workflow
 
 ```bash
-bun scripts/preview-verify.ts --url "https://anup4khandelwal.github.io/codex-stack/pr-preview/pr-42/" --repo anup4khandelwal/codex-stack --pr 42 --branch feat/42-preview --sha abcdef1234567890 --path /login --path /dashboard --device desktop --device mobile --flow portal-full-demo --markdown-out preview.md --json-out preview.json --comment-out preview-comment.md
+bun scripts/preview-verify.ts --url "https://anup4khandelwal.github.io/codex-stack/pr-preview/pr-42/" --repo anup4khandelwal/codex-stack --pr 42 --branch feat/42-preview --sha abcdef1234567890 --path /login --path /dashboard --device desktop --device mobile --flow release-full-demo --markdown-out preview.md --json-out preview.json --comment-out preview-comment.md
 bun scripts/preview-verify.ts --url-template "https://preview-{pr}.example.com" --repo anup4khandelwal/codex-stack --pr 42 --branch feat/42-preview --sha abcdef1234567890 --path / --path /dashboard --device desktop --device mobile --flow landing-smoke --snapshot landing-home --markdown-out preview.md --json-out preview.json --comment-out preview-comment.md
 bun scripts/preview-verify.ts --url-template "https://preview-{pr}.example.com" --repo anup4khandelwal/codex-stack --pr 42 --branch feat/42-preview --sha abcdef1234567890 --path /dashboard --device desktop --flow landing-smoke --snapshot landing-home --a11y --a11y-scope main --perf --perf-budget lcp=2s --markdown-out preview.md --json-out preview.json --comment-out preview-comment.md
-bun scripts/preview-verify.ts --url "https://anup4khandelwal.github.io/codex-stack/pr-preview/pr-42/" --repo anup4khandelwal/codex-stack --pr 42 --branch feat/42-preview --sha abcdef1234567890 --path /dashboard --device desktop --flow portal-dashboard --session preview-auth --session-bundle .codex-stack/private/preview-auth.json --markdown-out preview.md --json-out preview.json --comment-out preview-comment.md
+bun scripts/preview-verify.ts --url "https://anup4khandelwal.github.io/codex-stack/pr-preview/pr-42/" --repo anup4khandelwal/codex-stack --pr 42 --branch feat/42-preview --sha abcdef1234567890 --path /dashboard --device desktop --flow release-dashboard --session preview-auth --session-bundle .codex-stack/private/preview-auth.json --markdown-out preview.md --json-out preview.json --comment-out preview-comment.md
 bun scripts/preview-verify.ts --url https://preview.example.com --path /dashboard --device desktop --flow landing-smoke --snapshot landing-home --json
 ```
 
@@ -210,9 +210,9 @@ Notes:
 ## Deploy workflow
 
 ```bash
-bun scripts/deploy-verify.ts --url https://staging.example.com --path / --path /dashboard --device desktop --device mobile --flow portal-dashboard --snapshot portal-dashboard --markdown-out deploy.md --json-out deploy.json --comment-out deploy-comment.md
-bun scripts/deploy-verify.ts --url https://staging.example.com --path /dashboard --device desktop --flow portal-dashboard --snapshot portal-dashboard --a11y --a11y-scope main --perf --perf-budget lcp=2s --perf-budget cls=0.1 --markdown-out deploy.md --json-out deploy.json --comment-out deploy-comment.md
-bun scripts/deploy-verify.ts --url https://staging.example.com --path /dashboard --device desktop --flow portal-dashboard --session staging-auth --session-bundle .codex-stack/private/staging-auth.json --json
+bun scripts/deploy-verify.ts --url https://staging.example.com --path / --path /dashboard --path /changes --device desktop --device mobile --flow release-dashboard --flow release-changes --snapshot release-dashboard --markdown-out deploy.md --json-out deploy.json --comment-out deploy-comment.md
+bun scripts/deploy-verify.ts --url https://staging.example.com --path /dashboard --device desktop --flow release-dashboard --snapshot release-dashboard --a11y --a11y-scope main --perf --perf-budget lcp=2s --perf-budget cls=0.1 --markdown-out deploy.md --json-out deploy.json --comment-out deploy-comment.md
+bun scripts/deploy-verify.ts --url https://staging.example.com --path /dashboard --device desktop --flow release-dashboard --session staging-auth --session-bundle .codex-stack/private/staging-auth.json --json
 bun scripts/deploy-verify.ts --url-template "https://preview-{pr}.example.com" --repo anup4khandelwal/codex-stack --pr 42 --branch feat/42-preview --sha abcdef1234567890 --path /dashboard --device mobile --strict-console --strict-http --json
 ```
 
@@ -299,7 +299,7 @@ bun browse/src/cli.ts flows
 bun browse/src/cli.ts save-flow smoke-login '[{"action":"fill","selector":"input[name=email]","value":"demo@example.com"},{"action":"fill","selector":"input[name=password]","value":"demo-pass"},{"action":"click","selector":"button[type=submit]"},{"action":"wait","selector":"text=Dashboard"}]'
 bun browse/src/cli.ts save-repo-flow landing-smoke '[{"action":"assert-visible","selector":"body"}]'
 bun browse/src/cli.ts import-flow smoke-login ./docs/smoke-login.yaml
-bun browse/src/cli.ts export-flow portal-full-demo ./docs/portal-full-demo.md
+bun browse/src/cli.ts export-flow release-full-demo ./docs/release-full-demo.md
 bun browse/src/cli.ts export-session ./tmp/staging-session.json --session staging
 bun browse/src/cli.ts import-session ./tmp/staging-session.json --session staging-copy
 bun browse/src/cli.ts import-browser-cookies chrome --session staging --profile Default
@@ -332,7 +332,7 @@ Notes:
 - Flow steps also support `{ "action": "route", ... }` and `{ "action": "clear-routes" }` so network controls can be armed before navigation.
 - Use `download` to save a file to disk and `assert-download` when the filename fragment itself is part of the assertion.
 - Flow steps also support `{ "action": "download", ... }` and `{ "action": "assert-download", ... }` for checked-in export flows.
-- Use `{"action":"use-flow","name":"portal-login"}` inside a checked-in flow to compose a larger QA sequence.
+- Use `{"action":"use-flow","name":"release-login"}` inside a checked-in flow to compose a larger QA sequence.
 - Flow import/export supports `.json`, `.yaml` / `.yml`, and Markdown files with fenced JSON or YAML blocks.
 - Leading `{"action":"clear-storage"}` steps run before navigation, which is useful for repeatable login flows on persistent sessions.
 - Snapshots are stored under `.codex-stack/browse/snapshots/`; comparison artifacts are stored under `.codex-stack/browse/artifacts/`.

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -34,7 +34,7 @@ Use codex-stack-qa to verify the staging dashboard flow, compare it to the saved
 CLI:
 
 ```bash
-bun src/cli.ts qa http://127.0.0.1:4173/dashboard --flow portal-dashboard --snapshot portal-dashboard --session demo --json
+bun src/cli.ts qa http://127.0.0.1:4173/dashboard --flow release-dashboard --snapshot release-dashboard --session demo --json
 bun src/cli.ts qa https://preview.example.com --mode diff-aware --base-ref origin/main --session preview --json
 ```
 
@@ -59,7 +59,7 @@ Use codex-stack-deploy to verify the staging deploy across key pages and devices
 CLI:
 
 ```bash
-bun src/cli.ts deploy --url https://staging.example.com --path / --path /dashboard --device desktop --device mobile --flow portal-dashboard --snapshot portal-dashboard
+bun src/cli.ts deploy --url https://staging.example.com --path / --path /dashboard --path /changes --device desktop --device mobile --flow release-dashboard --flow release-changes --snapshot release-dashboard
 ```
 
 ## Ship mode
@@ -76,7 +76,7 @@ bun src/cli.ts ship --dry-run
 bun src/cli.ts ship --message "feat: ready for review" --push --pr
 bun src/cli.ts ship --message "feat: ready for review" --push --pr --template .github/pull_request_template.md
 bun src/cli.ts ship --message "feat: ready for review" --push --pr --reviewer octocat --assignee @me --project "Engineering Roadmap" --label release-candidate
-bun src/cli.ts ship --dry-run --pr --verify-url http://127.0.0.1:4173 --verify-path /dashboard --verify-device desktop --verify-console-errors --verify-flow portal-dashboard --verify-snapshot portal-dashboard
+bun src/cli.ts ship --dry-run --pr --verify-url http://127.0.0.1:4173 --verify-path /dashboard --verify-path /changes --verify-device desktop --verify-device mobile --verify-console-errors --verify-flow release-dashboard --verify-flow release-changes --verify-snapshot release-dashboard
 ```
 
 ## Browse mode
@@ -84,8 +84,8 @@ bun src/cli.ts ship --dry-run --pr --verify-url http://127.0.0.1:4173 --verify-p
 ```bash
 bun run demo:start
 bun src/cli.ts browse flows
-bun src/cli.ts browse export-flow portal-full-demo /tmp/portal-full-demo.md
-bun src/cli.ts browse import-flow portal-copy /tmp/portal-full-demo.md
+bun src/cli.ts browse export-flow release-full-demo /tmp/release-full-demo.md
+bun src/cli.ts browse import-flow portal-copy /tmp/release-full-demo.md
 bun src/cli.ts browse export-session /tmp/portal-session.json --session friend-demo
 bun src/cli.ts browse import-session /tmp/portal-session.json --session friend-demo-copy
 bun src/cli.ts browse import-browser-cookies chrome --session friend-demo --profile Default
@@ -100,12 +100,13 @@ bun src/cli.ts browse click http://127.0.0.1:4173/checkout "role:button:Pay now"
 bun src/cli.ts browse mock http://127.0.0.1:4173/dashboard "**/api/profile" '{"status":503,"json":{"error":"offline"}}' --session friend-demo
 bun src/cli.ts browse download http://127.0.0.1:4173/reports "role:button:Export CSV" ./artifacts/report.csv --session friend-demo
 bun src/cli.ts browse assert-focused http://127.0.0.1:4173/login "input[name=email]" --session friend-demo
-bun src/cli.ts browse snapshot http://127.0.0.1:4173/dashboard portal-dashboard --session friend-demo
-bun src/cli.ts browse compare-snapshot http://127.0.0.1:4173/dashboard portal-dashboard --session friend-demo
-bun src/cli.ts browse run-flow http://127.0.0.1:4173/login portal-login --session friend-demo
-bun src/cli.ts browse run-flow http://127.0.0.1:4173/dashboard portal-dashboard --session friend-demo
-bun src/cli.ts browse run-flow http://127.0.0.1:4173/login portal-full-demo --session friend-demo
-bun src/cli.ts browse screenshot http://127.0.0.1:4173/dashboard /tmp/customer-portal-demo.png --session friend-demo
+bun src/cli.ts browse snapshot http://127.0.0.1:4173/dashboard release-dashboard --session friend-demo
+bun src/cli.ts browse compare-snapshot http://127.0.0.1:4173/dashboard release-dashboard --session friend-demo
+bun src/cli.ts browse run-flow http://127.0.0.1:4173/login release-login --session friend-demo
+bun src/cli.ts browse run-flow http://127.0.0.1:4173/dashboard release-dashboard --session friend-demo
+bun src/cli.ts browse run-flow http://127.0.0.1:4173/changes release-changes --session friend-demo
+bun src/cli.ts browse run-flow http://127.0.0.1:4173/login release-full-demo --session friend-demo
+bun src/cli.ts browse screenshot http://127.0.0.1:4173/changes /tmp/release-readiness-demo.png --session friend-demo
 ```
 
 ## Authenticated preview verification
@@ -120,7 +121,7 @@ bun src/cli.ts preview \
   --sha abcdef1234567890 \
   --path /dashboard \
   --device desktop \
-  --flow portal-dashboard \
+  --flow release-dashboard \
   --session preview-auth \
   --session-bundle .codex-stack/private/preview-auth.json
 ```

--- a/examples/customer-portal-demo/README.md
+++ b/examples/customer-portal-demo/README.md
@@ -1,6 +1,12 @@
-# Customer Portal Demo
+# Release Readiness Demo
 
-This sample app exists to demo `codex-stack` to another engineer without needing a real backend.
+This sample app exists to help a technical evaluator understand why `codex-stack` is useful.
+
+It is not a toy landing page. It is a small release-readiness workspace that lets you demonstrate:
+- authenticated browser automation
+- release-readiness QA with stable assertions
+- preview and deploy verification against believable routes
+- ship decisions backed by evidence instead of vague prompts
 
 ## Start the app
 
@@ -14,31 +20,83 @@ Default URL:
 http://127.0.0.1:4173
 ```
 
-## Best live demo flow
+## 5-minute guided demo
 
-1. Start the app.
-2. Open the landing page in a browser.
-3. Run the checked-in QA flow.
-4. Show a `ship --dry-run --pr` preview.
-5. Show `retro` on recent repo history.
+### 1. Show the release candidate context
+Open the landing page and explain the setup:
+- one release candidate
+- one authenticated operator flow
+- one dashboard that says whether merge is safe
+- one change-impact page that explains where preview verification should focus
 
-## Browser demo commands
+### 2. Run the authenticated browser flow
 
 ```bash
-bun src/cli.ts browse flows
-bun src/cli.ts browse run-flow http://127.0.0.1:4173/login portal-login --session friend-demo
-bun src/cli.ts browse run-flow http://127.0.0.1:4173/dashboard portal-dashboard --session friend-demo
-bun src/cli.ts browse run-flow http://127.0.0.1:4173/login portal-full-demo --session friend-demo
-bun scripts/build-preview-site.ts --out .preview-site
+bun src/cli.ts browse run-flow http://127.0.0.1:4173/login release-full-demo --session evaluator-demo
 ```
 
-The preview-site builder turns the demo into a GitHub Pages-safe site with `/login/` and `/dashboard/` subpaths so PR previews can be hosted under `pr-preview/pr-<number>/`.
+What this proves:
+- the package can drive a real browser flow
+- session state persists across steps
+- the demo is stable enough for repeated live runs
+
+### 3. Show QA and snapshot evidence
+
+```bash
+bun src/cli.ts browse snapshot http://127.0.0.1:4173/dashboard release-dashboard --session evaluator-demo
+bun src/cli.ts qa http://127.0.0.1:4173/dashboard --flow release-dashboard --snapshot release-dashboard --session evaluator-demo --json
+```
+
+What this proves:
+- QA is not just “page looks okay”
+- the tool produces a health score, findings, and evidence
+- visual and route-level checks are part of the same decision
+
+### 4. Show deploy-style verification
+
+```bash
+bun src/cli.ts deploy --url http://127.0.0.1:4173 --path /dashboard --path /changes --device desktop --device mobile --flow release-dashboard --flow release-changes --snapshot release-dashboard --publish-dir docs/qa/demo/deploy
+```
+
+What this proves:
+- the package can verify multiple pages and devices
+- the app is designed to show a realistic merge blocker on mobile
+- the generated evidence can be published and reviewed
+
+### 5. Show the ship decision
+
+```bash
+bun src/cli.ts ship --dry-run --pr --verify-url http://127.0.0.1:4173 --verify-path /dashboard --verify-path /changes --verify-device desktop --verify-device mobile --verify-flow release-dashboard --verify-flow release-changes --verify-snapshot release-dashboard
+```
+
+What this proves:
+- shipping is connected to evidence, not just git automation
+- the same demo story flows from browse -> qa -> deploy -> ship
+
+## Best pages to talk through
+
+- `/`
+  - use this to frame the value proposition in 30 seconds
+- `/dashboard`
+  - use this to explain merge recommendation, blocking findings, and release confidence
+- `/changes`
+  - use this to explain route/device risk and why preview verification matters
 
 ## Recommended login
 
 ```text
-email: ops-demo@acme.dev
+email: release-owner@acme.dev
 password: demo-password
 ```
 
-Any non-empty values will work.
+Any non-empty values work. The recommended account simply gives the session a release-manager role label.
+
+## Compatibility note
+
+The repo still keeps the older `portal-*` flow names as wrappers so existing docs, fixtures, and workflows do not break immediately.
+
+For new demos, use:
+- `release-login`
+- `release-dashboard`
+- `release-changes`
+- `release-full-demo`

--- a/examples/customer-portal-demo/public/app.css
+++ b/examples/customer-portal-demo/public/app.css
@@ -7,7 +7,8 @@
   --accent: #0d9488;
   --accent-strong: #0f766e;
   --warn: #c2410c;
-  --sand: #e8dcc4;
+  --warn-soft: rgba(194, 65, 12, 0.12);
+  --good-soft: rgba(13, 148, 136, 0.12);
   --shadow: 0 18px 45px rgba(29, 42, 47, 0.1);
 }
 
@@ -26,26 +27,27 @@ body {
     linear-gradient(180deg, #faf5ea 0%, var(--bg) 100%);
 }
 
-body.portal-shell {
+body.release-shell {
   display: flex;
   justify-content: center;
 }
 
-body.portal-auth,
-body.portal-dashboard {
+body.release-auth,
+body.release-dashboard {
   padding: 32px;
 }
 
 .page {
-  width: min(1120px, calc(100% - 40px));
+  width: min(1140px, calc(100% - 40px));
   margin: 0 auto;
 }
 
-.topbar {
+.topbar,
+.dashboard-header {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   justify-content: space-between;
-  gap: 16px;
+  gap: 18px;
   padding: 24px 0 18px;
 }
 
@@ -58,13 +60,13 @@ body.portal-dashboard {
 }
 
 .brand-mark {
-  width: 42px;
-  height: 42px;
+  width: 44px;
+  height: 44px;
   display: grid;
   place-items: center;
   border-radius: 14px;
   background: linear-gradient(145deg, var(--accent), #14b8a6);
-  color: white;
+  color: #fff;
   font-size: 20px;
   box-shadow: var(--shadow);
 }
@@ -74,44 +76,79 @@ body.portal-dashboard {
   font-size: 18px;
 }
 
-.brand-copy span {
-  display: block;
+.brand-copy span,
+.label,
+.nav-links,
+.kicker,
+.inline-meta,
+.stack-card p,
+.stack-card li,
+.form-help,
+.notice,
+.metric-card span,
+.side-card .label,
+.button,
+button,
+label span,
+input,
+a {
+  font-family: "Trebuchet MS", sans-serif;
+}
+
+.brand-copy span,
+.metric-card span,
+.side-card .label,
+.inline-meta,
+.label {
   color: var(--muted);
   font-size: 13px;
-  font-family: "Trebuchet MS", sans-serif;
 }
 
 .nav-links {
   display: flex;
+  flex-wrap: wrap;
   gap: 16px;
-  font-family: "Trebuchet MS", sans-serif;
 }
 
 .nav-links a {
   color: var(--ink);
   text-decoration: none;
-  font-weight: 600;
+  font-weight: 700;
+}
+
+.hero,
+.section-grid,
+.auth-shell,
+.impact-grid {
+  display: grid;
+  grid-template-columns: 1.2fr 0.8fr;
+  gap: 24px;
 }
 
 .hero {
-  display: grid;
-  grid-template-columns: 1.2fr 0.8fr;
-  gap: 28px;
   padding: 40px 0 24px;
 }
 
-.panel {
-  background: rgba(255, 250, 240, 0.88);
+.panel,
+.metric-card {
+  background: rgba(255, 250, 240, 0.9);
   border: 1px solid var(--line);
   border-radius: 28px;
   box-shadow: var(--shadow);
 }
 
-.hero-copy {
-  padding: 40px;
+.hero-copy,
+.side-card,
+.stack-card,
+.auth-panel,
+.auth-form,
+.metric-card,
+.status-strip {
+  padding: 30px;
 }
 
-.eyebrow {
+.eyebrow,
+.kicker {
   display: inline-flex;
   gap: 8px;
   align-items: center;
@@ -119,7 +156,6 @@ body.portal-dashboard {
   border-radius: 999px;
   background: rgba(13, 148, 136, 0.12);
   color: var(--accent-strong);
-  font-family: "Trebuchet MS", sans-serif;
   font-size: 12px;
   letter-spacing: 0.08em;
   text-transform: uppercase;
@@ -133,23 +169,28 @@ h3 {
 }
 
 .hero-copy h1 {
-  font-size: clamp(42px, 6vw, 68px);
   margin-top: 20px;
+  font-size: clamp(42px, 6vw, 68px);
 }
 
 .lede {
-  margin-top: 20px;
-  max-width: 56ch;
+  margin-top: 18px;
+  max-width: 58ch;
   font-size: 19px;
   line-height: 1.7;
   color: #364349;
 }
 
-.actions {
+.actions,
+.header-actions {
   display: flex;
   flex-wrap: wrap;
-  gap: 14px;
-  margin-top: 30px;
+  gap: 12px;
+  margin-top: 28px;
+}
+
+.header-actions {
+  margin-top: 0;
 }
 
 .button,
@@ -158,7 +199,6 @@ button {
   border-radius: 999px;
   padding: 14px 20px;
   font: inherit;
-  font-family: "Trebuchet MS", sans-serif;
   font-weight: 700;
   cursor: pointer;
   transition: transform 120ms ease, box-shadow 120ms ease;
@@ -186,7 +226,6 @@ button.secondary {
 }
 
 .side-card {
-  padding: 32px;
   display: grid;
   gap: 18px;
   align-content: center;
@@ -197,15 +236,10 @@ button.secondary {
   padding-top: 18px;
 }
 
-.side-card .value {
-  font-size: 32px;
-  font-weight: 700;
-}
-
-.side-card .label {
-  color: var(--muted);
-  font-family: "Trebuchet MS", sans-serif;
-  font-size: 13px;
+.side-card .value,
+.metric-card strong {
+  display: block;
+  font-size: 30px;
 }
 
 .metrics-grid {
@@ -215,54 +249,63 @@ button.secondary {
   margin: 18px 0 26px;
 }
 
-.metric-card {
-  padding: 22px;
-  border-radius: 24px;
-  background: rgba(255, 250, 240, 0.9);
-  border: 1px solid var(--line);
-  box-shadow: var(--shadow);
-}
-
 .metric-card strong {
-  display: block;
-  font-size: 28px;
-  margin-top: 12px;
+  margin-top: 10px;
 }
 
-.metric-card span {
-  color: var(--muted);
-  font-family: "Trebuchet MS", sans-serif;
+.metric-card p {
+  margin: 12px 0 0;
+  color: #425158;
+  font-size: 14px;
+  line-height: 1.5;
 }
 
-.section-grid {
+.status-strip {
   display: grid;
-  grid-template-columns: 1.2fr 0.8fr;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
   gap: 18px;
-  margin-bottom: 28px;
+  margin-bottom: 22px;
+}
+
+.status-strip strong {
+  display: block;
+  margin-top: 8px;
+  font-size: 20px;
 }
 
 .stack-card {
-  padding: 28px;
+  margin-bottom: 24px;
 }
 
 .stack-card p,
 .stack-card li,
 .form-help,
-.meta-row {
+.notice,
+label span,
+input {
   color: #425158;
-  font-family: "Trebuchet MS", sans-serif;
   line-height: 1.6;
 }
 
-ul.task-list {
-  list-style: none;
+.task-list,
+.numbered-list {
   padding: 0;
-  margin: 22px 0 0;
+  margin: 20px 0 0;
   display: grid;
   gap: 14px;
 }
 
-.task-list li {
+.task-list {
+  list-style: none;
+}
+
+.numbered-list {
+  list-style: decimal;
+  padding-left: 22px;
+}
+
+.task-list li,
+.numbered-list li {
   display: flex;
   justify-content: space-between;
   gap: 16px;
@@ -270,42 +313,30 @@ ul.task-list {
   border-bottom: 1px solid var(--line);
 }
 
+.compact-list li {
+  align-items: flex-start;
+}
+
 .badge {
+  flex-shrink: 0;
   border-radius: 999px;
   padding: 5px 10px;
   font-size: 12px;
-  font-family: "Trebuchet MS", sans-serif;
 }
 
 .badge.good {
-  background: rgba(13, 148, 136, 0.12);
+  background: var(--good-soft);
   color: var(--accent-strong);
 }
 
 .badge.warn {
-  background: rgba(194, 65, 12, 0.12);
+  background: var(--warn-soft);
   color: var(--warn);
 }
 
 .auth-shell {
-  display: grid;
-  grid-template-columns: 1fr 0.95fr;
-  gap: 24px;
   min-height: calc(100vh - 64px);
   align-items: center;
-}
-
-.auth-panel,
-.auth-form {
-  padding: 34px;
-}
-
-.kicker {
-  color: var(--accent-strong);
-  font-family: "Trebuchet MS", sans-serif;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  font-size: 12px;
 }
 
 .auth-form form {
@@ -317,7 +348,6 @@ ul.task-list {
 label span {
   display: block;
   margin-bottom: 8px;
-  font-family: "Trebuchet MS", sans-serif;
   font-size: 14px;
 }
 
@@ -326,45 +356,47 @@ input {
   padding: 14px 16px;
   border-radius: 18px;
   border: 1px solid var(--line);
-  background: rgba(255,255,255,0.92);
+  background: rgba(255, 255, 255, 0.92);
   font: inherit;
 }
 
 .notice {
-  margin-top: 12px;
+  margin-top: 14px;
   padding: 12px 14px;
   border-radius: 16px;
   background: rgba(13, 148, 136, 0.1);
   color: var(--accent-strong);
-  font-family: "Trebuchet MS", sans-serif;
-}
-
-.dashboard-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: flex-start;
-  gap: 16px;
-  padding: 8px 0 24px;
-}
-
-.dashboard-meta {
-  color: var(--muted);
-  font-family: "Trebuchet MS", sans-serif;
 }
 
 .inline-meta {
   display: flex;
-  gap: 10px;
   flex-wrap: wrap;
-  font-family: "Trebuchet MS", sans-serif;
-  font-size: 13px;
-  color: var(--muted);
+  gap: 10px;
+  margin-top: 12px;
 }
 
-@media (max-width: 920px) {
+.gates-grid {
+  margin-top: 0;
+}
+
+.impact-summary {
+  margin-bottom: 22px;
+}
+
+code {
+  font-family: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+  font-size: 0.92em;
+  background: rgba(29, 42, 47, 0.08);
+  padding: 0.15em 0.35em;
+  border-radius: 6px;
+}
+
+@media (max-width: 980px) {
   .hero,
   .section-grid,
-  .auth-shell {
+  .auth-shell,
+  .impact-grid,
+  .status-strip {
     grid-template-columns: 1fr;
   }
 
@@ -374,21 +406,23 @@ input {
 }
 
 @media (max-width: 640px) {
-  body.portal-auth,
-  body.portal-dashboard {
+  body.release-auth,
+  body.release-dashboard {
     padding: 18px;
   }
 
   .page {
-    width: min(100%, calc(100% - 16px));
+    width: min(100%, calc(100% - 12px));
   }
 
-  .topbar {
+  .topbar,
+  .dashboard-header {
     flex-direction: column;
     align-items: flex-start;
   }
 
-  .metrics-grid {
+  .metrics-grid,
+  .status-strip {
     grid-template-columns: 1fr;
   }
 
@@ -396,7 +430,15 @@ input {
   .side-card,
   .stack-card,
   .auth-panel,
-  .auth-form {
+  .auth-form,
+  .metric-card,
+  .status-strip {
     padding: 24px;
+  }
+
+  .task-list li,
+  .numbered-list li {
+    flex-direction: column;
+    align-items: flex-start;
   }
 }

--- a/examples/customer-portal-demo/public/changes.html
+++ b/examples/customer-portal-demo/public/changes.html
@@ -1,0 +1,75 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Change Impact and Preview Evidence</title>
+    <link rel="stylesheet" href="/app.css" />
+    <script src="/app.js" defer></script>
+  </head>
+  <body class="release-dashboard" data-page="changes">
+    <div class="page">
+      <header class="dashboard-header">
+        <div>
+          <div class="kicker">Preview verification</div>
+          <h1>Change impact and preview evidence</h1>
+          <div class="inline-meta">
+            <span>User: <strong data-user-email>loading</strong></span>
+            <span>Role: <strong data-user-role>loading</strong></span>
+            <span>Session started: <strong data-signed-in-at>loading</strong></span>
+          </div>
+        </div>
+        <div class="header-actions">
+          <a class="button secondary" href="/dashboard">Back to dashboard</a>
+          <button class="secondary" type="button" data-signout>Sign out</button>
+        </div>
+      </header>
+
+      <section class="panel stack-card impact-summary">
+        <h2>What changed in this release candidate</h2>
+        <p>
+          The candidate updates the onboarding trial-plan selection flow. That makes it a good demo target because it creates copy changes,
+          layout changes, and a device-sensitive area for preview verification.
+        </p>
+      </section>
+
+      <section class="section-grid impact-grid">
+        <article class="panel stack-card">
+          <h2>Changed surfaces</h2>
+          <ul class="task-list compact-list">
+            <li data-qa="impact-row"><span>`/dashboard` merge recommendation copy and summary badges</span><span class="badge good">Desktop stable</span></li>
+            <li data-qa="impact-row"><span>`/changes` mobile CTA stack and evidence summary layout</span><span class="badge warn">Needs fix</span></li>
+            <li data-qa="impact-row"><span>`/login` release-operator copy and auth helper text</span><span class="badge good">Low risk</span></li>
+          </ul>
+        </article>
+
+        <article class="panel stack-card">
+          <h2>Device matrix</h2>
+          <ul class="task-list compact-list">
+            <li data-qa="device-card"><span>Desktop</span><span class="badge good">Pass</span></li>
+            <li data-qa="device-card"><span>Tablet</span><span class="badge good">Pass</span></li>
+            <li data-qa="device-card"><span>Mobile</span><span class="badge warn">CTA wraps</span></li>
+          </ul>
+        </article>
+      </section>
+
+      <section class="section-grid">
+        <article class="panel stack-card">
+          <h2>Known exceptions</h2>
+          <ul class="task-list compact-list">
+            <li><span>Approved: headline copy drift on dashboard after PM review.</span><span class="badge good">Approved</span></li>
+            <li><span>Unresolved: stale mobile baseline for `/changes` preview pack.</span><span class="badge warn">Refresh required</span></li>
+          </ul>
+        </article>
+
+        <article class="panel stack-card">
+          <h2>How to talk through it live</h2>
+          <p>
+            This page gives the evaluator a believable bridge between raw screenshots and a merge decision. It shows which route changed,
+            which device failed, and why `codex-stack` should block or downgrade confidence.
+          </p>
+        </article>
+      </section>
+    </div>
+  </body>
+</html>

--- a/examples/customer-portal-demo/public/dashboard.html
+++ b/examples/customer-portal-demo/public/dashboard.html
@@ -3,61 +3,88 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Operations Dashboard</title>
+    <title>Release Readiness Dashboard</title>
     <link rel="stylesheet" href="/app.css" />
     <script src="/app.js" defer></script>
   </head>
-  <body class="portal-dashboard" data-page="dashboard">
+  <body class="release-dashboard" data-page="dashboard">
     <div class="page">
       <header class="dashboard-header">
         <div>
-          <div class="kicker">Customer operations</div>
-          <h1>Daily portfolio health</h1>
+          <div class="kicker">PR release readiness</div>
+          <h1>Release readiness dashboard</h1>
           <div class="inline-meta">
             <span>User: <strong data-user-email>loading</strong></span>
             <span>Role: <strong data-user-role>loading</strong></span>
             <span>Session started: <strong data-signed-in-at>loading</strong></span>
           </div>
         </div>
-        <button class="secondary" type="button" data-signout>Sign out</button>
+        <div class="header-actions">
+          <a class="button secondary" href="/changes" data-open-evidence>Open change impact</a>
+          <button class="secondary" type="button" data-signout>Sign out</button>
+        </div>
       </header>
 
-      <section class="metrics-grid">
-        <article class="metric-card" data-qa="metric-card">
-          <span>Open escalations</span>
-          <strong>8</strong>
+      <section class="status-strip panel">
+        <div>
+          <span class="label">Candidate</span>
+          <strong>feat/77-release-readiness-copy</strong>
+        </div>
+        <div>
+          <span class="label">Merge recommendation</span>
+          <strong data-merge-status>Hold merge</strong>
+        </div>
+        <div>
+          <span class="label">Target window</span>
+          <strong>Today, 17:00 UTC</strong>
+        </div>
+        <div>
+          <span class="label">Owner</span>
+          <strong>Growth onboarding</strong>
+        </div>
+      </section>
+
+      <section class="metrics-grid gates-grid">
+        <article class="metric-card gate-card" data-qa="gate-card">
+          <span>Structural review</span>
+          <strong>Pass</strong>
+          <p>No critical trust-boundary issues detected.</p>
         </article>
-        <article class="metric-card" data-qa="metric-card">
-          <span>Healthy renewals</span>
-          <strong>91%</strong>
+        <article class="metric-card gate-card" data-qa="gate-card">
+          <span>Preview verification</span>
+          <strong>Warning</strong>
+          <p>Mobile layout clipped in the trial-plan card.</p>
         </article>
-        <article class="metric-card" data-qa="metric-card">
-          <span>Playbooks automated</span>
-          <strong>34</strong>
+        <article class="metric-card gate-card" data-qa="gate-card">
+          <span>QA evidence</span>
+          <strong>2 open</strong>
+          <p>Visual drift plus stale baseline on mobile.</p>
         </article>
-        <article class="metric-card" data-qa="metric-card">
-          <span>Queues under SLA</span>
-          <strong>17/19</strong>
+        <article class="metric-card gate-card" data-qa="gate-card">
+          <span>Release confidence</span>
+          <strong>74%</strong>
+          <p>Safe to continue review, not yet safe to merge.</p>
         </article>
       </section>
 
       <section class="section-grid">
         <article class="panel stack-card">
-          <h2>Priority queue</h2>
+          <h2>Blocking findings</h2>
           <ul class="task-list">
-            <li><span>Expand renewal-risk scoring to LATAM accounts</span><span class="badge warn">Needs review</span></li>
-            <li><span>Confirm migration status for enterprise pilot workspace</span><span class="badge good">On track</span></li>
-            <li><span>Publish Q2 retention automation playbook</span><span class="badge good">Ready</span></li>
+            <li data-qa="finding-row"><span>Mobile CTA row wraps below the viewport fold on `/changes`.</span><span class="badge warn">Visual</span></li>
+            <li data-qa="finding-row"><span>Saved dashboard snapshot is stale after copy and badge changes.</span><span class="badge warn">Baseline</span></li>
+            <li data-qa="finding-row"><span>Desktop layout and sign-in flow remain stable.</span><span class="badge good">Pass</span></li>
           </ul>
         </article>
 
         <article class="panel stack-card">
-          <h2>Demo notes</h2>
+          <h2>Why this is a convincing demo</h2>
           <p>
-            This page is built to be friendly to `browse` assertions. It has a stable heading, stable metric-card count, and explicit session metadata.
+            The page is deliberately optimized for release-readiness storytelling: a merge recommendation, concrete blockers,
+            stable QA selectors, and an evidence link into the change-impact surface.
           </p>
           <p>
-            It also gives `review` and `ship` something realistic to talk about when you change copy, cards, or login behavior.
+            This is the screen where `qa`, `preview`, `deploy`, and `ship --dry-run` all feel like they are describing the same decision.
           </p>
         </article>
       </section>

--- a/examples/customer-portal-demo/public/index.html
+++ b/examples/customer-portal-demo/public/index.html
@@ -3,87 +3,93 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Acme Customer Portal</title>
+    <title>Acme Release Readiness Demo</title>
     <link rel="stylesheet" href="/app.css" />
   </head>
-  <body class="portal-shell">
+  <body class="release-shell">
     <div class="page">
       <header class="topbar">
         <div class="brand">
-          <div class="brand-mark">A</div>
+          <div class="brand-mark">R</div>
           <div class="brand-copy">
-            <strong>Acme Customer Portal</strong>
-            <span>Operations visibility for fast-moving support teams</span>
+            <strong>Acme Release Readiness</strong>
+            <span>Demo the merge decision workflow, not just a random UI</span>
           </div>
         </div>
         <nav class="nav-links">
           <a href="/login">Sign in</a>
           <a href="/dashboard">Dashboard</a>
+          <a href="/changes">Change impact</a>
         </nav>
       </header>
 
       <section class="hero">
         <article class="panel hero-copy">
-          <div class="eyebrow">Demo project for codex-stack</div>
-          <h1>Show your friend a real login and dashboard flow.</h1>
+          <div class="eyebrow">codex-stack proof demo</div>
+          <h1>Show why an AI-coded change is or is not ready to merge.</h1>
           <p class="lede">
-            This sample project is intentionally small, local-first, and visual. It gives you something concrete to review, ship,
-            and browser-test without needing a full external stack.
+            This demo is built for technical evaluators. It gives you one believable release candidate, one authenticated flow,
+            one change-impact surface, and enough stable evidence to demonstrate browse, QA, preview verification, and ship
+            decisions in a single five-minute walkthrough.
           </p>
           <div class="actions">
-            <a class="button primary" href="/login">Launch operator login</a>
-            <a class="button secondary" href="/dashboard">View dashboard</a>
+            <a class="button primary" href="/login">Run the operator flow</a>
+            <a class="button secondary" href="/dashboard">Open release dashboard</a>
           </div>
         </article>
 
         <aside class="panel side-card">
           <div>
-            <div class="label">What this demo is for</div>
-            <div class="value">5-minute friend demo</div>
+            <div class="label">Primary audience</div>
+            <div class="value">Technical evaluator</div>
           </div>
           <div class="stat">
-            <div class="value">3</div>
-            <div class="label">core workflows to show: browse, ship, retro</div>
+            <div class="value">5 min</div>
+            <div class="label">to show authenticated QA, visual evidence, and merge gating</div>
           </div>
           <div class="stat">
-            <div class="value">0 deps</div>
-            <div class="label">outside Bun and the existing Playwright install</div>
+            <div class="value">4</div>
+            <div class="label">core proof points: browse, qa, preview/deploy, ship</div>
           </div>
         </aside>
       </section>
 
       <section class="metrics-grid">
         <article class="metric-card" data-qa="metric-card">
-          <span>Renewals at risk</span>
-          <strong>12</strong>
+          <span>Preview checks planned</span>
+          <strong>6</strong>
         </article>
         <article class="metric-card" data-qa="metric-card">
-          <span>Support queue age</span>
-          <strong>3.4h</strong>
+          <span>Unresolved regressions</span>
+          <strong>2</strong>
         </article>
         <article class="metric-card" data-qa="metric-card">
-          <span>Customers onboarded</span>
-          <strong>84</strong>
+          <span>Approved exceptions</span>
+          <strong>1</strong>
         </article>
         <article class="metric-card" data-qa="metric-card">
-          <span>Automation coverage</span>
-          <strong>71%</strong>
+          <span>Release confidence</span>
+          <strong>74%</strong>
         </article>
       </section>
 
       <section class="section-grid">
         <article class="panel stack-card">
-          <h2>What you can demonstrate</h2>
-          <ul class="task-list">
-            <li><span>Use `browse` to run a real login flow with assertions.</span><span class="badge good">QA</span></li>
-            <li><span>Use `ship --dry-run` to show PR title, labels, and reviewer planning.</span><span class="badge good">Release</span></li>
-            <li><span>Use `retro` to show delivery analytics after a couple of sample commits.</span><span class="badge warn">Ops</span></li>
-          </ul>
+          <h2>What this demo proves</h2>
+          <ol class="task-list numbered-list">
+            <li><span>Use <code>browse</code> to run a real login flow and persist session state.</span><span class="badge good">Auth</span></li>
+            <li><span>Use <code>qa</code> to score release readiness with visual evidence and stable selectors.</span><span class="badge good">QA</span></li>
+            <li><span>Use <code>preview</code> or <code>deploy</code> to verify key routes on desktop and mobile.</span><span class="badge warn">Preview</span></li>
+            <li><span>Use <code>ship --dry-run</code> to show how merge decisions become PR metadata.</span><span class="badge good">Release</span></li>
+          </ol>
         </article>
         <article class="panel stack-card">
           <h2>Suggested pitch</h2>
           <p>
-            "This is not a prompt pack. It is a workflow layer that makes an AI coding agent usable for actual engineering work."
+            “This package is useful when code generation stops being the bottleneck and release confidence becomes the bottleneck.”
+          </p>
+          <p>
+            The demo intentionally centers on merge readiness so the evaluator sees operational proof, not just automation tricks.
           </p>
         </article>
       </section>

--- a/examples/customer-portal-demo/public/login.html
+++ b/examples/customer-portal-demo/public/login.html
@@ -3,34 +3,35 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Operator Login</title>
+    <title>Release Operator Sign In</title>
     <link rel="stylesheet" href="/app.css" />
     <script src="/app.js" defer></script>
   </head>
-  <body class="portal-auth" data-page="login">
+  <body class="release-auth" data-page="login">
     <div class="page auth-shell">
       <section class="panel auth-panel">
-        <div class="kicker">Acme ops console</div>
-        <h1>Operator sign in</h1>
+        <div class="kicker">Release control workspace</div>
+        <h1>Release operator sign in</h1>
         <p class="lede">
-          Use any email and password. The demo stores a lightweight local session so Playwright flows can persist across runs.
+          Use any email and password. The demo stores a lightweight local session so authenticated preview and QA flows can be
+          re-run without rebuilding a backend.
         </p>
-        <div class="notice" data-login-notice>Recommended demo account: <strong>ops-demo@acme.dev</strong></div>
+        <div class="notice" data-login-notice>Recommended demo account: <strong>release-owner@acme.dev</strong></div>
       </section>
 
       <section class="panel auth-form">
-        <h2>Welcome back</h2>
-        <p class="form-help">This screen is intentionally simple so it is easy to automate during a live demo.</p>
+        <h2>Resume the candidate review</h2>
+        <p class="form-help">This is the deliberate auth gate for `browse`, preview verification, and session-bundle demos.</p>
         <form data-login-form>
           <label>
             <span>Email</span>
-            <input type="email" name="email" placeholder="ops-demo@acme.dev" autocomplete="email" />
+            <input type="email" name="email" placeholder="release-owner@acme.dev" autocomplete="email" />
           </label>
           <label>
             <span>Password</span>
             <input type="password" name="password" placeholder="demo-password" autocomplete="current-password" />
           </label>
-          <button class="primary" type="submit">Sign in to dashboard</button>
+          <button class="primary" type="submit">Continue to release dashboard</button>
         </form>
       </section>
     </div>

--- a/examples/customer-portal-demo/server.ts
+++ b/examples/customer-portal-demo/server.ts
@@ -17,6 +17,8 @@ const ROUTES: Record<string, string> = {
   "/login/": "login.html",
   "/dashboard": "dashboard.html",
   "/dashboard/": "dashboard.html",
+  "/changes": "changes.html",
+  "/changes/": "changes.html",
 };
 
 const REQUIRED_FILES = [...Object.values(ROUTES), "app.css", "app.js"];
@@ -37,7 +39,7 @@ function checkRoutes(): void {
     console.error(`Missing demo files: ${missing.join(", ")}`);
     process.exit(1);
   }
-  console.log("[customer-portal-demo] route map ok");
+  console.log("[release-readiness-demo] route map ok");
 }
 
 function send(
@@ -70,7 +72,7 @@ const server = http.createServer((req: IncomingMessage, res: ServerResponse<Inco
   const url = new URL(req.url || "/", `http://${req.headers.host || `${HOST}:${PORT}`}`);
 
   if (url.pathname === "/api/health") {
-    send(res, 200, JSON.stringify({ ok: true, service: "customer-portal-demo" }), CONTENT_TYPES[".json"]);
+    send(res, 200, JSON.stringify({ ok: true, service: "release-readiness-demo" }), CONTENT_TYPES[".json"]);
     return;
   }
 
@@ -96,5 +98,5 @@ if (process.argv.includes("--check")) {
 checkRoutes();
 
 server.listen(PORT, HOST, () => {
-  console.log(`[customer-portal-demo] http://${HOST}:${PORT}`);
+  console.log(`[release-readiness-demo] http://${HOST}:${PORT}`);
 });

--- a/examples/customer-portal-demo/src/app.ts
+++ b/examples/customer-portal-demo/src/app.ts
@@ -5,7 +5,7 @@ interface DemoSession {
 }
 
 const SESSION_KEY = "codexStackDemoSession";
-const PAGE_SEGMENTS = new Set(["login", "dashboard", "index.html", "login.html", "dashboard.html"]);
+const PAGE_SEGMENTS = new Set(["login", "dashboard", "changes", "index.html", "login.html", "dashboard.html", "changes.html"]);
 
 function getSession(): DemoSession | null {
   try {
@@ -68,6 +68,38 @@ function dashboardPath(): string {
   return new URL(appPath("dashboard"), window.location.origin).toString();
 }
 
+function changesPath(): string {
+  return new URL(appPath("changes"), window.location.origin).toString();
+}
+
+function currentRole(email: string): string {
+  if (email.includes("release") || email.includes("ops")) return "Release manager";
+  if (email.includes("design")) return "Design reviewer";
+  return "Engineering lead";
+}
+
+function hydrateSessionFields(session: DemoSession): void {
+  for (const element of document.querySelectorAll<HTMLElement>("[data-user-email]")) {
+    element.replaceChildren(document.createTextNode(session.email));
+  }
+  for (const element of document.querySelectorAll<HTMLElement>("[data-user-role]")) {
+    element.replaceChildren(document.createTextNode(session.role));
+  }
+  for (const element of document.querySelectorAll<HTMLElement>("[data-signed-in-at]")) {
+    element.replaceChildren(document.createTextNode(session.signedInAt));
+  }
+}
+
+function guardProtectedPage(targetPath: string): DemoSession | null {
+  const session = getSession();
+  if (!session) {
+    window.location.href = loginPath(targetPath);
+    return null;
+  }
+  hydrateSessionFields(session);
+  return session;
+}
+
 if (document.body.dataset.page === "login") {
   const form = document.querySelector<HTMLFormElement>("form[data-login-form]");
   const emailField = document.querySelector<HTMLInputElement>("input[name=email]");
@@ -86,14 +118,14 @@ if (document.body.dataset.page === "login") {
 
     if (!email || !password) {
       if (notice) {
-        notice.textContent = "Use any email and password to continue the demo.";
+        notice.textContent = "Use any email and password to continue the release-readiness demo.";
       }
       return;
     }
 
     setSession({
       email,
-      role: email.includes("ops") ? "Operations lead" : "Customer success",
+      role: currentRole(email),
       signedInAt: formatDate(),
     });
     window.location.href = next;
@@ -101,16 +133,20 @@ if (document.body.dataset.page === "login") {
 }
 
 if (document.body.dataset.page === "dashboard") {
-  const session = getSession();
-  if (!session) {
-    window.location.href = loginPath(dashboardPath());
-  } else {
-    document.querySelector<HTMLElement>("[data-user-email]")?.replaceChildren(document.createTextNode(session.email));
-    document.querySelector<HTMLElement>("[data-user-role]")?.replaceChildren(document.createTextNode(session.role));
-    document.querySelector<HTMLElement>("[data-signed-in-at]")?.replaceChildren(document.createTextNode(session.signedInAt));
-  }
+  guardProtectedPage(dashboardPath());
+  document.querySelector<HTMLElement>("[data-open-evidence]")?.addEventListener("click", (event) => {
+    if (!(event.currentTarget instanceof HTMLAnchorElement)) return;
+    event.preventDefault();
+    window.location.href = changesPath();
+  });
+}
 
-  document.querySelector<HTMLElement>("[data-signout]")?.addEventListener("click", () => {
+if (document.body.dataset.page === "changes") {
+  guardProtectedPage(changesPath());
+}
+
+for (const button of document.querySelectorAll<HTMLElement>("[data-signout]")) {
+  button.addEventListener("click", () => {
     clearSession();
     window.location.href = loginPath();
   });

--- a/scripts/build-preview-site.spec.ts
+++ b/scripts/build-preview-site.spec.ts
@@ -31,17 +31,19 @@ assert.ok(fs.existsSync(path.join(outDir, "app.js")));
 assert.ok(fs.existsSync(path.join(outDir, "index.html")));
 assert.ok(fs.existsSync(path.join(outDir, "login", "index.html")));
 assert.ok(fs.existsSync(path.join(outDir, "dashboard", "index.html")));
+assert.ok(fs.existsSync(path.join(outDir, "changes", "index.html")));
 
 const rootHtml = fs.readFileSync(path.join(outDir, "index.html"), "utf8");
 const loginHtml = fs.readFileSync(path.join(outDir, "login", "index.html"), "utf8");
 const dashboardHtml = fs.readFileSync(path.join(outDir, "dashboard", "index.html"), "utf8");
+const changesHtml = fs.readFileSync(path.join(outDir, "changes", "index.html"), "utf8");
 
-assert.match(rootHtml, /href="\.\//);
-assert.match(rootHtml, /href="\.\.\/login\/"|href="\.\/login\/"/);
+assert.match(rootHtml, /href="\.\/login\/"/);
+assert.match(rootHtml, /href="\.\/changes\/"/);
 assert.match(loginHtml, /href="\.\.\/app\.css"/);
 assert.match(loginHtml, /src="\.\.\/app\.js"/);
-assert.match(dashboardHtml, /href="\.\.\/app\.css"/);
-assert.match(dashboardHtml, /src="\.\.\/app\.js"/);
+assert.match(dashboardHtml, /href="\.\.\/changes\/"/);
+assert.match(changesHtml, /href="\.\.\/dashboard\/"/);
 
 fs.rmSync(outDir, { recursive: true, force: true });
 console.log("build-preview-site spec passed");

--- a/scripts/build-preview-site.ts
+++ b/scripts/build-preview-site.ts
@@ -12,10 +12,10 @@ export interface BuildPreviewArgs {
 interface BuildPreviewResult {
   source: string;
   out: string;
-  rootIndex: string;
-  loginIndex: string;
-  dashboardIndex: string;
+  pages: Record<string, string>;
 }
+
+const ROUTES = ["login", "dashboard", "changes"];
 
 function usage(): never {
   console.log(`build-preview-site
@@ -83,47 +83,50 @@ function readRequired(filePath: string): string {
 }
 
 function rewriteRootIndex(html: string): string {
-  return html
+  let output = html
     .replace(/href="\/app\.css"/g, 'href="./app.css"')
-    .replace(/src="\/app\.js"/g, 'src="./app.js"')
-    .replace(/href="\/login"/g, 'href="./login/"')
-    .replace(/href="\/dashboard"/g, 'href="./dashboard/"');
+    .replace(/src="\/app\.js"/g, 'src="./app.js"');
+  for (const route of ROUTES) {
+    const pattern = new RegExp(`href="/${route}"`, "g");
+    output = output.replace(pattern, `href="./${route}/"`);
+  }
+  return output;
 }
 
 function rewriteRoutePage(html: string): string {
-  return html
+  let output = html
     .replace(/href="\/app\.css"/g, 'href="../app.css"')
-    .replace(/src="\/app\.js"/g, 'src="../app.js"')
-    .replace(/href="\/login"/g, 'href="../login/"')
-    .replace(/href="\/dashboard"/g, 'href="../dashboard/"');
+    .replace(/src="\/app\.js"/g, 'src="../app.js"');
+  for (const route of ROUTES) {
+    const pattern = new RegExp(`href="/${route}"`, "g");
+    output = output.replace(pattern, `href="../${route}/"`);
+  }
+  return output;
 }
 
 export function buildPreviewSite(args: BuildPreviewArgs): BuildPreviewResult {
   cleanDir(args.out);
-
-  const sourceIndex = path.join(args.source, "index.html");
-  const sourceLogin = path.join(args.source, "login.html");
-  const sourceDashboard = path.join(args.source, "dashboard.html");
-
   copyTree(args.source, args.out, (filePath) => filePath.endsWith(".html"));
 
-  const rootIndex = path.join(args.out, "index.html");
-  const loginIndex = path.join(args.out, "login", "index.html");
-  const dashboardIndex = path.join(args.out, "dashboard", "index.html");
+  const pages: Record<string, string> = {
+    root: path.join(args.out, "index.html"),
+  };
 
-  fs.writeFileSync(rootIndex, rewriteRootIndex(readRequired(sourceIndex)));
-  ensureDir(path.dirname(loginIndex));
-  fs.writeFileSync(loginIndex, rewriteRoutePage(readRequired(sourceLogin)));
-  ensureDir(path.dirname(dashboardIndex));
-  fs.writeFileSync(dashboardIndex, rewriteRoutePage(readRequired(sourceDashboard)));
+  fs.writeFileSync(pages.root, rewriteRootIndex(readRequired(path.join(args.source, "index.html"))));
+
+  for (const route of ROUTES) {
+    const targetPath = path.join(args.out, route, "index.html");
+    ensureDir(path.dirname(targetPath));
+    fs.writeFileSync(targetPath, rewriteRoutePage(readRequired(path.join(args.source, `${route}.html`))));
+    pages[route] = targetPath;
+  }
+
   fs.writeFileSync(path.join(args.out, ".nojekyll"), "");
 
   return {
     source: args.source,
     out: args.out,
-    rootIndex,
-    loginIndex,
-    dashboardIndex,
+    pages,
   };
 }
 
@@ -135,8 +138,8 @@ if (import.meta.main) {
   } else {
     console.log(`Preview site source: ${result.source}`);
     console.log(`Preview site output: ${result.out}`);
-    console.log(`Root page: ${result.rootIndex}`);
-    console.log(`Login page: ${result.loginIndex}`);
-    console.log(`Dashboard page: ${result.dashboardIndex}`);
+    for (const [route, filePath] of Object.entries(result.pages)) {
+      console.log(`${route}: ${filePath}`);
+    }
   }
 }

--- a/scripts/ci-check.sh
+++ b/scripts/ci-check.sh
@@ -225,9 +225,12 @@ run_ts scripts/build-preview-site.ts --out .preview-site >/tmp/codex-stack-previ
 test -f .preview-site/index.html
 test -f .preview-site/login/index.html
 test -f .preview-site/dashboard/index.html
+test -f .preview-site/changes/index.html
 test -f .preview-site/.nojekyll
 grep -q '\./login/' .preview-site/index.html
+grep -q '\./changes/' .preview-site/index.html
 grep -q '\.\./app.css' .preview-site/login/index.html
+grep -q '\.\./dashboard/' .preview-site/changes/index.html
 rm -rf docs/qa/smoke-fixture
 rm -rf .site
 rm -rf .preview-site
@@ -328,6 +331,11 @@ test -f examples/customer-portal-demo/README.md
 test -f examples/customer-portal-demo/server.ts
 test -f examples/customer-portal-demo/src/app.ts
 test -f examples/customer-portal-demo/public/app.js
+test -f examples/customer-portal-demo/public/changes.html
+test -f browse/flows/release-login.json
+test -f browse/flows/release-dashboard.json
+test -f browse/flows/release-changes.json
+test -f browse/flows/release-full-demo.json
 test -f browse/flows/portal-login.json
 test -f browse/flows/portal-dashboard.json
 test -f browse/flows/portal-full-demo.json

--- a/scripts/demo-smoke.ts
+++ b/scripts/demo-smoke.ts
@@ -44,23 +44,27 @@ function main(): void {
   const landing = read("index.html");
   const login = read("login.html");
   const dashboard = read("dashboard.html");
+  const changes = read("changes.html");
   const css = read("app.css");
   const js = read("app.js");
 
-  if (!landing.includes("Acme Customer Portal")) {
-    throw new Error("Landing page is missing the expected title.");
+  if (!landing.includes("Acme Release Readiness Demo")) {
+    throw new Error("Landing page is missing the release-readiness title.");
   }
-  if (!login.includes("Operator sign in")) {
-    throw new Error("Login page is missing the expected heading.");
+  if (!login.includes("Release operator sign in")) {
+    throw new Error("Login page is missing the release-operator heading.");
   }
-  if (!dashboard.includes("Daily portfolio health")) {
-    throw new Error("Dashboard page is missing the expected heading.");
+  if (!dashboard.includes("Release readiness dashboard")) {
+    throw new Error("Dashboard page is missing the release-readiness heading.");
   }
-  if (!css.includes(".metric-card")) {
-    throw new Error("Demo styles are missing the metric-card styling.");
+  if (!changes.includes("Change impact and preview evidence")) {
+    throw new Error("Changes page is missing the evidence heading.");
   }
-  if (!js.includes("codexStackDemoSession")) {
-    throw new Error("Demo client script is missing session persistence.");
+  if (!css.includes(".status-strip")) {
+    throw new Error("Demo styles are missing the release status strip styling.");
+  }
+  if (!js.includes("changesPath")) {
+    throw new Error("Demo client script is missing the changes route helper.");
   }
 
   console.log("demo sample app is healthy");

--- a/skills/browse/SKILL.md
+++ b/skills/browse/SKILL.md
@@ -78,7 +78,7 @@ bun src/cli.ts browse text https://example.com --session staging
 bun src/cli.ts browse save-flow login-local '[{"action":"fill","selector":"input[name=email]","value":"demo@example.com"},{"action":"fill","selector":"input[name=password]","value":"demo-pass"},{"action":"click","selector":"button[type=submit]"}]'
 bun src/cli.ts browse save-repo-flow landing-smoke '[{"action":"assert-visible","selector":"body"}]'
 bun src/cli.ts browse import-flow login-local ./docs/login-flow.md
-bun src/cli.ts browse export-flow portal-full-demo ./docs/portal-full-demo.yaml
+bun src/cli.ts browse export-flow release-full-demo ./docs/release-full-demo.yaml
 bun src/cli.ts browse export-session ./tmp/staging-session.json --session staging
 bun src/cli.ts browse import-session ./tmp/staging-session.json --session staging-copy
 bun src/cli.ts browse import-browser-cookies chrome --session staging --profile Default

--- a/skills/deploy/SKILL.md
+++ b/skills/deploy/SKILL.md
@@ -29,9 +29,9 @@ Resolve the live deploy URL, wait for readiness, verify the important paths acro
 ## CLI
 
 ```bash
-bun src/cli.ts deploy --url-template "https://preview-{pr}.example.com" --pr 42 --branch feat/42-preview --sha abcdef123 --path / --path /dashboard --device desktop --device mobile --flow portal-dashboard --snapshot portal-dashboard
-bun src/cli.ts deploy --url https://staging.example.com --path /dashboard --device desktop --flow portal-dashboard --snapshot portal-dashboard --a11y --a11y-scope main --perf --perf-budget lcp=2s --perf-budget cls=0.1
-bun src/cli.ts deploy --url https://staging.example.com --path /dashboard --device desktop --flow portal-dashboard --session staging-auth --session-bundle .codex-stack/private/staging-auth.json --json
+bun src/cli.ts deploy --url-template "https://preview-{pr}.example.com" --pr 42 --branch feat/42-preview --sha abcdef123 --path / --path /dashboard --path /changes --device desktop --device mobile --flow release-dashboard --flow release-changes --snapshot release-dashboard
+bun src/cli.ts deploy --url https://staging.example.com --path /dashboard --device desktop --flow release-dashboard --snapshot release-dashboard --a11y --a11y-scope main --perf --perf-budget lcp=2s --perf-budget cls=0.1
+bun src/cli.ts deploy --url https://staging.example.com --path /dashboard --device desktop --flow release-dashboard --session staging-auth --session-bundle .codex-stack/private/staging-auth.json --json
 bun src/cli.ts deploy --url http://127.0.0.1:4173 --path /dashboard --device desktop --publish-dir docs/qa/local-demo/deploy --strict-console --json
 ```
 

--- a/skills/preview/SKILL.md
+++ b/skills/preview/SKILL.md
@@ -30,9 +30,9 @@ Turn preview verification into a repeatable workflow that resolves the right pre
 ```bash
 bun src/cli.ts preview --url-template "https://preview-{pr}.example.com" --pr 42 --branch feat/42-preview --sha abcdef123 --path / --path /dashboard --device desktop --device mobile --flow landing-smoke --snapshot landing-home
 bun src/cli.ts preview --url-template "https://preview-{pr}.example.com" --pr 42 --branch feat/42-preview --sha abcdef123 --path /dashboard --device desktop --flow landing-smoke --snapshot landing-home --a11y --a11y-scope main --perf --perf-budget lcp=2s
-bun src/cli.ts preview --url "https://anup4khandelwal.github.io/codex-stack/pr-preview/pr-42/" --pr 42 --branch feat/42-preview --sha abcdef123 --path /login --path /dashboard --device desktop --device mobile --flow portal-full-demo
-bun src/cli.ts preview --url "https://anup4khandelwal.github.io/codex-stack/pr-preview/pr-42/" --pr 42 --branch feat/42-preview --sha abcdef123 --path /dashboard --device desktop --flow portal-dashboard --session preview-auth --session-bundle .codex-stack/private/preview-auth.json
-bun src/cli.ts preview --url http://127.0.0.1:4173 --path /dashboard --device desktop --flow portal-dashboard --snapshot portal-dashboard --fixture /tmp/deploy-fixture.json --qa-fixture /tmp/qa-fixture.json --json
+bun src/cli.ts preview --url "https://anup4khandelwal.github.io/codex-stack/pr-preview/pr-42/" --pr 42 --branch feat/42-preview --sha abcdef123 --path /login --path /dashboard --device desktop --device mobile --flow release-full-demo
+bun src/cli.ts preview --url "https://anup4khandelwal.github.io/codex-stack/pr-preview/pr-42/" --pr 42 --branch feat/42-preview --sha abcdef123 --path /dashboard --device desktop --flow release-dashboard --session preview-auth --session-bundle .codex-stack/private/preview-auth.json
+bun src/cli.ts preview --url http://127.0.0.1:4173 --path /dashboard --device desktop --flow release-dashboard --snapshot release-dashboard --fixture /tmp/deploy-fixture.json --qa-fixture /tmp/qa-fixture.json --json
 ```
 
 ## Output format

--- a/skills/qa-decide/SKILL.md
+++ b/skills/qa-decide/SKILL.md
@@ -27,8 +27,8 @@ Keep visual, accessibility, and performance triage explicit and reviewable inste
 ## CLI
 
 ```bash
-bun src/cli.ts qa-decide approve --snapshot portal-dashboard --route /dashboard --device desktop --kind snapshot-drift --reason "Intentional redesign approved in PR #123" --review-after 2026-03-22T00:00:00Z
-bun src/cli.ts qa-decide suppress --snapshot portal-dashboard --route /dashboard --device mobile --kind missing-selectors --selector "header .promo" --reason "Promo banner intentionally removed"
+bun src/cli.ts qa-decide approve --snapshot release-dashboard --route /dashboard --device desktop --kind snapshot-drift --reason "Intentional redesign approved in PR #123" --review-after 2026-03-22T00:00:00Z
+bun src/cli.ts qa-decide suppress --snapshot release-dashboard --route /dashboard --device mobile --kind missing-selectors --selector "header .promo" --reason "Promo banner intentionally removed"
 bun src/cli.ts qa-decide approve --category accessibility --kind accessibility-rule --route /checkout --device desktop --rule color-contrast --reason "Vendor widget pending upstream fix" --expires-at 2026-03-29T00:00:00Z
 bun src/cli.ts qa-decide approve --category performance --kind performance-budget --route /dashboard --device desktop --metric lcp --reason "Temporary budget exception during analytics migration" --decision-type refresh-required
 bun src/cli.ts qa-decide list --active-only

--- a/skills/qa/SKILL.md
+++ b/skills/qa/SKILL.md
@@ -33,10 +33,10 @@ Run repeatable browser verification, collect evidence, and turn it into a ship/n
 ## CLI
 
 ```bash
-bun src/cli.ts qa http://127.0.0.1:4173/dashboard --flow portal-dashboard --snapshot portal-dashboard --session demo --json
-bun src/cli.ts qa http://127.0.0.1:4173/dashboard --flow portal-dashboard --snapshot portal-dashboard --a11y --a11y-scope main --perf --perf-budget lcp=2s --perf-budget cls=0.1 --session demo --json
-bun src/cli.ts qa http://127.0.0.1:4173/login --flow portal-full-demo --snapshot portal-login --session demo
-bun src/cli.ts qa https://preview.example.com/dashboard --flow portal-dashboard --session preview-auth --session-bundle .codex-stack/private/preview-auth.json --json
+bun src/cli.ts qa http://127.0.0.1:4173/dashboard --flow release-dashboard --snapshot release-dashboard --session demo --json
+bun src/cli.ts qa http://127.0.0.1:4173/dashboard --flow release-dashboard --snapshot release-dashboard --a11y --a11y-scope main --perf --perf-budget lcp=2s --perf-budget cls=0.1 --session demo --json
+bun src/cli.ts qa http://127.0.0.1:4173/login --flow release-full-demo --snapshot release-login --session demo
+bun src/cli.ts qa https://preview.example.com/dashboard --flow release-dashboard --session preview-auth --session-bundle .codex-stack/private/preview-auth.json --json
 bun src/cli.ts qa https://preview.example.com --mode diff-aware --base-ref origin/main --session preview --json
 bun scripts/qa-run.ts --fixture ./tmp/qa-fixture.json --json
 bun scripts/qa-trends.ts --dir .codex-stack/qa --json


### PR DESCRIPTION
## Summary\n- reposition the demo app around release-readiness decisions instead of a generic portal\n- add stronger demo flows, a new change-impact route, and updated preview/demo smoke coverage\n- rewrite the demo documentation into a guided evaluator story for browse, qa, preview, and ship\n\n## Validation\n- bun run build\n- bun run demo:smoke\n- bun scripts/build-preview-site.spec.ts\n- bun run typecheck\n- bun run smoke\n\nCloses #77