### PR TITLE
feat: add codex-stack MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 `codex-stack` turns Codex from a generic coding assistant into a team of workflow specialists you can call on demand.
 
-Twelve opinionated workflow modes for Codex: product framing, technical planning, paranoid diff review, scored QA, regression triage, preview verification, deploy verification, release shipping, browser automation, engineering retrospectives, upgrade audits, and fleet rollout plus auto-remediation control.
+Thirteen opinionated workflow modes for Codex: product framing, technical planning, paranoid diff review, scored QA, regression triage, preview verification, deploy verification, release shipping, browser automation, engineering retrospectives, upgrade audits, fleet rollout plus auto-remediation control, and local MCP interoperability.
 
 Inspired by [`gstack`](https://github.com/garrytan/gstack), `codex-stack` adapts the same specialist-workflow idea for Codex. If `gstack` is the Claude Code version of this pattern, `codex-stack` is the Codex-native version. This project is independently maintained and is not affiliated with `gstack`.
 
@@ -31,6 +31,7 @@ Inspired by [`gstack`](https://github.com/garrytan/gstack), `codex-stack` adapts
 | `retro` | Engineering manager | Summarizes delivery patterns from git history and optional GitHub PR analytics. |
 | `upgrade` | Repo maintainer | Audits Bun, dependency drift, workflow action drift, and install health for codex-stack itself. |
 | `fleet` | Control plane operator | Pushes shared policy packs across repos, collects normalized health, and renders a GitHub-native rollout dashboard. |
+| `mcp` | Interop engineer | Exposes read-only codex-stack tools and evidence resources to MCP-capable clients over local stdio. |
 
 ## Default workflow
 
@@ -63,6 +64,7 @@ Use the repo in this order:
 - GitHub Pages publishing for `docs/qa/` so merged QA reports keep a stable URL after branch cleanup
 - Issue-first workflow automation with PR review comments and opt-in auto-merge
 - Fleet rollout controls for multi-repo policy packs, policy-aware health expectations, rollout PR planning, auto-remediation issues, and org-level dashboard rendering
+- Local stdio MCP server with read-only and dry-run wrappers for review, QA, preview, deploy, ship planning, fleet planning, retro, and upgrade workflows
 - Retrospective analytics plus weekly digest publishing outputs for markdown, Slack, and email, including visual regression rollups from published QA evidence
 - Upgrade auditing via CLI plus a daily scheduled update-check workflow that syncs a stable issue
 
@@ -93,6 +95,7 @@ bun src/cli.ts list
 - `retro`
 - `upgrade`
 - `fleet`
+- `mcp`
 
 If you want shell-level commands, link those wrappers into your `PATH`:
 
@@ -197,6 +200,8 @@ bun src/cli.ts fleet sync --manifest .codex-stack/fleet.example.json --dry-run -
 bun src/cli.ts fleet collect --manifest .codex-stack/fleet.example.json --json
 bun src/cli.ts fleet dashboard --manifest .codex-stack/fleet.example.json --out .fleet-site
 bun src/cli.ts fleet remediate --manifest .codex-stack/fleet.example.json --dry-run --json
+bun src/cli.ts mcp inspect --json
+bun src/cli.ts mcp serve
 bun src/cli.ts retro --since "7 days ago" --repo anup4khandelwal/codex-stack
 bun src/cli.ts upgrade --offline --json
 bun src/cli.ts upgrade --offline --apply
@@ -233,10 +238,45 @@ bun src/cli.ts qa-decide list --active-only
 bun run preview -- --url-template "https://preview-{pr}.example.com" --pr 42 --branch feat/42-preview --sha abcdef123 --path / --device desktop --flow landing-smoke --snapshot landing-home
 bun run deploy -- --url https://staging.example.com --path /dashboard --device desktop --flow release-dashboard --snapshot release-dashboard
 bun run ship:dry
+bun run mcp -- inspect --json
 bun run retro
 bun run upgrade
 bun run upgrade:apply
 bun run weekly
+```
+
+## MCP interop
+
+`codex-stack` can expose its workflow layer to MCP-capable clients through a local `stdio` server.
+
+v1 policy:
+
+- `stdio` transport only
+- read-only plus dry-run tools only
+- no repo mutation, GitHub mutation, issue creation, PR creation, or baseline updates through MCP
+
+Useful commands:
+
+```bash
+bun src/cli.ts mcp inspect --json
+bun src/cli.ts mcp serve
+```
+
+Example client wiring:
+
+```json
+{
+  "mcpServers": {
+    "codex-stack": {
+      "command": "bun",
+      "args": [
+        "/Users/anup.khandelwal/Desktop/codex/codex/codex-stack/src/cli.ts",
+        "mcp",
+        "serve"
+      ]
+    }
+  }
+}
 ```
 
 ## Fleet rollout

--- a/bun.lock
+++ b/bun.lock
@@ -5,9 +5,11 @@
     "": {
       "name": "codex-stack",
       "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.27.1",
         "axe-core": "^4.11.0",
         "playwright": "^1.58.2",
         "pngjs": "^7.0.0",
+        "zod": "^4.3.6",
       },
       "devDependencies": {
         "@types/node": "^25.5.0",
@@ -17,13 +19,145 @@
     },
   },
   "packages": {
+    "@hono/node-server": ["@hono/node-server@1.19.11", "", { "peerDependencies": { "hono": "^4" } }, "sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g=="],
+
+    "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.27.1", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA=="],
+
     "@types/node": ["@types/node@25.5.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw=="],
 
     "@types/pngjs": ["@types/pngjs@6.0.5", "", { "dependencies": { "@types/node": "*" } }, "sha512-0k5eKfrA83JOZPppLtS2C7OUtyNAl2wKNxfyYl9Q5g9lPkgBl/9hNyAu6HuEH2J4XmIv2znEpkDd0SaZVxW6iQ=="],
 
+    "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
+
+    "ajv": ["ajv@8.18.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A=="],
+
+    "ajv-formats": ["ajv-formats@3.0.1", "", { "dependencies": { "ajv": "^8.0.0" } }, "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ=="],
+
     "axe-core": ["axe-core@4.11.1", "", {}, "sha512-BASOg+YwO2C+346x3LZOeoovTIoTrRqEsqMa6fmfAV0P+U9mFr9NsyOEpiYvFjbc64NMrSswhV50WdXzdb/Z5A=="],
 
+    "body-parser": ["body-parser@2.2.2", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^1.0.5", "debug": "^4.4.3", "http-errors": "^2.0.0", "iconv-lite": "^0.7.0", "on-finished": "^2.4.1", "qs": "^6.14.1", "raw-body": "^3.0.1", "type-is": "^2.0.1" } }, "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA=="],
+
+    "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
+
+    "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
+
+    "call-bound": ["call-bound@1.0.4", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "get-intrinsic": "^1.3.0" } }, "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg=="],
+
+    "content-disposition": ["content-disposition@1.0.1", "", {}, "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q=="],
+
+    "content-type": ["content-type@1.0.5", "", {}, "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="],
+
+    "cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
+
+    "cookie-signature": ["cookie-signature@1.2.2", "", {}, "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg=="],
+
+    "cors": ["cors@2.8.6", "", { "dependencies": { "object-assign": "^4", "vary": "^1" } }, "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw=="],
+
+    "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
+
+    "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "depd": ["depd@2.0.0", "", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
+
+    "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
+
+    "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
+
+    "encodeurl": ["encodeurl@2.0.0", "", {}, "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="],
+
+    "es-define-property": ["es-define-property@1.0.1", "", {}, "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="],
+
+    "es-errors": ["es-errors@1.3.0", "", {}, "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="],
+
+    "es-object-atoms": ["es-object-atoms@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA=="],
+
+    "escape-html": ["escape-html@1.0.3", "", {}, "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="],
+
+    "etag": ["etag@1.8.1", "", {}, "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="],
+
+    "eventsource": ["eventsource@3.0.7", "", { "dependencies": { "eventsource-parser": "^3.0.1" } }, "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA=="],
+
+    "eventsource-parser": ["eventsource-parser@3.0.6", "", {}, "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg=="],
+
+    "express": ["express@5.2.1", "", { "dependencies": { "accepts": "^2.0.0", "body-parser": "^2.2.1", "content-disposition": "^1.0.0", "content-type": "^1.0.5", "cookie": "^0.7.1", "cookie-signature": "^1.2.1", "debug": "^4.4.0", "depd": "^2.0.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "finalhandler": "^2.1.0", "fresh": "^2.0.0", "http-errors": "^2.0.0", "merge-descriptors": "^2.0.0", "mime-types": "^3.0.0", "on-finished": "^2.4.1", "once": "^1.4.0", "parseurl": "^1.3.3", "proxy-addr": "^2.0.7", "qs": "^6.14.0", "range-parser": "^1.2.1", "router": "^2.2.0", "send": "^1.1.0", "serve-static": "^2.2.0", "statuses": "^2.0.1", "type-is": "^2.0.1", "vary": "^1.1.2" } }, "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw=="],
+
+    "express-rate-limit": ["express-rate-limit@8.3.1", "", { "dependencies": { "ip-address": "10.1.0" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-D1dKN+cmyPWuvB+G2SREQDzPY1agpBIcTa9sJxOPMCNeH3gwzhqJRDWCXW3gg0y//+LQ/8j52JbMROWyrKdMdw=="],
+
+    "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
+
+    "fast-uri": ["fast-uri@3.1.0", "", {}, "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA=="],
+
+    "finalhandler": ["finalhandler@2.1.1", "", { "dependencies": { "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "on-finished": "^2.4.1", "parseurl": "^1.3.3", "statuses": "^2.0.1" } }, "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA=="],
+
+    "forwarded": ["forwarded@0.2.0", "", {}, "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="],
+
+    "fresh": ["fresh@2.0.0", "", {}, "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A=="],
+
     "fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
+
+    "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
+
+    "get-intrinsic": ["get-intrinsic@1.3.0", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "function-bind": "^1.1.2", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "math-intrinsics": "^1.1.0" } }, "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ=="],
+
+    "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
+
+    "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
+
+    "has-symbols": ["has-symbols@1.1.0", "", {}, "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="],
+
+    "hasown": ["hasown@2.0.2", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ=="],
+
+    "hono": ["hono@4.12.8", "", {}, "sha512-VJCEvtrezO1IAR+kqEYnxUOoStaQPGrCmX3j4wDTNOcD1uRPFpGlwQUIW8niPuvHXaTUxeOUl5MMDGrl+tmO9A=="],
+
+    "http-errors": ["http-errors@2.0.1", "", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
+
+    "iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
+
+    "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
+
+    "ip-address": ["ip-address@10.1.0", "", {}, "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q=="],
+
+    "ipaddr.js": ["ipaddr.js@1.9.1", "", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
+
+    "is-promise": ["is-promise@4.0.0", "", {}, "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="],
+
+    "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
+
+    "jose": ["jose@6.2.1", "", {}, "sha512-jUaKr1yrbfaImV7R2TN/b3IcZzsw38/chqMpo2XJ7i2F8AfM/lA4G1goC3JVEwg0H7UldTmSt3P68nt31W7/mw=="],
+
+    "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
+
+    "json-schema-typed": ["json-schema-typed@8.0.2", "", {}, "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA=="],
+
+    "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
+
+    "media-typer": ["media-typer@1.1.0", "", {}, "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw=="],
+
+    "merge-descriptors": ["merge-descriptors@2.0.0", "", {}, "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g=="],
+
+    "mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
+
+    "mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
+
+    "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
+
+    "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
+
+    "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
+
+    "on-finished": ["on-finished@2.4.1", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
+
+    "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
+
+    "parseurl": ["parseurl@1.3.3", "", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
+
+    "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
+
+    "path-to-regexp": ["path-to-regexp@8.3.0", "", {}, "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA=="],
+
+    "pkce-challenge": ["pkce-challenge@5.0.1", "", {}, "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ=="],
 
     "playwright": ["playwright@1.58.2", "", { "dependencies": { "playwright-core": "1.58.2" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A=="],
 
@@ -31,8 +165,58 @@
 
     "pngjs": ["pngjs@7.0.0", "", {}, "sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow=="],
 
+    "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
+
+    "qs": ["qs@6.15.0", "", { "dependencies": { "side-channel": "^1.1.0" } }, "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ=="],
+
+    "range-parser": ["range-parser@1.2.1", "", {}, "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="],
+
+    "raw-body": ["raw-body@3.0.2", "", { "dependencies": { "bytes": "~3.1.2", "http-errors": "~2.0.1", "iconv-lite": "~0.7.0", "unpipe": "~1.0.0" } }, "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA=="],
+
+    "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
+
+    "router": ["router@2.2.0", "", { "dependencies": { "debug": "^4.4.0", "depd": "^2.0.0", "is-promise": "^4.0.0", "parseurl": "^1.3.3", "path-to-regexp": "^8.0.0" } }, "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ=="],
+
+    "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
+
+    "send": ["send@1.2.1", "", { "dependencies": { "debug": "^4.4.3", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "fresh": "^2.0.0", "http-errors": "^2.0.1", "mime-types": "^3.0.2", "ms": "^2.1.3", "on-finished": "^2.4.1", "range-parser": "^1.2.1", "statuses": "^2.0.2" } }, "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ=="],
+
+    "serve-static": ["serve-static@2.2.1", "", { "dependencies": { "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "parseurl": "^1.3.3", "send": "^1.2.0" } }, "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw=="],
+
+    "setprototypeof": ["setprototypeof@1.2.0", "", {}, "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="],
+
+    "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
+
+    "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
+
+    "side-channel": ["side-channel@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.3", "side-channel-list": "^1.0.0", "side-channel-map": "^1.0.1", "side-channel-weakmap": "^1.0.2" } }, "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw=="],
+
+    "side-channel-list": ["side-channel-list@1.0.0", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.3" } }, "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA=="],
+
+    "side-channel-map": ["side-channel-map@1.0.1", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3" } }, "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA=="],
+
+    "side-channel-weakmap": ["side-channel-weakmap@1.0.2", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3", "side-channel-map": "^1.0.1" } }, "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A=="],
+
+    "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
+
+    "toidentifier": ["toidentifier@1.0.1", "", {}, "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="],
+
+    "type-is": ["type-is@2.0.1", "", { "dependencies": { "content-type": "^1.0.5", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw=="],
+
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
     "undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
+
+    "unpipe": ["unpipe@1.0.0", "", {}, "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="],
+
+    "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
+
+    "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
+
+    "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
+
+    "zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
+
+    "zod-to-json-schema": ["zod-to-json-schema@3.25.1", "", { "peerDependencies": { "zod": "^3.25 || ^4" } }, "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA=="],
   }
 }

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -31,6 +31,8 @@ bun src/cli.ts fleet sync --manifest .codex-stack/fleet.example.json --dry-run -
 bun src/cli.ts fleet collect --manifest .codex-stack/fleet.example.json --json
 bun src/cli.ts fleet dashboard --manifest .codex-stack/fleet.example.json --out .fleet-site
 bun src/cli.ts fleet remediate --manifest .codex-stack/fleet.example.json --dry-run --json
+bun src/cli.ts mcp inspect --json
+bun src/cli.ts mcp serve
 bun src/cli.ts retro --since "7 days ago"
 bun src/cli.ts retro --since "7 days ago" --artifact-dir .codex-stack/retros
 bun src/cli.ts retro --since "7 days ago" --repo anup4khandelwal/codex-stack
@@ -251,6 +253,20 @@ Notes:
 - Use `.codex-stack/fleet.anup4khandelwal.json` for the current checked-in rollout targeting `autopilot-multi-agent-loop`, `awesome-codex-skills`, and the profile repo.
 - The script writes `report.md`, `report.json`, `comment.md`, `screenshots.json`, and a visual review pack under `visual/index.html` and `visual/manifest.json`.
 - Deploy reports now include a single visual-risk score that combines path/device failures, console errors, snapshot drift, and stale baselines.
+
+## MCP workflow
+
+```bash
+bun src/cli.ts mcp inspect --json
+bun src/cli.ts mcp serve
+```
+
+Notes:
+
+- MCP v1 is `stdio` only.
+- MCP v1 is read-only plus dry-run only. Live `ship`, `issue`, `qa-decide`, `fleet sync --open-prs`, and `fleet remediate --open-prs` are intentionally not exposed.
+- Published QA resources come from local tracked files under `docs/qa/`, including the checked-in `release-readiness-demo` sample report.
+- The MCP server advertises tools for review, QA, preview, deploy, ship planning, fleet planning, retro summaries, and upgrade checks, plus resources for registered modes, skills, QA reports, and fleet metadata.
 
 ## Retro workflow
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -154,3 +154,16 @@ bun src/cli.ts upgrade --json
 bun src/cli.ts upgrade --offline --apply
 bun src/cli.ts upgrade --markdown-out docs/daily-update-check.md --json-out docs/daily-update-check.json
 ```
+
+## MCP mode
+
+```text
+Use codex-stack-mcp to expose codex-stack workflows and published QA evidence to an MCP-capable client without giving it mutation access.
+```
+
+CLI:
+
+```bash
+bun src/cli.ts mcp inspect --json
+bun src/cli.ts mcp serve
+```

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "preview": "bun scripts/preview-verify.ts",
     "deploy": "bun scripts/deploy-verify.ts",
     "fleet": "bun scripts/fleet.ts",
+    "mcp": "bun scripts/mcp-server.ts",
     "ship:dry": "bun scripts/ship-branch.ts --dry-run",
     "retro": "bun scripts/retro-report.ts --since '7 days ago'",
     "upgrade": "bun scripts/upgrade-check.ts",
@@ -38,9 +39,11 @@
     "browse:screenshot": "bun browse/src/cli.ts screenshot"
   },
   "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.27.1",
     "axe-core": "^4.11.0",
     "playwright": "^1.58.2",
-    "pngjs": "^7.0.0"
+    "pngjs": "^7.0.0",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@types/node": "^25.5.0",

--- a/scripts/ci-check.sh
+++ b/scripts/ci-check.sh
@@ -102,6 +102,7 @@ run_ts scripts/build-preview-site.ts --help >/tmp/codex-stack-build-preview-help
 run_ts scripts/deploy-verify.spec.ts >/tmp/codex-stack-deploy-spec.log
 run_ts scripts/build-preview-site.spec.ts >/tmp/codex-stack-build-preview-spec.log
 run_ts scripts/publish-demo-qa.spec.ts >/tmp/codex-stack-publish-demo-qa-spec.log
+run_ts scripts/mcp-server.spec.ts >/tmp/codex-stack-mcp-server-spec.log
 run_ts scripts/cleanup-preview-site.spec.ts >/tmp/codex-stack-preview-cleanup-spec.log
 run_ts scripts/preview-workflow-auth.spec.ts >/tmp/codex-stack-preview-workflow-auth-spec.log
 run_ts scripts/ship-branch.ts --help >/tmp/codex-stack-ship-help.log

--- a/scripts/mcp-server.spec.ts
+++ b/scripts/mcp-server.spec.ts
@@ -1,0 +1,65 @@
+#!/usr/bin/env bun
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+
+const inspect = spawnSync(process.execPath || "bun", ["src/cli.ts", "mcp", "inspect", "--json"], {
+  cwd: process.cwd(),
+  encoding: "utf8",
+  stdio: ["ignore", "pipe", "pipe"],
+});
+assert.equal(inspect.status, 0, inspect.stderr || "Expected mcp inspect to succeed.");
+const manifest = JSON.parse(inspect.stdout || "{}") as {
+  server?: { transport?: string; mutationPolicy?: string };
+  tools?: Array<{ name?: string }>;
+  resources?: Array<{ uri?: string }>;
+  resourceTemplates?: Array<{ uriTemplate?: string }>;
+};
+assert.equal(manifest.server?.transport, "stdio");
+assert.equal(manifest.server?.mutationPolicy, "read-only-plus-dry-run");
+assert.ok(manifest.tools?.some((tool) => tool.name === "codex_stack_review_diff"));
+assert.ok(manifest.tools?.some((tool) => tool.name === "codex_stack_fleet_validate"));
+assert.ok(manifest.resources?.some((resource) => resource.uri === "codex-stack://qa/published/index.json"));
+assert.ok(manifest.resourceTemplates?.some((resource) => resource.uriTemplate === "codex-stack://skills/{mode}"));
+
+const client = new Client({ name: "codex-stack-mcp-spec", version: "1.0.0" }, { capabilities: {} });
+const transport = new StdioClientTransport({
+  command: process.execPath || "bun",
+  args: ["src/cli.ts", "mcp", "serve"],
+  cwd: process.cwd(),
+  stderr: "pipe",
+});
+await client.connect(transport);
+
+const tools = await client.listTools();
+assert.ok(tools.tools.some((tool) => tool.name === "codex_stack_ship_plan"));
+assert.ok(tools.tools.some((tool) => tool.name === "codex_stack_upgrade_check"));
+
+const resources = await client.listResources();
+assert.ok(resources.resources.some((resource) => resource.uri === "codex-stack://modes"));
+assert.ok(resources.resources.some((resource) => resource.uri === "codex-stack://skills/review"));
+assert.ok(resources.resources.some((resource) => resource.uri === "codex-stack://qa/published/release-readiness-demo/report.json"));
+
+const skillResource = await client.readResource({ uri: "codex-stack://skills/review" });
+const skillText = "text" in skillResource.contents[0] ? skillResource.contents[0].text : "";
+assert.match(skillText, /review/i);
+
+const qaReport = await client.readResource({ uri: "codex-stack://qa/published/release-readiness-demo/report.json" });
+const qaText = "text" in qaReport.contents[0] ? qaReport.contents[0].text : "{}";
+const qaPayload = JSON.parse(qaText) as { status?: string; healthScore?: number };
+assert.equal(qaPayload.status, "warning");
+assert.equal(qaPayload.healthScore, 14);
+
+const fleetValidate = await client.callTool({
+  name: "codex_stack_fleet_validate",
+  arguments: { manifest: ".codex-stack/fleet.example.json" },
+});
+assert.equal(fleetValidate.isError, false);
+const structured = (fleetValidate.structuredContent || {}) as { ok?: boolean; result?: { controlRepo?: unknown } };
+assert.equal(structured.ok, true);
+assert.ok(structured.result && typeof structured.result === "object" && "controlRepo" in structured.result);
+
+await client.close();
+await transport.close();
+console.log("mcp-server spec passed");

--- a/scripts/mcp-server.ts
+++ b/scripts/mcp-server.ts
@@ -1,0 +1,34 @@
+#!/usr/bin/env bun
+import process from "node:process";
+import { inspectMcp, serveMcp } from "../src/mcp/server.ts";
+
+function usage(): never {
+  console.log(`mcp-server
+
+Usage:
+  bun scripts/mcp-server.ts serve
+  bun scripts/mcp-server.ts inspect --json
+`);
+  process.exit(1);
+}
+
+async function main(): Promise<void> {
+  const [, , command, ...rest] = process.argv;
+  if (!command) usage();
+  if (command === "serve") {
+    await serveMcp();
+    return;
+  }
+  if (command === "inspect") {
+    const asJson = rest.includes("--json");
+    const payload = inspectMcp();
+    process.stdout.write(asJson ? `${JSON.stringify(payload, null, 2)}\n` : `${JSON.stringify(payload, null, 2)}\n`);
+    return;
+  }
+  usage();
+}
+
+main().catch((error) => {
+  console.error("codex-stack MCP server failed:", error instanceof Error ? error.message : String(error));
+  process.exit(1);
+});

--- a/setup
+++ b/setup
@@ -71,11 +71,12 @@ write_wrapper "setup-browser-cookies" "show setup-browser-cookies"
 write_wrapper "retro" "retro"
 write_wrapper "upgrade" "upgrade"
 write_wrapper "fleet" "fleet"
+write_wrapper "mcp" "mcp"
 
 echo "[codex-stack] local wrappers ready:"
 echo "  $LOCAL_BIN/codex-stack"
 echo "  $LOCAL_BIN/codex-stack-browse"
-echo "  $LOCAL_BIN/{product,tech,review,qa,qa-decide,preview,deploy,ship,browse,setup-browser-cookies,retro,upgrade,fleet}"
+echo "  $LOCAL_BIN/{product,tech,review,qa,qa-decide,preview,deploy,ship,browse,setup-browser-cookies,retro,upgrade,fleet,mcp}"
 echo
 echo "Next steps:"
 echo "  1. bun src/cli.ts list"

--- a/skills/mcp/SKILL.md
+++ b/skills/mcp/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: mcp
+summary: Expose codex-stack workflows and evidence through a local stdio MCP server.
+allowed-tools: Bash, Read, Grep, Glob
+---
+
+# MCP
+
+Use this mode when you need to wire `codex-stack` into an MCP-capable client.
+
+## What it does
+- starts a local `stdio` MCP server from the current repo
+- exposes read-only workflow tools for review, QA, preview, deploy, ship planning, fleet planning, retro, and upgrade checks
+- exposes resources for registered modes, skill files, published QA reports, and fleet metadata
+
+## Operating rules
+- v1 is read-only plus dry-run only
+- do not expose live repo or GitHub mutation through MCP
+- prefer existing JSON-capable scripts rather than re-implementing workflow logic
+
+## Useful commands
+```bash
+bun src/cli.ts mcp inspect --json
+bun src/cli.ts mcp serve
+```

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -27,6 +27,7 @@ Usage:
   codex-stack deploy [--url <url> | --url-template <template>] [--pr <number>] [--branch <ref>] [--sha <sha>] [--repo <owner/name>] [--path <path>] [--device <desktop|tablet|mobile>] [--flow <name>] [--snapshot <name>] [--session <name>] [--session-bundle <path>] [--publish-dir <path>] [--markdown-out <path>] [--json-out <path>] [--comment-out <path>] [--strict-console] [--strict-http] [--wait-timeout <seconds>] [--wait-interval <seconds>] [--fixture <path>] [--qa-fixture <path>] [--readiness-fixture <path>] [--json]
   codex-stack ship [--dry-run] [--message <msg>] [--push] [--pr] [--template <path>] [--reviewer <user>] [--team-reviewer <org/team>] [--assignee <user>] [--assign-self] [--project <title>] [--label <name>] [--milestone <title>] [--verify-url <url>] [--verify-path <path>] [--verify-device <desktop|tablet|mobile>] [--verify-flow <name>] [--verify-snapshot <name>] [--verify-session <name>] [--verify-console-errors] [--update-verify-snapshot] [--draft]
   codex-stack fleet <validate|sync|collect|dashboard> --manifest <path> [args...]
+  codex-stack mcp <serve|inspect> [args...]
   codex-stack retro [--since <range>] [--out <path>] [--json] [--artifact-dir <path>] [--no-artifacts] [--repo <owner/name>] [--no-github]
   codex-stack upgrade [--json] [--json-out <path>] [--markdown-out <path>] [--repo <owner/name>] [--offline] [--apply]
   codex-stack show setup-browser-cookies
@@ -122,6 +123,10 @@ if (command === "ship") {
 
 if (command === "fleet") {
   runScript(path.join("scripts", "fleet.ts"), rest);
+}
+
+if (command === "mcp") {
+  runScript(path.join("scripts", "mcp-server.ts"), rest);
 }
 
 if (command === "retro") {

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -1,0 +1,878 @@
+import fs from "node:fs";
+import path from "node:path";
+import process from "node:process";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { McpServer, ResourceTemplate } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import * as z from "zod/v4";
+import { allModes, findMode } from "../registry.ts";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const ROOT_DIR = path.resolve(__dirname, "..", "..");
+const BUN = process.execPath || "bun";
+const PACKAGE_JSON = path.join(ROOT_DIR, "package.json");
+const VERSION = readPackageVersion();
+const MCP_DIR = path.join(ROOT_DIR, ".codex-stack", "mcp");
+
+const TOOL_OUTPUT_SCHEMA = {
+  ok: z.boolean(),
+  tool: z.string(),
+  command: z.string(),
+  args: z.array(z.string()),
+  result: z.any(),
+  stderr: z.string().optional(),
+};
+
+type JsonObject = Record<string, unknown>;
+type JsonShape = Record<string, z.ZodTypeAny>;
+type ToolInput = Record<string, unknown>;
+
+interface ToolDescriptor {
+  name: string;
+  title: string;
+  description: string;
+  inputSchema: JsonShape;
+  script: string;
+  buildArgs: (input: ToolInput) => string[];
+}
+
+interface ResourceDescriptor {
+  name: string;
+  uri: string;
+  title: string;
+  description: string;
+  mimeType: string;
+}
+
+interface InspectManifest {
+  server: {
+    name: string;
+    version: string;
+    transport: "stdio";
+    mutationPolicy: "read-only-plus-dry-run";
+  };
+  tools: Array<{
+    name: string;
+    title: string;
+    description: string;
+    script: string;
+    inputKeys: string[];
+  }>;
+  resources: ResourceDescriptor[];
+  resourceTemplates: Array<{
+    name: string;
+    uriTemplate: string;
+    title: string;
+    description: string;
+    mimeType: string;
+  }>;
+}
+
+function readPackageVersion(): string {
+  try {
+    const parsed = JSON.parse(fs.readFileSync(PACKAGE_JSON, "utf8")) as { version?: string };
+    return parsed.version || "0.1.0";
+  } catch {
+    return "0.1.0";
+  }
+}
+
+function ensureDir(dirPath: string): void {
+  fs.mkdirSync(dirPath, { recursive: true });
+}
+
+function rel(filePath: string): string {
+  return path.relative(ROOT_DIR, filePath) || ".";
+}
+
+function writeScratchDir(): string {
+  ensureDir(MCP_DIR);
+  return MCP_DIR;
+}
+
+function textContent(text: string) {
+  return [{ type: "text" as const, text }];
+}
+
+function normalizeStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value.map((item) => String(item || "").trim()).filter(Boolean);
+}
+
+function normalizeBoolean(value: unknown): boolean {
+  return value === true;
+}
+
+function normalizeString(value: unknown): string {
+  return String(value || "").trim();
+}
+
+function normalizeNumber(value: unknown): number | null {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string" && value.trim()) {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+  return null;
+}
+
+function resolveFleetManifestPath(): string {
+  const preferred = path.join(ROOT_DIR, ".codex-stack", "fleet.anup4khandelwal.json");
+  const fallback = path.join(ROOT_DIR, ".codex-stack", "fleet.example.json");
+  if (fs.existsSync(preferred)) return preferred;
+  return fallback;
+}
+
+function listPublishedQaSlugs(): string[] {
+  const qaDir = path.join(ROOT_DIR, "docs", "qa");
+  if (!fs.existsSync(qaDir)) return [];
+  return fs.readdirSync(qaDir, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => entry.name)
+    .filter((slug) => fs.existsSync(path.join(qaDir, slug, "report.json")))
+    .sort();
+}
+
+function buildPublishedQaIndex(): JsonObject {
+  const slugs = listPublishedQaSlugs();
+  return {
+    generatedAt: new Date().toISOString(),
+    reports: slugs.map((slug) => ({
+      slug,
+      reportJsonUri: `codex-stack://qa/published/${slug}/report.json`,
+      reportMarkdownUri: `codex-stack://qa/published/${slug}/report.md`,
+      visualManifestUri: fs.existsSync(path.join(ROOT_DIR, "docs", "qa", slug, "visual", "manifest.json"))
+        ? `codex-stack://qa/published/${slug}/visual/manifest.json`
+        : "",
+      localDir: rel(path.join(ROOT_DIR, "docs", "qa", slug)),
+    })),
+  };
+}
+
+function buildFleetStatusIndex(): JsonObject {
+  const statusPath = path.join(ROOT_DIR, ".codex-stack", "fleet-status", "status.json");
+  return {
+    generatedAt: new Date().toISOString(),
+    statusPath: fs.existsSync(statusPath) ? rel(statusPath) : "",
+    available: fs.existsSync(statusPath),
+    status: readJsonFile(statusPath, null),
+  };
+}
+
+function readFileOrFallback(filePath: string, fallback: string): string {
+  if (!fs.existsSync(filePath)) return fallback;
+  return fs.readFileSync(filePath, "utf8");
+}
+
+function readJsonFile(filePath: string, fallback: unknown): unknown {
+  if (!fs.existsSync(filePath)) return fallback;
+  try {
+    return JSON.parse(fs.readFileSync(filePath, "utf8"));
+  } catch {
+    return fallback;
+  }
+}
+
+function jsonResource(uri: string, payload: unknown) {
+  return {
+    contents: [
+      {
+        uri,
+        mimeType: "application/json",
+        text: `${JSON.stringify(payload, null, 2)}\n`,
+      },
+    ],
+  };
+}
+
+function markdownResource(uri: string, text: string) {
+  return {
+    contents: [
+      {
+        uri,
+        mimeType: "text/markdown",
+        text,
+      },
+    ],
+  };
+}
+
+function readResourceText(uri: string, filePath: string, mimeType: string, missingMessage: string) {
+  const text = readFileOrFallback(filePath, missingMessage);
+  return {
+    contents: [
+      {
+        uri,
+        mimeType,
+        text,
+      },
+    ],
+  };
+}
+
+function baseResourceDescriptors(): ResourceDescriptor[] {
+  return [
+    {
+      name: "modes",
+      uri: "codex-stack://modes",
+      title: "Codex-stack modes",
+      description: "Registered codex-stack modes and summaries.",
+      mimeType: "application/json",
+    },
+    {
+      name: "qa-latest-json",
+      uri: "codex-stack://qa/latest/report.json",
+      title: "Latest QA report JSON",
+      description: "The latest local QA report under .codex-stack/qa/latest.json.",
+      mimeType: "application/json",
+    },
+    {
+      name: "qa-latest-markdown",
+      uri: "codex-stack://qa/latest/report.md",
+      title: "Latest QA report Markdown",
+      description: "The latest local QA report under .codex-stack/qa/latest.md.",
+      mimeType: "text/markdown",
+    },
+    {
+      name: "qa-published-index",
+      uri: "codex-stack://qa/published/index.json",
+      title: "Published QA report index",
+      description: "Published docs/qa report slugs and resource URIs.",
+      mimeType: "application/json",
+    },
+    {
+      name: "fleet-manifest",
+      uri: "codex-stack://fleet/manifest.json",
+      title: "Fleet manifest",
+      description: "The active fleet manifest used by this repo.",
+      mimeType: "application/json",
+    },
+    {
+      name: "fleet-member-status-index",
+      uri: "codex-stack://fleet/member-status/index.json",
+      title: "Fleet member status index",
+      description: "Local fleet-status payloads discovered in this repo.",
+      mimeType: "application/json",
+    },
+  ];
+}
+
+function templateDescriptors() {
+  return [
+    {
+      name: "skills",
+      uriTemplate: "codex-stack://skills/{mode}",
+      title: "Codex-stack skill",
+      description: "Raw SKILL.md content for a registered codex-stack mode.",
+      mimeType: "text/markdown",
+    },
+    {
+      name: "qa-published-report-json",
+      uriTemplate: "codex-stack://qa/published/{slug}/report.json",
+      title: "Published QA report JSON",
+      description: "Tracked docs/qa report JSON for a published slug.",
+      mimeType: "application/json",
+    },
+    {
+      name: "qa-published-report-markdown",
+      uriTemplate: "codex-stack://qa/published/{slug}/report.md",
+      title: "Published QA report Markdown",
+      description: "Tracked docs/qa report markdown for a published slug.",
+      mimeType: "text/markdown",
+    },
+    {
+      name: "qa-published-visual-manifest",
+      uriTemplate: "codex-stack://qa/published/{slug}/visual/manifest.json",
+      title: "Published visual manifest",
+      description: "Tracked visual manifest for a published QA report slug.",
+      mimeType: "application/json",
+    },
+  ];
+}
+
+function toolDescriptors(): ToolDescriptor[] {
+  return [
+    {
+      name: "codex_stack_review_diff",
+      title: "Review diff",
+      description: "Run codex-stack diff review and return the JSON result.",
+      script: "scripts/review-diff.ts",
+      inputSchema: {
+        baseRef: z.string().optional().describe("Optional base ref, e.g. origin/main"),
+      },
+      buildArgs: (input) => {
+        const args: string[] = ["--json"];
+        const baseRef = normalizeString(input.baseRef);
+        if (baseRef) args.push("--base", baseRef);
+        return args;
+      },
+    },
+    {
+      name: "codex_stack_qa_run",
+      title: "Run QA",
+      description: "Run QA against a URL with flows, snapshot checks, a11y, and performance options.",
+      script: "scripts/qa-run.ts",
+      inputSchema: {
+        url: z.string().describe("URL to verify"),
+        flows: z.array(z.string()).optional(),
+        snapshot: z.string().optional(),
+        session: z.string().optional(),
+        sessionBundle: z.string().optional(),
+        mode: z.enum(["quick", "full", "regression", "diff-aware"]).optional(),
+        baseRef: z.string().optional(),
+        a11y: z.boolean().optional(),
+        a11yScopes: z.array(z.string()).optional(),
+        a11yImpact: z.enum(["critical", "serious", "moderate", "minor"]).optional(),
+        perf: z.boolean().optional(),
+        perfBudgets: z.array(z.string()).optional(),
+        perfWaitMs: z.number().int().nonnegative().optional(),
+      },
+      buildArgs: (input) => {
+        const args: string[] = [normalizeString(input.url), "--json"];
+        for (const flow of normalizeStringArray(input.flows)) args.push("--flow", flow);
+        const snapshot = normalizeString(input.snapshot);
+        if (snapshot) args.push("--snapshot", snapshot);
+        const session = normalizeString(input.session);
+        if (session) args.push("--session", session);
+        const sessionBundle = normalizeString(input.sessionBundle);
+        if (sessionBundle) args.push("--session-bundle", sessionBundle);
+        const mode = normalizeString(input.mode);
+        if (mode) args.push("--mode", mode);
+        const baseRef = normalizeString(input.baseRef);
+        if (baseRef) args.push("--base-ref", baseRef);
+        if (normalizeBoolean(input.a11y)) {
+          args.push("--a11y");
+          const impact = normalizeString(input.a11yImpact) || "serious";
+          args.push("--a11y-impact", impact);
+          for (const scope of normalizeStringArray(input.a11yScopes)) args.push("--a11y-scope", scope);
+        }
+        if (normalizeBoolean(input.perf)) {
+          args.push("--perf");
+          const perfWaitMs = normalizeNumber(input.perfWaitMs);
+          if (perfWaitMs !== null) args.push("--perf-wait-ms", String(perfWaitMs));
+          for (const budget of normalizeStringArray(input.perfBudgets)) args.push("--perf-budget", budget);
+        }
+        return args;
+      },
+    },
+    {
+      name: "codex_stack_preview_verify",
+      title: "Verify preview",
+      description: "Resolve and verify a preview URL with page/device checks and QA evidence.",
+      script: "scripts/preview-verify.ts",
+      inputSchema: {
+        url: z.string().optional(),
+        urlTemplate: z.string().optional(),
+        pr: z.number().int().positive().optional(),
+        branch: z.string().optional(),
+        sha: z.string().optional(),
+        repo: z.string().optional(),
+        paths: z.array(z.string()).optional(),
+        devices: z.array(z.enum(["desktop", "tablet", "mobile"])).optional(),
+        flows: z.array(z.string()).optional(),
+        snapshots: z.array(z.string()).optional(),
+        session: z.string().optional(),
+        sessionBundle: z.string().optional(),
+        waitTimeout: z.number().int().positive().optional(),
+        waitInterval: z.number().int().positive().optional(),
+        strictConsole: z.boolean().optional(),
+        strictHttp: z.boolean().optional(),
+        a11y: z.boolean().optional(),
+        a11yScopes: z.array(z.string()).optional(),
+        a11yImpact: z.enum(["critical", "serious", "moderate", "minor"]).optional(),
+        perf: z.boolean().optional(),
+        perfBudgets: z.array(z.string()).optional(),
+        perfWaitMs: z.number().int().nonnegative().optional(),
+      },
+      buildArgs: (input) => buildDeployLikeArgs(input),
+    },
+    {
+      name: "codex_stack_deploy_verify",
+      title: "Verify deploy",
+      description: "Verify a preview or staging deploy across pages, devices, flows, and evidence checks.",
+      script: "scripts/deploy-verify.ts",
+      inputSchema: {
+        url: z.string().optional(),
+        urlTemplate: z.string().optional(),
+        pr: z.number().int().positive().optional(),
+        branch: z.string().optional(),
+        sha: z.string().optional(),
+        repo: z.string().optional(),
+        paths: z.array(z.string()).optional(),
+        devices: z.array(z.enum(["desktop", "tablet", "mobile"])).optional(),
+        flows: z.array(z.string()).optional(),
+        snapshots: z.array(z.string()).optional(),
+        session: z.string().optional(),
+        sessionBundle: z.string().optional(),
+        waitTimeout: z.number().int().positive().optional(),
+        waitInterval: z.number().int().positive().optional(),
+        strictConsole: z.boolean().optional(),
+        strictHttp: z.boolean().optional(),
+        a11y: z.boolean().optional(),
+        a11yScopes: z.array(z.string()).optional(),
+        a11yImpact: z.enum(["critical", "serious", "moderate", "minor"]).optional(),
+        perf: z.boolean().optional(),
+        perfBudgets: z.array(z.string()).optional(),
+        perfWaitMs: z.number().int().nonnegative().optional(),
+      },
+      buildArgs: (input) => buildDeployLikeArgs(input),
+    },
+    {
+      name: "codex_stack_ship_plan",
+      title: "Plan ship",
+      description: "Run ship in dry-run mode and return the JSON shipping plan without git or GitHub mutation.",
+      script: "scripts/ship-branch.ts",
+      inputSchema: {
+        message: z.string().optional(),
+        title: z.string().optional(),
+        body: z.string().optional(),
+        bodyFile: z.string().optional(),
+        template: z.string().optional(),
+        reviewers: z.array(z.string()).optional(),
+        teamReviewers: z.array(z.string()).optional(),
+        assignees: z.array(z.string()).optional(),
+        assignSelf: z.boolean().optional(),
+        project: z.string().optional(),
+        labels: z.array(z.string()).optional(),
+        milestone: z.string().optional(),
+        draft: z.boolean().optional(),
+        noAutoLabels: z.boolean().optional(),
+        noAutoReviewers: z.boolean().optional(),
+      },
+      buildArgs: (input) => {
+        const args: string[] = ["--dry-run", "--json"];
+        const pairs: Array<[string, string]> = [
+          ["--message", normalizeString(input.message)],
+          ["--title", normalizeString(input.title)],
+          ["--body", normalizeString(input.body)],
+          ["--body-file", normalizeString(input.bodyFile)],
+          ["--template", normalizeString(input.template)],
+          ["--project", normalizeString(input.project)],
+          ["--milestone", normalizeString(input.milestone)],
+        ];
+        for (const [flag, value] of pairs) if (value) args.push(flag, value);
+        for (const reviewer of normalizeStringArray(input.reviewers)) args.push("--reviewer", reviewer);
+        for (const teamReviewer of normalizeStringArray(input.teamReviewers)) args.push("--team-reviewer", teamReviewer);
+        for (const assignee of normalizeStringArray(input.assignees)) args.push("--assignee", assignee);
+        for (const label of normalizeStringArray(input.labels)) args.push("--label", label);
+        if (normalizeBoolean(input.assignSelf)) args.push("--assign-self");
+        if (normalizeBoolean(input.draft)) args.push("--draft");
+        if (normalizeBoolean(input.noAutoLabels)) args.push("--no-auto-labels");
+        if (normalizeBoolean(input.noAutoReviewers)) args.push("--no-auto-reviewers");
+        return args;
+      },
+    },
+    {
+      name: "codex_stack_fleet_validate",
+      title: "Validate fleet",
+      description: "Validate the fleet manifest and policy-pack references.",
+      script: "scripts/fleet.ts",
+      inputSchema: {
+        manifest: z.string().describe("Fleet manifest path"),
+      },
+      buildArgs: (input) => ["validate", "--manifest", normalizeString(input.manifest), "--json"],
+    },
+    {
+      name: "codex_stack_fleet_collect",
+      title: "Collect fleet status",
+      description: "Collect normalized health across the fleet manifest.",
+      script: "scripts/fleet.ts",
+      inputSchema: {
+        manifest: z.string().describe("Fleet manifest path"),
+      },
+      buildArgs: (input) => ["collect", "--manifest", normalizeString(input.manifest), "--json"],
+    },
+    {
+      name: "codex_stack_fleet_sync_plan",
+      title: "Plan fleet sync",
+      description: "Compute the dry-run rollout plan for the fleet manifest.",
+      script: "scripts/fleet.ts",
+      inputSchema: {
+        manifest: z.string().describe("Fleet manifest path"),
+        branchName: z.string().optional(),
+      },
+      buildArgs: (input) => {
+        const args = ["sync", "--manifest", normalizeString(input.manifest), "--dry-run", "--json"];
+        const branchName = normalizeString(input.branchName);
+        if (branchName) args.push("--branch-name", branchName);
+        return args;
+      },
+    },
+    {
+      name: "codex_stack_fleet_remediate_plan",
+      title: "Plan fleet remediation",
+      description: "Compute the dry-run remediation plan for the fleet manifest.",
+      script: "scripts/fleet.ts",
+      inputSchema: {
+        manifest: z.string().describe("Fleet manifest path"),
+        issueRepo: z.string().optional(),
+      },
+      buildArgs: (input) => {
+        const args = ["remediate", "--manifest", normalizeString(input.manifest), "--dry-run", "--json"];
+        const issueRepo = normalizeString(input.issueRepo);
+        if (issueRepo) args.push("--issue-repo", issueRepo);
+        return args;
+      },
+    },
+    {
+      name: "codex_stack_retro_summary",
+      title: "Generate retrospective",
+      description: "Generate a retrospective summary from git and optional GitHub metadata.",
+      script: "scripts/retro-report.ts",
+      inputSchema: {
+        since: z.string().optional(),
+        repo: z.string().optional(),
+        noGithub: z.boolean().optional(),
+        noArtifacts: z.boolean().optional(),
+        githubLimit: z.number().int().positive().optional(),
+      },
+      buildArgs: (input) => {
+        const args: string[] = ["--json"];
+        const since = normalizeString(input.since);
+        const repo = normalizeString(input.repo);
+        const githubLimit = normalizeNumber(input.githubLimit);
+        if (since) args.push("--since", since);
+        if (repo) args.push("--repo", repo);
+        if (githubLimit !== null) args.push("--github-limit", String(githubLimit));
+        if (normalizeBoolean(input.noGithub)) args.push("--no-github");
+        if (normalizeBoolean(input.noArtifacts)) args.push("--no-artifacts");
+        return args;
+      },
+    },
+    {
+      name: "codex_stack_upgrade_check",
+      title: "Check upgrades",
+      description: "Audit dependency, workflow, and install drift.",
+      script: "scripts/upgrade-check.ts",
+      inputSchema: {
+        repo: z.string().optional(),
+        offline: z.boolean().optional(),
+      },
+      buildArgs: (input) => {
+        const args: string[] = ["--json"];
+        const repo = normalizeString(input.repo);
+        if (repo) args.push("--repo", repo);
+        if (normalizeBoolean(input.offline)) args.push("--offline");
+        return args;
+      },
+    },
+  ];
+}
+
+function buildDeployLikeArgs(input: ToolInput): string[] {
+  const args: string[] = ["--json"];
+  const url = normalizeString(input.url);
+  const urlTemplate = normalizeString(input.urlTemplate);
+  const branch = normalizeString(input.branch);
+  const sha = normalizeString(input.sha);
+  const repo = normalizeString(input.repo);
+  const session = normalizeString(input.session);
+  const sessionBundle = normalizeString(input.sessionBundle);
+  const waitTimeout = normalizeNumber(input.waitTimeout);
+  const waitInterval = normalizeNumber(input.waitInterval);
+  const pr = normalizeNumber(input.pr);
+
+  if (url) args.push("--url", url);
+  if (urlTemplate) args.push("--url-template", urlTemplate);
+  if (pr !== null) args.push("--pr", String(pr));
+  if (branch) args.push("--branch", branch);
+  if (sha) args.push("--sha", sha);
+  if (repo) args.push("--repo", repo);
+  for (const routePath of normalizeStringArray(input.paths)) args.push("--path", routePath);
+  for (const device of normalizeStringArray(input.devices)) args.push("--device", device);
+  for (const flow of normalizeStringArray(input.flows)) args.push("--flow", flow);
+  for (const snapshot of normalizeStringArray(input.snapshots)) args.push("--snapshot", snapshot);
+  if (session) args.push("--session", session);
+  if (sessionBundle) args.push("--session-bundle", sessionBundle);
+  if (waitTimeout !== null) args.push("--wait-timeout", String(waitTimeout));
+  if (waitInterval !== null) args.push("--wait-interval", String(waitInterval));
+  if (normalizeBoolean(input.strictConsole)) args.push("--strict-console");
+  if (normalizeBoolean(input.strictHttp)) args.push("--strict-http");
+  if (normalizeBoolean(input.a11y)) {
+    args.push("--a11y");
+    const impact = normalizeString(input.a11yImpact) || "serious";
+    args.push("--a11y-impact", impact);
+    for (const scope of normalizeStringArray(input.a11yScopes)) args.push("--a11y-scope", scope);
+  }
+  if (normalizeBoolean(input.perf)) {
+    args.push("--perf");
+    const perfWaitMs = normalizeNumber(input.perfWaitMs);
+    if (perfWaitMs !== null) args.push("--perf-wait-ms", String(perfWaitMs));
+    for (const budget of normalizeStringArray(input.perfBudgets)) args.push("--perf-budget", budget);
+  }
+  args.push("--publish-dir", path.join(rel(writeScratchDir()), "deploy-output"));
+  return args;
+}
+
+function buildManifest(): InspectManifest {
+  return {
+    server: {
+      name: "codex-stack",
+      version: VERSION,
+      transport: "stdio",
+      mutationPolicy: "read-only-plus-dry-run",
+    },
+    tools: toolDescriptors().map((tool) => ({
+      name: tool.name,
+      title: tool.title,
+      description: tool.description,
+      script: tool.script,
+      inputKeys: Object.keys(tool.inputSchema),
+    })),
+    resources: baseResourceDescriptors(),
+    resourceTemplates: templateDescriptors(),
+  };
+}
+
+function runJsonScript(tool: ToolDescriptor, args: string[]) {
+  const commandPath = path.join(ROOT_DIR, tool.script);
+  const result = spawnSync(BUN, [commandPath, ...args], {
+    cwd: ROOT_DIR,
+    encoding: "utf8",
+  });
+  const stderr = String(result.stderr || "").trim();
+  const stdout = String(result.stdout || "").trim();
+  if (result.status !== 0) {
+    return {
+      ok: false,
+      tool: tool.name,
+      command: rel(commandPath),
+      args,
+      result: stderr || stdout || `Command exited with status ${result.status ?? 1}`,
+      stderr,
+    };
+  }
+  try {
+    return {
+      ok: true,
+      tool: tool.name,
+      command: rel(commandPath),
+      args,
+      result: stdout ? JSON.parse(stdout) : {},
+      stderr,
+    };
+  } catch {
+    return {
+      ok: false,
+      tool: tool.name,
+      command: rel(commandPath),
+      args,
+      result: stdout,
+      stderr: stderr || "Expected JSON output from wrapped codex-stack script.",
+    };
+  }
+}
+
+function toolText(payload: JsonObject): string {
+  return `${JSON.stringify(payload, null, 2)}\n`;
+}
+
+function createServer(): McpServer {
+  const server = new McpServer({
+    name: "codex-stack",
+    version: VERSION,
+  });
+
+  for (const descriptor of toolDescriptors()) {
+    server.registerTool(descriptor.name, {
+      title: descriptor.title,
+      description: descriptor.description,
+      inputSchema: descriptor.inputSchema,
+      outputSchema: TOOL_OUTPUT_SCHEMA,
+    }, async (input) => {
+      const payload = runJsonScript(descriptor, descriptor.buildArgs((input || {}) as ToolInput));
+      return {
+        content: textContent(toolText(payload)),
+        structuredContent: payload,
+        isError: !payload.ok,
+      };
+    });
+  }
+
+  const modesUri = "codex-stack://modes";
+  server.registerResource("modes", modesUri, {
+    title: "Codex-stack modes",
+    description: "Registered codex-stack modes and summaries.",
+    mimeType: "application/json",
+  }, async () => jsonResource(modesUri, {
+    generatedAt: new Date().toISOString(),
+    modes: allModes().map((mode) => ({
+      name: mode.name,
+      role: mode.role,
+      summary: mode.summary,
+      skillPath: mode.skillPath,
+    })),
+  }));
+
+  const latestJsonUri = "codex-stack://qa/latest/report.json";
+  server.registerResource("qa-latest-json", latestJsonUri, {
+    title: "Latest QA report JSON",
+    description: "Latest local QA report JSON.",
+    mimeType: "application/json",
+  }, async () => jsonResource(latestJsonUri, readJsonFile(path.join(ROOT_DIR, ".codex-stack", "qa", "latest.json"), {
+    status: "missing",
+    message: "No local QA latest report found.",
+  })));
+
+  const latestMarkdownUri = "codex-stack://qa/latest/report.md";
+  server.registerResource("qa-latest-markdown", latestMarkdownUri, {
+    title: "Latest QA report Markdown",
+    description: "Latest local QA report markdown.",
+    mimeType: "text/markdown",
+  }, async () => markdownResource(latestMarkdownUri, readFileOrFallback(path.join(ROOT_DIR, ".codex-stack", "qa", "latest.md"), "# No local QA report\n\nNo `.codex-stack/qa/latest.md` file is present yet.\n")));
+
+  const qaPublishedIndexUri = "codex-stack://qa/published/index.json";
+  server.registerResource("qa-published-index", qaPublishedIndexUri, {
+    title: "Published QA report index",
+    description: "Tracked docs/qa report slugs and resource URIs.",
+    mimeType: "application/json",
+  }, async () => jsonResource(qaPublishedIndexUri, buildPublishedQaIndex()));
+
+  const fleetManifestUri = "codex-stack://fleet/manifest.json";
+  server.registerResource("fleet-manifest", fleetManifestUri, {
+    title: "Fleet manifest",
+    description: "The active fleet manifest used by this repo.",
+    mimeType: "application/json",
+  }, async () => {
+    const manifestPath = resolveFleetManifestPath();
+    return jsonResource(fleetManifestUri, readJsonFile(manifestPath, {
+      status: "missing",
+      message: `No fleet manifest found at ${rel(manifestPath)}.`,
+    }));
+  });
+
+  const fleetStatusUri = "codex-stack://fleet/member-status/index.json";
+  server.registerResource("fleet-member-status-index", fleetStatusUri, {
+    title: "Fleet member status index",
+    description: "Local fleet status payloads discovered in this repo.",
+    mimeType: "application/json",
+  }, async () => jsonResource(fleetStatusUri, buildFleetStatusIndex()));
+
+  server.registerResource(
+    "skill-resource",
+    new ResourceTemplate("codex-stack://skills/{mode}", {
+      list: async () => ({
+        resources: allModes().map((mode) => ({
+          uri: `codex-stack://skills/${mode.name}`,
+          name: `${mode.name}-skill`,
+          title: `${mode.name} skill`,
+          description: mode.summary,
+          mimeType: "text/markdown",
+        })),
+      }),
+    }),
+    {
+      title: "Codex-stack skill",
+      description: "Raw SKILL.md content for a registered codex-stack mode.",
+      mimeType: "text/markdown",
+    },
+    async (uri, variables) => {
+      const modeName = String(variables.mode || "");
+      const mode = findMode(modeName);
+      const text = mode
+        ? fs.readFileSync(mode.skillPath, "utf8")
+        : `# Missing skill\n\nNo skill was found for mode \`${modeName}\`.\n`;
+      return markdownResource(uri.toString(), text);
+    },
+  );
+
+  server.registerResource(
+    "qa-published-report-json",
+    new ResourceTemplate("codex-stack://qa/published/{slug}/report.json", {
+      list: async () => ({
+        resources: listPublishedQaSlugs().map((slug) => ({
+          uri: `codex-stack://qa/published/${slug}/report.json`,
+          name: `${slug}-report-json`,
+          title: `${slug} report JSON`,
+          description: `Tracked QA report JSON for ${slug}.`,
+          mimeType: "application/json",
+        })),
+      }),
+    }),
+    {
+      title: "Published QA report JSON",
+      description: "Tracked docs/qa report JSON for a published slug.",
+      mimeType: "application/json",
+    },
+    async (uri, variables) => {
+      const slug = String(variables.slug || "");
+      const filePath = path.join(ROOT_DIR, "docs", "qa", slug, "report.json");
+      return jsonResource(uri.toString(), readJsonFile(filePath, {
+        status: "missing",
+        slug,
+        message: `No tracked report.json exists for docs/qa/${slug}.`,
+      }));
+    },
+  );
+
+  server.registerResource(
+    "qa-published-report-markdown",
+    new ResourceTemplate("codex-stack://qa/published/{slug}/report.md", {
+      list: async () => ({
+        resources: listPublishedQaSlugs().map((slug) => ({
+          uri: `codex-stack://qa/published/${slug}/report.md`,
+          name: `${slug}-report-markdown`,
+          title: `${slug} report Markdown`,
+          description: `Tracked QA report markdown for ${slug}.`,
+          mimeType: "text/markdown",
+        })),
+      }),
+    }),
+    {
+      title: "Published QA report Markdown",
+      description: "Tracked docs/qa report markdown for a published slug.",
+      mimeType: "text/markdown",
+    },
+    async (uri, variables) => {
+      const slug = String(variables.slug || "");
+      const filePath = path.join(ROOT_DIR, "docs", "qa", slug, "report.md");
+      return readResourceText(uri.toString(), filePath, "text/markdown", `# Missing report\n\nNo tracked report.md exists for docs/qa/${slug}.\n`);
+    },
+  );
+
+  server.registerResource(
+    "qa-published-visual-manifest",
+    new ResourceTemplate("codex-stack://qa/published/{slug}/visual/manifest.json", {
+      list: async () => ({
+        resources: listPublishedQaSlugs()
+          .filter((slug) => fs.existsSync(path.join(ROOT_DIR, "docs", "qa", slug, "visual", "manifest.json")))
+          .map((slug) => ({
+            uri: `codex-stack://qa/published/${slug}/visual/manifest.json`,
+            name: `${slug}-visual-manifest`,
+            title: `${slug} visual manifest`,
+            description: `Tracked visual manifest for ${slug}.`,
+            mimeType: "application/json",
+          })),
+      }),
+    }),
+    {
+      title: "Published visual manifest",
+      description: "Tracked visual manifest for a published QA slug.",
+      mimeType: "application/json",
+    },
+    async (uri, variables) => {
+      const slug = String(variables.slug || "");
+      const filePath = path.join(ROOT_DIR, "docs", "qa", slug, "visual", "manifest.json");
+      return jsonResource(uri.toString(), readJsonFile(filePath, {
+        status: "missing",
+        slug,
+        message: `No tracked visual manifest exists for docs/qa/${slug}.`,
+      }));
+    },
+  );
+
+  return server;
+}
+
+export async function serveMcp(): Promise<void> {
+  const server = createServer();
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+  console.error("codex-stack MCP server running on stdio");
+}
+
+export function inspectMcp(): InspectManifest {
+  return buildManifest();
+}

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -85,6 +85,12 @@ export const modeRegistry: ModeDefinition[] = [
     summary: "Roll out codex-stack policies across multiple repos and aggregate org-level health.",
     skillPath: path.join(rootDir, "skills", "fleet", "SKILL.md"),
   },
+  {
+    name: "mcp",
+    role: "Interop engineer",
+    summary: "Expose codex-stack workflows and evidence to MCP-capable clients over stdio.",
+    skillPath: path.join(rootDir, "skills", "mcp", "SKILL.md"),
+  },
 ];
 
 export function findMode(name: string): ModeDefinition | undefined {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-export type ModeName = "product" | "tech" | "review" | "qa" | "qa-decide" | "preview" | "deploy" | "ship" | "browse" | "setup-browser-cookies" | "retro" | "upgrade" | "fleet";
+export type ModeName = "product" | "tech" | "review" | "qa" | "qa-decide" | "preview" | "deploy" | "ship" | "browse" | "setup-browser-cookies" | "retro" | "upgrade" | "fleet" | "mcp";
 
 export interface ModeDefinition {
   name: ModeName;


### PR DESCRIPTION
## Summary
- add a local stdio MCP server with read-only and dry-run codex-stack tools
- expose MCP resources for modes, skills, published QA reports, and fleet metadata
- add MCP docs, skill wiring, and integration tests

Closes #81

## Validation
- bun scripts/mcp-server.spec.ts
- bun run typecheck
- bun run smoke