### PR TITLE
feat: add autonomous heartbeat execution loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,11 +212,11 @@ bun src/cli.ts fleet remediate --manifest .codex-stack/fleet.example.json --dry-
 bun src/cli.ts agents add --name lead-1 --runtime codex --role manager --team platform --status working
 bun src/cli.ts agents dashboard --out .codex-stack/control-plane/dashboard
 bun src/cli.ts goals add --id release-q2 --title "Release Q2 hardening" --type initiative --owner lead-1 --status active
-bun src/cli.ts goals task add --id review-contracts --goal release-q2 --title "Review agent contracts" --assignee reviewer-1
+bun src/cli.ts goals task add --id review-contracts --goal release-q2 --title "Review agent contracts" --assignee reviewer-1 --action-kind review --action-arg --base --action-arg origin/main --expected-minutes 10
 bun src/cli.ts goals queue --json
 bun src/cli.ts agents budget set --agent reviewer-1 --window daily --max-runs 8 --max-minutes 120 --max-cost-units 20
 bun src/cli.ts heartbeat schedule add --agent reviewer-1 --task review-contracts --trigger cron --expression "*/30 * * * *" --summary "Review new queue items"
-bun src/cli.ts heartbeat beat --agent reviewer-1 --task review-contracts --summary "Reviewed current diff" --next-action "Run QA after approval"
+bun src/cli.ts heartbeat run-due --agent reviewer-1 --max-agents 1 --max-tasks 1 --json
 bun src/cli.ts approvals gate --agent reviewer-1 --kind ship-pr --target review-contracts --json
 bun src/cli.ts mcp inspect --json
 bun src/cli.ts mcp serve
@@ -277,6 +277,7 @@ Core ideas:
 - track initiative and repo goals explicitly
 - assign persistent queued work and delegate parent tasks into child tasks instead of only running one-shot commands
 - schedule heartbeats with continuity state, retry limits, and cooloff windows per agent
+- execute one bounded workflow step per agent heartbeat, capture execution history, and resume from continuity state on the next tick
 - enforce budget limits and explicit approvals for high-risk actions, including `ship` and rollout remediation preflight
 - render a static dashboard under `.codex-stack/control-plane/dashboard/`
 
@@ -286,12 +287,13 @@ Useful commands:
 bun src/cli.ts agents add --name lead-1 --runtime codex --role manager --team platform --status working
 bun src/cli.ts agents add --name reviewer-1 --runtime claude-code --role reviewer --team platform --manager lead-1
 bun src/cli.ts goals add --id release-q2 --title "Release Q2 hardening" --type initiative --owner lead-1 --status active
-bun src/cli.ts goals task add --id review-contracts --goal release-q2 --title "Review agent contracts" --assignee reviewer-1
-bun src/cli.ts goals task delegate review-contracts --id qa-contracts --title "Run delegated QA" --assignee qa-1
+bun src/cli.ts goals task add --id review-contracts --goal release-q2 --title "Review agent contracts" --assignee reviewer-1 --action-kind review --action-arg --base --action-arg origin/main --expected-minutes 10
+bun src/cli.ts goals task add --id release-train --goal release-q2 --title "Coordinate release" --assignee lead-1 --action-kind custom-command --action-arg node --action-arg -e --action-arg "console.log(JSON.stringify({summary:'lead ok',nextAction:'complete'}))" --delegate-id qa-contracts --delegate-title "Run delegated QA" --delegate-assignee qa-1 --delegate-action-kind qa --delegate-action-arg http://127.0.0.1:4173/dashboard --delegate-action-arg --flow --delegate-action-arg release-dashboard --delegate-expected-minutes 15
 bun src/cli.ts agents budget set --agent reviewer-1 --window daily --max-runs 8 --max-minutes 120 --max-cost-units 20
 bun src/cli.ts heartbeat schedule add --agent reviewer-1 --task review-contracts --trigger cron --expression "*/30 * * * *" --summary "Review queue" --retry-limit 2 --cooldown-minutes 30
-bun src/cli.ts heartbeat due --agent reviewer-1 --json
-bun src/cli.ts heartbeat beat --agent reviewer-1 --task review-contracts --summary "Reviewed queue" --next-action "Open PR after approval" --require-approval ship-pr --approval-target review-contracts
+bun src/cli.ts heartbeat inspect --agent reviewer-1 --json
+bun src/cli.ts heartbeat run-due --agent reviewer-1 --max-agents 1 --max-tasks 1 --json
+bun src/cli.ts heartbeat run-agent --agent lead-1 --json
 bun src/cli.ts approvals approve <id> --by lead-1 --note "Approved release work"
 bun src/cli.ts ship --dry-run --pr --control-agent reviewer-1 --control-state .codex-stack/control-plane/state.json
 bun src/cli.ts fleet remediate --manifest .codex-stack/fleet.example.json --dry-run --open-prs --control-agent lead-1 --control-state .codex-stack/control-plane/state.json --json

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -34,13 +34,14 @@ bun src/cli.ts fleet remediate --manifest .codex-stack/fleet.example.json --dry-
 bun src/cli.ts agents add --name lead-1 --runtime codex --role manager --team platform --status working
 bun src/cli.ts agents dashboard --out .codex-stack/control-plane/dashboard
 bun src/cli.ts goals add --id release-q2 --title "Release Q2 hardening" --type initiative --owner lead-1 --status active
-bun src/cli.ts goals task add --id review-contracts --goal release-q2 --title "Review agent contracts" --assignee reviewer-1
-bun src/cli.ts goals task delegate review-contracts --id qa-contracts --title "Run delegated QA" --assignee qa-1
+bun src/cli.ts goals task add --id review-contracts --goal release-q2 --title "Review agent contracts" --assignee reviewer-1 --action-kind review --action-arg --base --action-arg origin/main --expected-minutes 10
+bun src/cli.ts goals task add --id release-train --goal release-q2 --title "Coordinate release" --assignee lead-1 --action-kind custom-command --action-arg node --action-arg -e --action-arg "console.log(JSON.stringify({summary:'lead ok',nextAction:'complete'}))" --delegate-id qa-contracts --delegate-title "Run delegated QA" --delegate-assignee qa-1 --delegate-action-kind qa --delegate-action-arg http://127.0.0.1:4173/dashboard --delegate-action-arg --flow --delegate-action-arg release-dashboard --delegate-expected-minutes 15
 bun src/cli.ts goals queue --json
 bun src/cli.ts agents budget set --agent reviewer-1 --window daily --max-runs 8 --max-minutes 120 --max-cost-units 20
 bun src/cli.ts heartbeat schedule add --agent reviewer-1 --task review-contracts --trigger cron --expression "*/30 * * * *" --summary "Review queue" --retry-limit 2 --cooldown-minutes 30
-bun src/cli.ts heartbeat due --agent reviewer-1 --json
-bun src/cli.ts heartbeat beat --agent reviewer-1 --task review-contracts --summary "Reviewed queue" --next-action "Open PR after approval"
+bun src/cli.ts heartbeat inspect --agent reviewer-1 --json
+bun src/cli.ts heartbeat run-due --agent reviewer-1 --max-agents 1 --max-tasks 1 --json
+bun src/cli.ts heartbeat run-agent --agent lead-1 --json
 bun src/cli.ts approvals gate --agent reviewer-1 --kind ship-pr --target review-contracts --json
 bun src/cli.ts ship --dry-run --pr --control-agent reviewer-1 --control-state .codex-stack/control-plane/state.json
 bun src/cli.ts fleet remediate --manifest .codex-stack/fleet.example.json --dry-run --open-prs --control-agent lead-1 --control-state .codex-stack/control-plane/state.json --json
@@ -277,8 +278,8 @@ bun src/cli.ts agents list --json
 bun src/cli.ts agents add --name lead-1 --runtime codex --role manager --team platform --status working
 bun src/cli.ts agents add --name reviewer-1 --runtime claude-code --role reviewer --team platform --manager lead-1
 bun src/cli.ts goals add --id release-q2 --title "Release Q2 hardening" --type initiative --owner lead-1 --status active
-bun src/cli.ts goals task add --id review-contracts --goal release-q2 --title "Review agent contracts" --assignee reviewer-1
-bun src/cli.ts goals task delegate review-contracts --id qa-contracts --title "Run delegated QA" --assignee qa-1
+bun src/cli.ts goals task add --id review-contracts --goal release-q2 --title "Review agent contracts" --assignee reviewer-1 --action-kind review --action-arg --base --action-arg origin/main --expected-minutes 10
+bun src/cli.ts goals task add --id release-train --goal release-q2 --title "Coordinate release" --assignee lead-1 --action-kind custom-command --action-arg node --action-arg -e --action-arg "console.log(JSON.stringify({summary:'lead ok',nextAction:'complete'}))" --delegate-id qa-contracts --delegate-title "Run delegated QA" --delegate-assignee qa-1 --delegate-action-kind qa --delegate-action-arg http://127.0.0.1:4173/dashboard --delegate-action-arg --flow --delegate-action-arg release-dashboard --delegate-expected-minutes 15
 bun src/cli.ts goals queue --assignee reviewer-1 --json
 bun src/cli.ts agents dashboard --out .codex-stack/control-plane/dashboard
 ```
@@ -287,7 +288,7 @@ Notes:
 
 - The local state file defaults to `.codex-stack/control-plane/state.json`.
 - `agents` manages roster metadata such as runtime, role, team, manager, and staffing status.
-- `goals` manages goal hierarchy plus a persistent task queue with claim, reassign, block, unblock, complete, and delegate actions.
+- `goals` manages goal hierarchy plus a persistent task queue with claim, reassign, block, unblock, complete, delegate, and executable action metadata.
 - `agents dashboard` writes `index.html`, `manifest.json`, and `summary.md` so you can inspect the local control plane without needing a server.
 
 ## Heartbeat and governance workflow
@@ -295,7 +296,9 @@ Notes:
 ```bash
 bun src/cli.ts agents budget set --agent ship-1 --window daily --max-runs 8 --max-minutes 120 --max-cost-units 20
 bun src/cli.ts heartbeat schedule add --agent ship-1 --task ship-pr --trigger cron --expression "*/15 * * * *" --summary "Check release branch" --retry-limit 2 --cooldown-minutes 30
-bun src/cli.ts heartbeat due --agent ship-1 --json
+bun src/cli.ts heartbeat inspect --agent ship-1 --json
+bun src/cli.ts heartbeat run-due --max-agents 2 --max-tasks 2 --json
+bun src/cli.ts heartbeat run-agent --agent ship-1 --json
 bun src/cli.ts heartbeat beat --agent ship-1 --task ship-pr --summary "Ready to open PR" --next-action "Open PR after approval" --require-approval ship-pr --approval-target ship-pr --json
 bun src/cli.ts approvals list --agent ship-1 --status pending --json
 bun src/cli.ts approvals approve <approval-id> --by lead-1 --note "Approved release PR"
@@ -307,7 +310,9 @@ Notes:
 
 - `heartbeat schedule` records named wakeups using `manual`, `cron`, or `event` triggers.
 - `heartbeat schedule` also tracks retry limits and cooloff windows, and `heartbeat due` only returns schedules whose cooloff has expired.
-- `heartbeat beat` records a run, updates per-agent continuity state, and can automatically request approvals when the action needs a gate.
+- `heartbeat run-due` executes one bounded task per runnable agent, writes execution history, updates continuity, and honors retry/cooloff windows.
+- `heartbeat run-agent` forces one bounded execution cycle for a specific agent without waiting for a due cron slot.
+- `heartbeat beat` remains available for manual or external run recording when the built-in executor is not the thing doing the work.
 - Budget policies are attached per agent and checked against heartbeat runs in a daily, weekly, or monthly window.
 - When a beat would exceed budget without a `budget-override` approval, it is recorded as blocked and the pending approval is created automatically.
 - `approvals gate` gives a cheap allow/block answer for a specific kind plus target pair.

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -179,8 +179,8 @@ CLI:
 
 ```bash
 bun src/cli.ts goals add --id release-q2 --title "Release Q2 hardening" --type initiative --owner lead-1 --status active
-bun src/cli.ts goals task add --id review-contracts --goal release-q2 --title "Review agent contracts" --assignee reviewer-1
-bun src/cli.ts goals task delegate review-contracts --id qa-contracts --title "Run delegated QA" --assignee qa-1
+bun src/cli.ts goals task add --id review-contracts --goal release-q2 --title "Review agent contracts" --assignee reviewer-1 --action-kind review --action-arg --base --action-arg origin/main --expected-minutes 10
+bun src/cli.ts goals task add --id release-train --goal release-q2 --title "Coordinate release" --assignee lead-1 --action-kind custom-command --action-arg node --action-arg -e --action-arg "console.log(JSON.stringify({summary:'lead ok',nextAction:'complete'}))" --delegate-id qa-contracts --delegate-title "Run delegated QA" --delegate-assignee qa-1 --delegate-action-kind qa --delegate-action-arg http://127.0.0.1:4173/dashboard --delegate-action-arg --flow --delegate-action-arg release-dashboard
 bun src/cli.ts goals queue --json
 ```
 
@@ -194,8 +194,9 @@ CLI:
 
 ```bash
 bun src/cli.ts heartbeat schedule add --agent reviewer-1 --task review-contracts --trigger cron --expression "*/30 * * * *" --summary "Review queue" --retry-limit 2 --cooldown-minutes 30
-bun src/cli.ts heartbeat due --agent reviewer-1 --json
-bun src/cli.ts heartbeat beat --agent reviewer-1 --task review-contracts --summary "Reviewed queue" --next-action "Run QA after approval" --json
+bun src/cli.ts heartbeat inspect --agent reviewer-1 --json
+bun src/cli.ts heartbeat run-due --agent reviewer-1 --max-agents 1 --max-tasks 1 --json
+bun src/cli.ts heartbeat run-agent --agent lead-1 --json
 bun src/cli.ts heartbeat show reviewer-1 --json
 ```
 

--- a/scripts/ci-check.sh
+++ b/scripts/ci-check.sh
@@ -107,6 +107,7 @@ run_ts scripts/qa-trends.spec.ts >/tmp/codex-stack-qa-trends-spec.log
 run_ts scripts/control-plane.spec.ts >/tmp/codex-stack-control-plane-spec.log
 run_ts scripts/control-plane-governance.spec.ts >/tmp/codex-stack-control-plane-governance-spec.log
 run_ts scripts/control-plane-preflight.spec.ts >/tmp/codex-stack-control-plane-preflight-spec.log
+run_ts scripts/control-plane-loop.spec.ts >/tmp/codex-stack-control-plane-loop-spec.log
 run_ts scripts/qa-diff-mode.spec.ts >/tmp/codex-stack-qa-diff-mode-spec.log
 run_ts scripts/browse-session.spec.ts >/tmp/codex-stack-browse-session-spec.log
 run_ts scripts/browse-browser-profile.spec.ts >/tmp/codex-stack-browse-browser-profile-spec.log

--- a/scripts/control-plane-loop.spec.ts
+++ b/scripts/control-plane-loop.spec.ts
@@ -1,0 +1,196 @@
+#!/usr/bin/env bun
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+
+const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "codex-stack-loop-"));
+const statePath = path.join(tmpRoot, "state.json");
+const rootDir = process.cwd();
+
+function run(args: string[]): string {
+  const result = spawnSync(process.execPath || "bun", args, {
+    cwd: rootDir,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  assert.equal(result.status, 0, result.stderr || result.stdout || `Expected success for ${args.join(" ")}`);
+  return String(result.stdout || "").trim();
+}
+
+function addActionArg(target: string[], ...values: string[]): string[] {
+  for (const value of values) {
+    target.push("--action-arg", value);
+  }
+  return target;
+}
+
+function addDelegateActionArg(target: string[], ...values: string[]): string[] {
+  for (const value of values) {
+    target.push("--delegate-action-arg", value);
+  }
+  return target;
+}
+
+run(["src/cli.ts", "agents", "add", "--name", "lead-1", "--runtime", "codex", "--role", "manager", "--workspace", rootDir, "--team", "platform", "--status", "working", "--state", statePath, "--json"]);
+run(["src/cli.ts", "agents", "add", "--name", "worker-1", "--runtime", "codex", "--role", "reviewer", "--workspace", rootDir, "--team", "platform", "--manager", "lead-1", "--status", "working", "--state", statePath, "--json"]);
+run(["src/cli.ts", "agents", "add", "--name", "ship-1", "--runtime", "codex", "--role", "shipper", "--workspace", rootDir, "--team", "release", "--status", "working", "--state", statePath, "--json"]);
+run(["src/cli.ts", "goals", "add", "--id", "release-q4", "--title", "Release Q4", "--type", "initiative", "--owner", "lead-1", "--status", "active", "--state", statePath, "--json"]);
+
+run([
+  "src/cli.ts", "goals", "task", "add",
+  "--id", "upgrade-offline",
+  "--goal", "release-q4",
+  "--title", "Run upgrade audit",
+  "--assignee", "worker-1",
+  "--action-kind", "upgrade",
+  "--action-arg", "--offline",
+  "--expected-minutes", "1",
+  "--expected-cost-units", "1",
+  "--state", statePath,
+  "--json",
+]);
+run([
+  "src/cli.ts", "heartbeat", "schedule", "add",
+  "--agent", "worker-1",
+  "--task", "upgrade-offline",
+  "--trigger", "cron",
+  "--expression", "*/15 * * * *",
+  "--summary", "Run upgrade audit",
+  "--state", statePath,
+  "--json",
+]);
+const dueResult = JSON.parse(run([
+  "src/cli.ts", "heartbeat", "run-due",
+  "--state", statePath,
+  "--max-agents", "1",
+  "--max-tasks", "1",
+  "--json",
+])) as {
+  results: Array<{
+    taskId: string;
+    actionKind: string;
+    execution: { status: string };
+    heartbeat: { status: string } | null;
+    taskStatusAfter: string;
+  }>;
+};
+assert.equal(dueResult.results.length, 1);
+assert.equal(dueResult.results[0].taskId, "upgrade-offline");
+assert.equal(dueResult.results[0].actionKind, "upgrade");
+assert.notEqual(dueResult.results[0].execution.status, "error");
+assert.ok(dueResult.results[0].heartbeat);
+assert.equal(dueResult.results[0].taskStatusAfter, "done");
+
+const parentArgs = [
+  "src/cli.ts", "goals", "task", "add",
+  "--id", "lead-release",
+  "--goal", "release-q4",
+  "--title", "Coordinate release",
+  "--assignee", "lead-1",
+  "--action-kind", "custom-command",
+  "--expected-minutes", "1",
+  "--expected-cost-units", "1",
+  "--delegate-id", "worker-followup",
+  "--delegate-title", "Run delegated follow-up",
+  "--delegate-assignee", "worker-1",
+  "--delegate-summary", "Delegated from lead",
+  "--delegate-action-kind", "custom-command",
+  "--delegate-expected-minutes", "1",
+  "--delegate-expected-cost-units", "1",
+  "--state", statePath,
+  "--json",
+];
+addActionArg(parentArgs, "node", "-e", "console.log(JSON.stringify({summary:'lead ok',nextAction:'complete'}))");
+addDelegateActionArg(parentArgs, "node", "-e", "console.log(JSON.stringify({summary:'child ok',nextAction:'hand back'}))");
+run(parentArgs);
+
+const delegateFirst = JSON.parse(run(["src/cli.ts", "heartbeat", "run-agent", "--agent", "lead-1", "--state", statePath, "--json"])) as {
+  result: { execution: { status: string; createdTaskIds: string[] }; taskStatusAfter: string };
+};
+assert.equal(delegateFirst.result.execution.status, "success");
+assert.deepEqual(delegateFirst.result.execution.createdTaskIds, ["worker-followup"]);
+assert.equal(delegateFirst.result.taskStatusAfter, "blocked");
+
+const childRun = JSON.parse(run(["src/cli.ts", "heartbeat", "run-agent", "--agent", "worker-1", "--state", statePath, "--json"])) as {
+  result: { taskId: string; execution: { status: string }; taskStatusAfter: string };
+};
+assert.equal(childRun.result.taskId, "worker-followup");
+assert.equal(childRun.result.execution.status, "success");
+assert.equal(childRun.result.taskStatusAfter, "done");
+
+const parentResume = JSON.parse(run(["src/cli.ts", "heartbeat", "run-agent", "--agent", "lead-1", "--state", statePath, "--json"])) as {
+  result: { taskId: string; execution: { status: string }; taskStatusAfter: string };
+};
+assert.equal(parentResume.result.taskId, "lead-release");
+assert.equal(parentResume.result.execution.status, "success");
+assert.equal(parentResume.result.taskStatusAfter, "done");
+
+run([
+  "src/cli.ts", "goals", "task", "add",
+  "--id", "ship-gated",
+  "--goal", "release-q4",
+  "--title", "Ship gated change",
+  "--assignee", "ship-1",
+  "--action-kind", "custom-command",
+  "--action-arg", "node",
+  "--action-arg", "-e",
+  "--action-arg", "console.log(JSON.stringify({summary:'ship ok',nextAction:'merge'}))",
+  "--require-approval", "ship-pr",
+  "--approval-target", "ship-gated",
+  "--expected-minutes", "1",
+  "--expected-cost-units", "1",
+  "--state", statePath,
+  "--json",
+]);
+const approvalBlocked = JSON.parse(run(["src/cli.ts", "heartbeat", "run-agent", "--agent", "ship-1", "--state", statePath, "--json"])) as {
+  result: { execution: { status: string; approvalId: string }; taskStatusAfter: string };
+};
+assert.equal(approvalBlocked.result.execution.status, "blocked");
+assert.equal(approvalBlocked.result.taskStatusAfter, "blocked");
+assert.ok(approvalBlocked.result.execution.approvalId);
+run(["src/cli.ts", "approvals", "approve", approvalBlocked.result.execution.approvalId, "--by", "lead-1", "--note", "Ship approved", "--state", statePath, "--json"]);
+const approvalAllowed = JSON.parse(run(["src/cli.ts", "heartbeat", "run-agent", "--agent", "ship-1", "--state", statePath, "--json"])) as {
+  result: { execution: { status: string }; taskStatusAfter: string };
+};
+assert.equal(approvalAllowed.result.execution.status, "success");
+assert.equal(approvalAllowed.result.taskStatusAfter, "done");
+
+run(["src/cli.ts", "agents", "budget", "set", "--agent", "ship-1", "--window", "daily", "--max-cost-units", "1", "--state", statePath, "--json"]);
+run([
+  "src/cli.ts", "goals", "task", "add",
+  "--id", "budget-gated",
+  "--goal", "release-q4",
+  "--title", "Budget gated task",
+  "--assignee", "ship-1",
+  "--action-kind", "custom-command",
+  "--action-arg", "node",
+  "--action-arg", "-e",
+  "--action-arg", "console.log(JSON.stringify({summary:'budget ok',nextAction:'done'}))",
+  "--expected-minutes", "1",
+  "--expected-cost-units", "2",
+  "--state", statePath,
+  "--json",
+]);
+const budgetBlocked = JSON.parse(run(["src/cli.ts", "heartbeat", "run-agent", "--agent", "ship-1", "--state", statePath, "--json"])) as {
+  result: { execution: { status: string; approvalId: string; budgetExceeded: boolean }; taskStatusAfter: string };
+};
+assert.equal(budgetBlocked.result.execution.status, "blocked");
+assert.equal(budgetBlocked.result.execution.budgetExceeded, true);
+assert.ok(budgetBlocked.result.execution.approvalId);
+run(["src/cli.ts", "approvals", "approve", budgetBlocked.result.execution.approvalId, "--by", "lead-1", "--note", "Budget override approved", "--state", statePath, "--json"]);
+const budgetAllowed = JSON.parse(run(["src/cli.ts", "heartbeat", "run-agent", "--agent", "ship-1", "--state", statePath, "--json"])) as {
+  result: { execution: { status: string }; taskStatusAfter: string };
+};
+assert.equal(budgetAllowed.result.execution.status, "success");
+assert.equal(budgetAllowed.result.taskStatusAfter, "done");
+
+const inspectPayload = JSON.parse(run(["src/cli.ts", "heartbeat", "inspect", "--agent", "ship-1", "--state", statePath, "--json"])) as {
+  executions: Array<unknown>;
+  approvals: Array<unknown>;
+};
+assert.ok(inspectPayload.executions.length >= 2);
+assert.equal(inspectPayload.approvals.length, 0);
+
+console.log("control-plane loop spec passed");

--- a/scripts/control-plane-runner.ts
+++ b/scripts/control-plane-runner.ts
@@ -1,0 +1,710 @@
+#!/usr/bin/env bun
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import {
+  applyHeartbeatScheduleResult,
+  computeBudgetUsage,
+  delegateTask,
+  ensureApprovalGate,
+  findAgent,
+  findApprovedApproval,
+  findBudgetPolicy,
+  findPendingApproval,
+  findSchedule,
+  findSession,
+  findTask,
+  listDueSchedules,
+  listQueue,
+  normalizeHeartbeatStatus,
+  normalizeTaskActionKind,
+  normalizeTaskExecutionStatus,
+  projectedBudgetUsage,
+  recordExecution,
+  recordHeartbeat,
+  syncDelegatedParent,
+  upsertSession,
+  type ApprovalRecord,
+  type ApprovalKind,
+  type BudgetUsage,
+  type ControlPlaneState,
+  type HeartbeatRecord,
+  type HeartbeatScheduleRecord,
+  type HeartbeatStatus,
+  type HeartbeatTrigger,
+  type TaskActionKind,
+  type TaskExecutionRecord,
+  type TaskExecutionStatus,
+  type TaskFailureClass,
+  type TaskRecord,
+} from "./control-plane.ts";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const ROOT_DIR = path.resolve(__dirname, "..");
+const BUN = process.execPath || "bun";
+
+export interface LoopRunOptions {
+  agent?: string;
+  maxAgents?: number;
+  maxTasks?: number;
+}
+
+export interface ExecutionSummary {
+  agent: string;
+  scheduleId: string;
+  taskId: string;
+  actionKind: TaskActionKind | "";
+  skipped: boolean;
+  reason: string;
+  heartbeat: HeartbeatRecord | null;
+  execution: TaskExecutionRecord;
+  approvals: ApprovalRecord[];
+  budgetUsage: BudgetUsage | null;
+  delegatedTaskIds: string[];
+  taskStatusBefore: string;
+  taskStatusAfter: string;
+}
+
+export interface RunAgentResult extends ExecutionSummary {
+  schedule: HeartbeatScheduleRecord | null;
+}
+
+function clean(value: unknown): string {
+  return String(value || "").replace(/\s+/g, " ").trim();
+}
+
+function parseDate(value: string): Date | null {
+  const normalized = clean(value);
+  if (!normalized) return null;
+  const parsed = new Date(normalized);
+  return Number.isNaN(parsed.getTime()) ? null : parsed;
+}
+
+function taskPriority(task: TaskRecord): number {
+  if (task.status === "working") return 0;
+  if (task.status === "claimed") return 1;
+  if (task.status === "queued") return 2;
+  if (task.status === "blocked") return 3;
+  return 4;
+}
+
+function hasPendingDependencies(state: ControlPlaneState, task: TaskRecord): boolean {
+  return task.blockedBy.some((dependency) => {
+    const blocker = findTask(state, dependency);
+    return blocker && blocker.status !== "done";
+  });
+}
+
+function taskReadyAfter(task: TaskRecord): boolean {
+  const nextRunAt = parseDate(task.nextRunAfter);
+  return !nextRunAt || nextRunAt.getTime() <= Date.now();
+}
+
+function maybeResumeTask(state: ControlPlaneState, task: TaskRecord): void {
+  if (task.parentTaskId) syncDelegatedParent(state, task.parentTaskId);
+  if (task.status !== "blocked") return;
+  if (task.stuck) return;
+  if (hasPendingDependencies(state, task)) return;
+  if (!taskReadyAfter(task)) return;
+  task.status = task.assignee ? "claimed" : "queued";
+  task.blockedReason = "";
+  task.updatedAt = new Date().toISOString();
+}
+
+function isRunnableTask(state: ControlPlaneState, task: TaskRecord): boolean {
+  maybeResumeTask(state, task);
+  if (task.status === "done" || task.stuck) return false;
+  if (hasPendingDependencies(state, task)) return false;
+  if (!taskReadyAfter(task)) return false;
+  if (task.status === "blocked") return false;
+  return true;
+}
+
+function pickTaskForAgent(state: ControlPlaneState, agent: string, preferredTaskId = ""): TaskRecord | null {
+  const preferred = clean(preferredTaskId);
+  if (preferred) {
+    const task = findTask(state, preferred);
+    if (task && task.assignee === agent && isRunnableTask(state, task)) return task;
+  }
+  const sessionTaskId = findSession(state, agent)?.currentTaskId || "";
+  if (sessionTaskId) {
+    const task = findTask(state, sessionTaskId);
+    if (task && task.assignee === agent && isRunnableTask(state, task)) return task;
+  }
+  const candidates = listQueue(state, agent)
+    .filter((task) => task.assignee === agent)
+    .filter((task) => isRunnableTask(state, task))
+    .sort((a, b) => {
+      const priority = taskPriority(a) - taskPriority(b);
+      if (priority !== 0) return priority;
+      return a.updatedAt.localeCompare(b.updatedAt);
+    });
+  return candidates[0] || null;
+}
+
+function incrementTaskFailure(task: TaskRecord, failureClass: TaskFailureClass, reason: string, retryLimit = 0, cooldownMinutes = 0): void {
+  task.failureCount += 1;
+  task.lastFailureClass = failureClass;
+  task.blockedReason = clean(reason);
+  task.status = "blocked";
+  task.nextRunAfter = cooldownMinutes > 0
+    ? new Date(Date.now() + cooldownMinutes * 60 * 1000).toISOString()
+    : "";
+  task.stuck = retryLimit > 0 ? task.failureCount >= retryLimit : task.failureCount >= 3;
+  task.updatedAt = new Date().toISOString();
+}
+
+function resetTaskAfterSuccess(task: TaskRecord, markDone: boolean): void {
+  task.failureCount = 0;
+  task.lastFailureClass = "";
+  task.nextRunAfter = "";
+  task.stuck = false;
+  task.blockedReason = "";
+  task.updatedAt = new Date().toISOString();
+  if (markDone) {
+    task.status = "done";
+    task.completedAt = task.completedAt || task.updatedAt;
+  } else {
+    task.status = task.assignee ? "claimed" : "queued";
+  }
+}
+
+function blockTaskForDependency(state: ControlPlaneState, task: TaskRecord, schedule: HeartbeatScheduleRecord | null): ExecutionSummary {
+  const reason = task.blockedBy.length
+    ? `Waiting on dependencies: ${task.blockedBy.join(", ")}`
+    : task.blockedReason || "Task is blocked";
+  incrementTaskFailure(task, "blocked-by-dependency", reason, schedule?.retryLimit || 0, schedule?.cooldownMinutes || 0);
+  const execution = recordExecution(state, {
+    agent: task.assignee,
+    taskId: task.id,
+    scheduleId: schedule?.id || "",
+    trigger: schedule?.trigger || "manual",
+    actionKind: task.actionKind,
+    status: "blocked",
+    summary: reason,
+    nextAction: "Wait for dependencies to resolve",
+    output: "",
+    branch: "",
+    prUrl: "",
+    failureClass: "blocked-by-dependency",
+    approvalId: "",
+    budgetExceeded: false,
+    createdTaskIds: [],
+    durationMinutes: 0,
+    costUnits: 0,
+    startedAt: new Date().toISOString(),
+    finishedAt: new Date().toISOString(),
+  });
+  if (schedule) applyHeartbeatScheduleResult(state, schedule.id, "blocked");
+  upsertSession(state, {
+    agent: task.assignee,
+    currentTaskId: task.id,
+    branch: "",
+    prUrl: "",
+    summary: reason,
+    nextAction: "Wait for dependencies to resolve",
+    lastOutput: "",
+  });
+  return {
+    agent: task.assignee,
+    scheduleId: schedule?.id || "",
+    taskId: task.id,
+    actionKind: task.actionKind,
+    skipped: false,
+    reason,
+    heartbeat: null,
+    execution,
+    approvals: [],
+    budgetUsage: null,
+    delegatedTaskIds: [],
+    taskStatusBefore: "blocked",
+    taskStatusAfter: task.status,
+  };
+}
+
+function createSkippedExecution(state: ControlPlaneState, agent: string, schedule: HeartbeatScheduleRecord | null, reason: string): RunAgentResult {
+  const execution = recordExecution(state, {
+    agent,
+    taskId: schedule?.taskId || "",
+    scheduleId: schedule?.id || "",
+    trigger: schedule?.trigger || "manual",
+    actionKind: "",
+    status: "skipped",
+    summary: clean(reason),
+    nextAction: "Wait for queued work",
+    output: "",
+    branch: "",
+    prUrl: "",
+    failureClass: "",
+    approvalId: "",
+    budgetExceeded: false,
+    createdTaskIds: [],
+    durationMinutes: 0,
+    costUnits: 0,
+    startedAt: new Date().toISOString(),
+    finishedAt: new Date().toISOString(),
+  });
+  if (schedule) applyHeartbeatScheduleResult(state, schedule.id, "ok");
+  return {
+    agent,
+    schedule,
+    scheduleId: schedule?.id || "",
+    taskId: schedule?.taskId || "",
+    actionKind: "",
+    skipped: true,
+    reason: clean(reason),
+    heartbeat: null,
+    execution,
+    approvals: [],
+    budgetUsage: null,
+    delegatedTaskIds: [],
+    taskStatusBefore: "",
+    taskStatusAfter: "",
+  };
+}
+
+function buildBudgetGate(state: ControlPlaneState, task: TaskRecord): { policy: ReturnType<typeof findBudgetPolicy> | null; usage: BudgetUsage | null; pending: ApprovalRecord | null; approved: ApprovalRecord | null } {
+  const policy = task.assignee ? findBudgetPolicy(state, task.assignee) || null : null;
+  if (!policy) return { policy, usage: null, pending: null, approved: null };
+  const projected = projectedBudgetUsage(state, policy, {
+    durationMinutes: task.expectedDurationMinutes || 1,
+    costUnits: task.expectedCostUnits || 1,
+  });
+  if (!projected.exceeded) return { policy, usage: projected, pending: null, approved: null };
+  const approved = findApprovedApproval(state, task.assignee, "budget-override", task.assignee) || null;
+  if (approved) return { policy, usage: projected, pending: null, approved };
+  const pending = ensureApprovalGate(state, {
+    agent: task.assignee,
+    kind: "budget-override",
+    target: task.assignee,
+    summary: `Budget override required for ${task.assignee}: exceeded ${projected.exceededFields.join(", ")}`,
+    requestedBy: task.assignee,
+    createPending: true,
+  }).pending;
+  return { policy, usage: projected, pending: pending || null, approved: null };
+}
+
+function buildApprovalBlock(state: ControlPlaneState, task: TaskRecord): ApprovalRecord | null {
+  if (!task.requireApprovalKind) return null;
+  const target = task.approvalTarget || task.id;
+  const approved = findApprovedApproval(state, task.assignee, task.requireApprovalKind, target);
+  if (approved) return null;
+  return ensureApprovalGate(state, {
+    agent: task.assignee,
+    kind: task.requireApprovalKind,
+    target,
+    summary: `${task.requireApprovalKind} approval required for ${task.id}`,
+    requestedBy: task.assignee,
+    createPending: true,
+  }).pending;
+}
+
+function spawnAction(task: TaskRecord, workspace: string): { status: number; stdout: string; stderr: string; actionKind: TaskActionKind | "" } {
+  const actionKind = normalizeTaskActionKind(task.actionKind, true);
+  if (!actionKind) {
+    return { status: 2, stdout: "", stderr: "No action configured for task", actionKind };
+  }
+  let program = BUN;
+  let args: string[] = [];
+  if (actionKind === "review") args = [path.join(ROOT_DIR, "scripts", "review-diff.ts"), ...task.actionArgs];
+  else if (actionKind === "qa") args = [path.join(ROOT_DIR, "scripts", "qa-run.ts"), ...task.actionArgs];
+  else if (actionKind === "preview") args = [path.join(ROOT_DIR, "scripts", "preview-verify.ts"), ...task.actionArgs];
+  else if (actionKind === "deploy") args = [path.join(ROOT_DIR, "scripts", "deploy-verify.ts"), ...task.actionArgs];
+  else if (actionKind === "ship-plan") args = [path.join(ROOT_DIR, "scripts", "ship-branch.ts"), "--dry-run", ...task.actionArgs];
+  else if (actionKind === "fleet-collect") args = [path.join(ROOT_DIR, "scripts", "fleet.ts"), "collect", ...task.actionArgs];
+  else if (actionKind === "fleet-remediate-plan") args = [path.join(ROOT_DIR, "scripts", "fleet.ts"), "remediate", "--dry-run", ...task.actionArgs];
+  else if (actionKind === "retro") args = [path.join(ROOT_DIR, "scripts", "retro-report.ts"), ...task.actionArgs];
+  else if (actionKind === "upgrade") args = [path.join(ROOT_DIR, "scripts", "upgrade-check.ts"), ...task.actionArgs];
+  else if (actionKind === "custom-command") {
+    const [customProgram, ...customArgs] = task.actionArgs;
+    if (!customProgram) return { status: 2, stdout: "", stderr: "custom-command requires an executable in actionArgs", actionKind };
+    program = customProgram;
+    args = customArgs;
+  }
+  if (actionKind !== "custom-command" && !args.includes("--json")) args.push("--json");
+  const result = spawnSync(program, args, {
+    cwd: workspace,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  return {
+    status: result.status ?? 1,
+    stdout: String(result.stdout || ""),
+    stderr: String(result.stderr || ""),
+    actionKind,
+  };
+}
+
+function parseActionPayload(stdout: string): Record<string, unknown> | null {
+  const trimmed = String(stdout || "").trim();
+  if (!trimmed) return null;
+  try {
+    return JSON.parse(trimmed) as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+}
+
+function deriveExecutionStatus(actionKind: TaskActionKind | "", exitCode: number, payload: Record<string, unknown> | null): TaskExecutionStatus {
+  if (exitCode !== 0) return "error";
+  const statusValue = clean(payload?.status || payload?.overallStatus || payload?.recommendation);
+  if (statusValue === "warning") return "warning";
+  if (statusValue === "blocked") return "blocked";
+  if (statusValue === "error" || statusValue === "critical") return "error";
+  if (actionKind === "review" && Array.isArray(payload?.findings) && payload?.findings.length) return "warning";
+  return "success";
+}
+
+function deriveExecutionSummary(actionKind: TaskActionKind | "", payload: Record<string, unknown> | null, fallback: string): { summary: string; nextAction: string; branch: string; prUrl: string } {
+  const findings = Array.isArray(payload?.findings) ? payload.findings.length : 0;
+  const summary = clean(payload?.summary) || clean(payload?.recommendation) || (actionKind === "review" && findings ? `Review completed with ${findings} findings` : fallback);
+  const nextAction = clean(payload?.nextAction) || clean(payload?.recommendation) || (findings ? "Inspect findings" : "Queue next task");
+  const branch = clean(payload?.branch || payload?.currentBranch);
+  const prUrl = clean(payload?.prUrl || ((payload?.pr as Record<string, unknown> | undefined)?.url));
+  return { summary, nextAction, branch, prUrl };
+}
+
+function executeTask(state: ControlPlaneState, task: TaskRecord, schedule: HeartbeatScheduleRecord | null, trigger: HeartbeatTrigger): RunAgentResult {
+  const agent = findAgent(state, task.assignee);
+  if (!agent) return createSkippedExecution(state, task.assignee, schedule, `Unknown agent ${task.assignee}`);
+  const taskStatusBefore = task.status;
+  if (hasPendingDependencies(state, task)) return { ...blockTaskForDependency(state, task, schedule), schedule };
+  const taskWorkspace = clean(agent.workspace) || ROOT_DIR;
+
+  if (task.delegateTaskId && !findTask(state, task.delegateTaskId)) {
+    const delegated = delegateTask(state, {
+      parentTaskId: task.id,
+      id: task.delegateTaskId,
+      title: task.delegateTitle || `Delegated work from ${task.id}`,
+      assignee: task.delegateAssignee,
+      goalId: task.delegateGoalId || task.goalId,
+      summary: task.delegateSummary,
+      blockedReason: task.delegateBlockedReason,
+      blockedBy: task.delegateBlockedBy,
+      delegatedBy: task.assignee,
+      actionKind: task.delegateActionKind,
+      actionArgs: task.delegateActionArgs,
+      expectedDurationMinutes: task.delegateExpectedDurationMinutes,
+      expectedCostUnits: task.delegateExpectedCostUnits,
+    });
+    const nowIso = new Date().toISOString();
+    const execution = recordExecution(state, {
+      agent: task.assignee,
+      taskId: task.id,
+      scheduleId: schedule?.id || "",
+      trigger,
+      actionKind: task.actionKind,
+      status: "success",
+      summary: `Delegated ${delegated.child.id}`,
+      nextAction: `Wait for ${delegated.child.id}`,
+      output: JSON.stringify({ delegatedTaskId: delegated.child.id }),
+      branch: "",
+      prUrl: "",
+      failureClass: "",
+      approvalId: "",
+      budgetExceeded: false,
+      createdTaskIds: [delegated.child.id],
+      durationMinutes: 0,
+      costUnits: 0,
+      startedAt: nowIso,
+      finishedAt: nowIso,
+    });
+    const heartbeatOutcome = recordHeartbeat(state, {
+      agent: task.assignee,
+      taskId: task.id,
+      trigger,
+      status: "ok",
+      summary: `Delegated ${delegated.child.id}`,
+      nextAction: `Wait for ${delegated.child.id}`,
+      output: JSON.stringify({ delegatedTaskId: delegated.child.id }),
+      durationMinutes: 0,
+      costUnits: 0,
+      scheduledBy: task.assignee,
+    });
+    if (schedule) applyHeartbeatScheduleResult(state, schedule.id, heartbeatOutcome.heartbeat.status);
+    return {
+      agent: task.assignee,
+      schedule,
+      scheduleId: schedule?.id || "",
+      taskId: task.id,
+      actionKind: task.actionKind,
+      skipped: false,
+      reason: `Delegated ${delegated.child.id}`,
+      heartbeat: heartbeatOutcome.heartbeat,
+      execution,
+      approvals: heartbeatOutcome.approvals,
+      budgetUsage: heartbeatOutcome.budget.usage,
+      delegatedTaskIds: [delegated.child.id],
+      taskStatusBefore,
+      taskStatusAfter: delegated.parent.status,
+    };
+  }
+
+  const approvalBlock = buildApprovalBlock(state, task);
+  if (approvalBlock) {
+    incrementTaskFailure(task, "blocked-by-approval", `Waiting on approval ${approvalBlock.id}`, schedule?.retryLimit || 0, schedule?.cooldownMinutes || 0);
+    upsertSession(state, {
+      agent: task.assignee,
+      currentTaskId: task.id,
+      branch: "",
+      prUrl: "",
+      summary: `Approval required for ${task.id}`,
+      nextAction: `Approve ${approvalBlock.id} to continue`,
+      lastOutput: "",
+    });
+    const execution = recordExecution(state, {
+      agent: task.assignee,
+      taskId: task.id,
+      scheduleId: schedule?.id || "",
+      trigger,
+      actionKind: task.actionKind,
+      status: "blocked",
+      summary: `Approval required for ${task.id}`,
+      nextAction: `Approve ${approvalBlock.id} to continue`,
+      output: "",
+      branch: "",
+      prUrl: "",
+      failureClass: "blocked-by-approval",
+      approvalId: approvalBlock.id,
+      budgetExceeded: false,
+      createdTaskIds: [],
+      durationMinutes: 0,
+      costUnits: 0,
+      startedAt: new Date().toISOString(),
+      finishedAt: new Date().toISOString(),
+    });
+    if (schedule) applyHeartbeatScheduleResult(state, schedule.id, "blocked");
+    agent.status = "blocked";
+    agent.updatedAt = new Date().toISOString();
+    return {
+      agent: task.assignee,
+      schedule,
+      scheduleId: schedule?.id || "",
+      taskId: task.id,
+      actionKind: task.actionKind,
+      skipped: false,
+      reason: `Waiting on approval ${approvalBlock.id}`,
+      heartbeat: null,
+      execution,
+      approvals: [approvalBlock],
+      budgetUsage: null,
+      delegatedTaskIds: [],
+      taskStatusBefore,
+      taskStatusAfter: task.status,
+    };
+  }
+
+  const budgetGate = buildBudgetGate(state, task);
+  if (budgetGate.pending) {
+    incrementTaskFailure(task, "blocked-by-budget", `Waiting on budget override ${budgetGate.pending.id}`, schedule?.retryLimit || 0, schedule?.cooldownMinutes || 0);
+    upsertSession(state, {
+      agent: task.assignee,
+      currentTaskId: task.id,
+      branch: "",
+      prUrl: "",
+      summary: `Budget override required for ${task.id}`,
+      nextAction: `Approve ${budgetGate.pending.id} to continue`,
+      lastOutput: "",
+    });
+    const execution = recordExecution(state, {
+      agent: task.assignee,
+      taskId: task.id,
+      scheduleId: schedule?.id || "",
+      trigger,
+      actionKind: task.actionKind,
+      status: "blocked",
+      summary: `Budget override required for ${task.id}`,
+      nextAction: `Approve ${budgetGate.pending.id} to continue`,
+      output: "",
+      branch: "",
+      prUrl: "",
+      failureClass: "blocked-by-budget",
+      approvalId: budgetGate.pending.id,
+      budgetExceeded: true,
+      createdTaskIds: [],
+      durationMinutes: 0,
+      costUnits: 0,
+      startedAt: new Date().toISOString(),
+      finishedAt: new Date().toISOString(),
+    });
+    if (schedule) applyHeartbeatScheduleResult(state, schedule.id, "blocked");
+    agent.status = "blocked";
+    agent.updatedAt = new Date().toISOString();
+    return {
+      agent: task.assignee,
+      schedule,
+      scheduleId: schedule?.id || "",
+      taskId: task.id,
+      actionKind: task.actionKind,
+      skipped: false,
+      reason: `Waiting on budget override ${budgetGate.pending.id}`,
+      heartbeat: null,
+      execution,
+      approvals: [budgetGate.pending],
+      budgetUsage: budgetGate.usage,
+      delegatedTaskIds: [],
+      taskStatusBefore,
+      taskStatusAfter: task.status,
+    };
+  }
+
+  if (task.status === "queued") {
+    task.status = "claimed";
+    task.claimedAt = task.claimedAt || new Date().toISOString();
+  }
+  task.status = "working";
+  task.updatedAt = new Date().toISOString();
+
+  const startedAt = new Date();
+  const spawnResult = spawnAction(task, taskWorkspace);
+  const finishedAt = new Date();
+  const durationMinutes = Number(((finishedAt.getTime() - startedAt.getTime()) / 60000).toFixed(2));
+  const costUnits = task.expectedCostUnits || 1;
+  const payload = parseActionPayload(spawnResult.stdout);
+  const executionStatus = deriveExecutionStatus(spawnResult.actionKind, spawnResult.status, payload);
+  const derived = deriveExecutionSummary(spawnResult.actionKind, payload, spawnResult.status === 0 ? `${spawnResult.actionKind} completed` : `${spawnResult.actionKind} failed`);
+  const output = String(spawnResult.stdout || spawnResult.stderr || "").trim();
+
+  if (executionStatus === "error") {
+    incrementTaskFailure(task, "hard-failure", clean(spawnResult.stderr || derived.summary || `${spawnResult.actionKind} failed`), schedule?.retryLimit || 0, schedule?.cooldownMinutes || 0);
+    agent.status = task.stuck ? "blocked" : "working";
+    agent.updatedAt = finishedAt.toISOString();
+    upsertSession(state, {
+      agent: task.assignee,
+      currentTaskId: task.id,
+      branch: derived.branch,
+      prUrl: derived.prUrl,
+      summary: derived.summary,
+      nextAction: task.stuck ? "Unstick task manually" : "Retry on next heartbeat",
+      lastOutput: output,
+    });
+    const execution = recordExecution(state, {
+      agent: task.assignee,
+      taskId: task.id,
+      scheduleId: schedule?.id || "",
+      trigger,
+      actionKind: spawnResult.actionKind,
+      status: "error",
+      summary: derived.summary,
+      nextAction: task.stuck ? "Unstick task manually" : "Retry on next heartbeat",
+      output,
+      branch: derived.branch,
+      prUrl: derived.prUrl,
+      failureClass: "hard-failure",
+      approvalId: "",
+      budgetExceeded: false,
+      createdTaskIds: [],
+      durationMinutes,
+      costUnits,
+      startedAt: startedAt.toISOString(),
+      finishedAt: finishedAt.toISOString(),
+    });
+    if (task.parentTaskId) syncDelegatedParent(state, task.parentTaskId);
+    if (schedule) applyHeartbeatScheduleResult(state, schedule.id, "error", finishedAt);
+    return {
+      agent: task.assignee,
+      schedule,
+      scheduleId: schedule?.id || "",
+      taskId: task.id,
+      actionKind: spawnResult.actionKind,
+      skipped: false,
+      reason: derived.summary,
+      heartbeat: null,
+      execution,
+      approvals: [],
+      budgetUsage: budgetGate.usage,
+      delegatedTaskIds: [],
+      taskStatusBefore,
+      taskStatusAfter: task.status,
+    };
+  }
+
+  const heartbeatStatus: HeartbeatStatus = executionStatus === "warning" ? "warning" : executionStatus === "blocked" ? "blocked" : "ok";
+  const heartbeatOutcome = recordHeartbeat(state, {
+    agent: task.assignee,
+    taskId: task.id,
+    trigger,
+    status: normalizeHeartbeatStatus(heartbeatStatus),
+    summary: derived.summary,
+    nextAction: derived.nextAction,
+    output,
+    branch: derived.branch,
+    prUrl: derived.prUrl,
+    durationMinutes,
+    costUnits,
+    scheduledBy: schedule?.id || task.assignee,
+  });
+
+  if (heartbeatOutcome.blocked) {
+    const blockingApproval = heartbeatOutcome.approvals[0] || null;
+    incrementTaskFailure(task, blockingApproval?.kind === "budget-override" ? "blocked-by-budget" : "blocked-by-approval", heartbeatOutcome.heartbeat.summary, schedule?.retryLimit || 0, schedule?.cooldownMinutes || 0);
+  } else {
+    resetTaskAfterSuccess(task, true);
+  }
+  if (task.parentTaskId) syncDelegatedParent(state, task.parentTaskId);
+  const execution = recordExecution(state, {
+    agent: task.assignee,
+    taskId: task.id,
+    scheduleId: schedule?.id || "",
+    trigger,
+    actionKind: spawnResult.actionKind,
+    status: heartbeatOutcome.blocked ? "blocked" : executionStatus,
+    summary: heartbeatOutcome.heartbeat.summary,
+    nextAction: heartbeatOutcome.heartbeat.nextAction,
+    output,
+    branch: heartbeatOutcome.heartbeat.branch,
+    prUrl: heartbeatOutcome.heartbeat.prUrl,
+    failureClass: heartbeatOutcome.blocked ? (heartbeatOutcome.approvals[0]?.kind === "budget-override" ? "blocked-by-budget" : "blocked-by-approval") : "",
+    approvalId: heartbeatOutcome.approvals[0]?.id || "",
+    budgetExceeded: Boolean(heartbeatOutcome.budget.usage?.exceeded),
+    createdTaskIds: [],
+    durationMinutes,
+    costUnits,
+    startedAt: startedAt.toISOString(),
+    finishedAt: finishedAt.toISOString(),
+  });
+  if (schedule) applyHeartbeatScheduleResult(state, schedule.id, heartbeatOutcome.heartbeat.status, finishedAt);
+  return {
+    agent: task.assignee,
+    schedule,
+    scheduleId: schedule?.id || "",
+    taskId: task.id,
+    actionKind: spawnResult.actionKind,
+    skipped: false,
+    reason: heartbeatOutcome.heartbeat.summary,
+    heartbeat: heartbeatOutcome.heartbeat,
+    execution,
+    approvals: heartbeatOutcome.approvals,
+    budgetUsage: heartbeatOutcome.budget.usage,
+    delegatedTaskIds: [],
+    taskStatusBefore,
+    taskStatusAfter: task.status,
+  };
+}
+
+export function runAgentCycle(state: ControlPlaneState, agentName: string, scheduleId = ""): RunAgentResult {
+  const schedule = clean(scheduleId) ? findSchedule(state, scheduleId) || null : null;
+  const agent = findAgent(state, agentName);
+  if (!agent) return createSkippedExecution(state, agentName, schedule, `Unknown agent ${agentName}`);
+  if (agent.status === "paused" || agent.status === "offline") return createSkippedExecution(state, agent.name, schedule, `Agent ${agent.name} is ${agent.status}`);
+  const task = pickTaskForAgent(state, agent.name, schedule?.taskId || "");
+  if (!task) return createSkippedExecution(state, agent.name, schedule, `No runnable task for ${agent.name}`);
+  return executeTask(state, task, schedule, schedule?.trigger || "manual");
+}
+
+export function runDueSchedules(state: ControlPlaneState, options: LoopRunOptions = {}): RunAgentResult[] {
+  const dueSchedules = listDueSchedules(state, options.agent);
+  const maxAgents = Math.max(1, options.maxAgents || 1);
+  const maxTasks = Math.max(1, options.maxTasks || maxAgents);
+  const results: RunAgentResult[] = [];
+  const seenAgents = new Set<string>();
+  for (const schedule of dueSchedules) {
+    if (results.length >= maxTasks) break;
+    if (seenAgents.has(schedule.agent)) continue;
+    results.push(runAgentCycle(state, schedule.agent, schedule.id));
+    seenAgents.add(schedule.agent);
+    if (seenAgents.size >= maxAgents) break;
+  }
+  return results;
+}

--- a/scripts/control-plane.ts
+++ b/scripts/control-plane.ts
@@ -12,6 +12,9 @@ export type HeartbeatStatus = "ok" | "warning" | "blocked" | "error";
 export type BudgetWindow = "daily" | "weekly" | "monthly";
 export type ApprovalStatus = "pending" | "approved" | "rejected" | "cancelled";
 export type ApprovalKind = "ship-pr" | "merge-pr" | "update-snapshot" | "fleet-remediate" | "budget-override" | "custom";
+export type TaskActionKind = "review" | "qa" | "preview" | "deploy" | "ship-plan" | "fleet-collect" | "fleet-remediate-plan" | "retro" | "upgrade" | "custom-command";
+export type TaskFailureClass = "transient" | "blocked-by-approval" | "blocked-by-budget" | "blocked-by-dependency" | "hard-failure";
+export type TaskExecutionStatus = "success" | "warning" | "blocked" | "error" | "skipped";
 
 export interface AgentRecord {
   name: string;
@@ -52,6 +55,27 @@ export interface TaskRecord {
   summary: string;
   blockedReason: string;
   blockedBy: string[];
+  actionKind: TaskActionKind | "";
+  actionArgs: string[];
+  expectedDurationMinutes: number;
+  expectedCostUnits: number;
+  requireApprovalKind: ApprovalKind | "";
+  approvalTarget: string;
+  nextRunAfter: string;
+  failureCount: number;
+  lastFailureClass: TaskFailureClass | "";
+  stuck: boolean;
+  delegateTaskId: string;
+  delegateTitle: string;
+  delegateAssignee: string;
+  delegateGoalId: string;
+  delegateSummary: string;
+  delegateBlockedReason: string;
+  delegateBlockedBy: string[];
+  delegateActionKind: TaskActionKind | "";
+  delegateActionArgs: string[];
+  delegateExpectedDurationMinutes: number;
+  delegateExpectedCostUnits: number;
   createdAt: string;
   updatedAt: string;
   claimedAt: string;
@@ -90,6 +114,29 @@ export interface HeartbeatRecord {
   costUnits: number;
   scheduledBy: string;
   createdAt: string;
+}
+
+export interface TaskExecutionRecord {
+  id: string;
+  agent: string;
+  taskId: string;
+  scheduleId: string;
+  trigger: HeartbeatTrigger;
+  actionKind: TaskActionKind | "";
+  status: TaskExecutionStatus;
+  summary: string;
+  nextAction: string;
+  output: string;
+  branch: string;
+  prUrl: string;
+  failureClass: TaskFailureClass | "";
+  approvalId: string;
+  budgetExceeded: boolean;
+  createdTaskIds: string[];
+  durationMinutes: number;
+  costUnits: number;
+  startedAt: string;
+  finishedAt: string;
 }
 
 export interface AgentSessionRecord {
@@ -150,13 +197,14 @@ export interface HeartbeatOutcome {
 }
 
 export interface ControlPlaneState {
-  schemaVersion: 3;
+  schemaVersion: 4;
   updatedAt: string;
   agents: AgentRecord[];
   goals: GoalRecord[];
   tasks: TaskRecord[];
   schedules: HeartbeatScheduleRecord[];
   heartbeats: HeartbeatRecord[];
+  executions: TaskExecutionRecord[];
   sessions: AgentSessionRecord[];
   budgets: BudgetPolicyRecord[];
   approvals: ApprovalRecord[];
@@ -178,24 +226,31 @@ export interface DashboardReport {
     pausedSchedules: number;
     exhaustedSchedules: number;
     recentHeartbeats: number;
+    recentExecutions: number;
     pendingApprovals: number;
     exceededBudgets: number;
+    stuckTasks: number;
+    runnableAgents: number;
   };
   agents: Array<AgentRecord & {
     directReports: string[];
     queuedTasks: number;
     activeTasks: number;
     blockedTasks: number;
+    stuckTasks: number;
     session: AgentSessionRecord | null;
     budget: BudgetUsage | null;
     pendingApprovals: number;
+    runnable: boolean;
   }>;
   goals: Array<GoalRecord & { childGoals: string[]; taskIds: string[] }>;
   queue: TaskRecord[];
   active: TaskRecord[];
   blocked: TaskRecord[];
+  stuck: TaskRecord[];
   schedules: HeartbeatScheduleRecord[];
   heartbeats: HeartbeatRecord[];
+  executions: TaskExecutionRecord[];
   approvals: ApprovalRecord[];
 }
 
@@ -234,13 +289,14 @@ function sortByKey<T>(items: T[], getter: (item: T) => string): T[] {
 
 export function defaultState(): ControlPlaneState {
   return {
-    schemaVersion: 3,
+    schemaVersion: 4,
     updatedAt: now(),
     agents: [],
     goals: [],
     tasks: [],
     schedules: [],
     heartbeats: [],
+    executions: [],
     sessions: [],
     budgets: [],
     approvals: [],
@@ -257,7 +313,7 @@ export function readState(inputPath = ""): ControlPlaneState {
   if (!fs.existsSync(statePath)) return defaultState();
   const parsed = JSON.parse(fs.readFileSync(statePath, "utf8")) as Partial<ControlPlaneState> & Record<string, unknown>;
   return {
-    schemaVersion: 3,
+    schemaVersion: 4,
     updatedAt: clean(parsed.updatedAt) || now(),
     agents: Array.isArray(parsed.agents) ? parsed.agents as AgentRecord[] : [],
     goals: Array.isArray(parsed.goals) ? parsed.goals as GoalRecord[] : [],
@@ -268,6 +324,43 @@ export function readState(inputPath = ""): ControlPlaneState {
       blockedBy: Array.isArray((task as Partial<TaskRecord>).blockedBy)
         ? [...new Set(((task as Partial<TaskRecord>).blockedBy as string[]).map((value) => clean(value)).filter(Boolean))]
         : [],
+      actionKind: normalizeTaskActionKind(String((task as Partial<TaskRecord>).actionKind || ""), true),
+      actionArgs: Array.isArray((task as Partial<TaskRecord>).actionArgs)
+        ? [...new Set(((task as Partial<TaskRecord>).actionArgs as string[]).map((value) => String(value)))]
+        : [],
+      expectedDurationMinutes: Number.isFinite(Number((task as Partial<TaskRecord>).expectedDurationMinutes))
+        ? Number((task as Partial<TaskRecord>).expectedDurationMinutes)
+        : 0,
+      expectedCostUnits: Number.isFinite(Number((task as Partial<TaskRecord>).expectedCostUnits))
+        ? Number((task as Partial<TaskRecord>).expectedCostUnits)
+        : 0,
+      requireApprovalKind: normalizeApprovalKind(String((task as Partial<TaskRecord>).requireApprovalKind || ""), true),
+      approvalTarget: clean((task as Partial<TaskRecord>).approvalTarget),
+      nextRunAfter: clean((task as Partial<TaskRecord>).nextRunAfter),
+      failureCount: Number.isFinite(Number((task as Partial<TaskRecord>).failureCount))
+        ? Number((task as Partial<TaskRecord>).failureCount)
+        : 0,
+      lastFailureClass: normalizeTaskFailureClass(String((task as Partial<TaskRecord>).lastFailureClass || ""), true),
+      stuck: Boolean((task as Partial<TaskRecord>).stuck),
+      delegateTaskId: clean((task as Partial<TaskRecord>).delegateTaskId),
+      delegateTitle: clean((task as Partial<TaskRecord>).delegateTitle),
+      delegateAssignee: clean((task as Partial<TaskRecord>).delegateAssignee),
+      delegateGoalId: clean((task as Partial<TaskRecord>).delegateGoalId),
+      delegateSummary: clean((task as Partial<TaskRecord>).delegateSummary),
+      delegateBlockedReason: clean((task as Partial<TaskRecord>).delegateBlockedReason),
+      delegateBlockedBy: Array.isArray((task as Partial<TaskRecord>).delegateBlockedBy)
+        ? [...new Set(((task as Partial<TaskRecord>).delegateBlockedBy as string[]).map((value) => clean(value)).filter(Boolean))]
+        : [],
+      delegateActionKind: normalizeTaskActionKind(String((task as Partial<TaskRecord>).delegateActionKind || ""), true),
+      delegateActionArgs: Array.isArray((task as Partial<TaskRecord>).delegateActionArgs)
+        ? [...new Set(((task as Partial<TaskRecord>).delegateActionArgs as string[]).map((value) => String(value)))]
+        : [],
+      delegateExpectedDurationMinutes: Number.isFinite(Number((task as Partial<TaskRecord>).delegateExpectedDurationMinutes))
+        ? Number((task as Partial<TaskRecord>).delegateExpectedDurationMinutes)
+        : 0,
+      delegateExpectedCostUnits: Number.isFinite(Number((task as Partial<TaskRecord>).delegateExpectedCostUnits))
+        ? Number((task as Partial<TaskRecord>).delegateExpectedCostUnits)
+        : 0,
     })) : [],
     schedules: Array.isArray(parsed.schedules) ? parsed.schedules.map((schedule) => ({
       ...(schedule as HeartbeatScheduleRecord),
@@ -284,6 +377,22 @@ export function readState(inputPath = ""): ControlPlaneState {
       nextRunAfter: clean((schedule as Partial<HeartbeatScheduleRecord>).nextRunAfter),
     })) : [],
     heartbeats: Array.isArray(parsed.heartbeats) ? parsed.heartbeats as HeartbeatRecord[] : [],
+    executions: Array.isArray(parsed.executions) ? parsed.executions.map((execution) => ({
+      ...(execution as TaskExecutionRecord),
+      actionKind: normalizeTaskActionKind(String((execution as Partial<TaskExecutionRecord>).actionKind || ""), true),
+      status: normalizeTaskExecutionStatus(String((execution as Partial<TaskExecutionRecord>).status || ""), true) || "success",
+      failureClass: normalizeTaskFailureClass(String((execution as Partial<TaskExecutionRecord>).failureClass || ""), true),
+      approvalId: clean((execution as Partial<TaskExecutionRecord>).approvalId),
+      createdTaskIds: Array.isArray((execution as Partial<TaskExecutionRecord>).createdTaskIds)
+        ? [...new Set(((execution as Partial<TaskExecutionRecord>).createdTaskIds as string[]).map((value) => clean(value)).filter(Boolean))]
+        : [],
+      durationMinutes: Number.isFinite(Number((execution as Partial<TaskExecutionRecord>).durationMinutes))
+        ? Number((execution as Partial<TaskExecutionRecord>).durationMinutes)
+        : 0,
+      costUnits: Number.isFinite(Number((execution as Partial<TaskExecutionRecord>).costUnits))
+        ? Number((execution as Partial<TaskExecutionRecord>).costUnits)
+        : 0,
+    })) : [],
     sessions: Array.isArray(parsed.sessions) ? parsed.sessions as AgentSessionRecord[] : [],
     budgets: Array.isArray(parsed.budgets) ? parsed.budgets as BudgetPolicyRecord[] : [],
     approvals: Array.isArray(parsed.approvals) ? parsed.approvals as ApprovalRecord[] : [],
@@ -411,10 +520,61 @@ export function normalizeApprovalStatus(value: string): ApprovalStatus {
   throw new Error(`Unknown approval status: ${JSON.stringify(value)}`);
 }
 
-export function normalizeApprovalKind(value: string): ApprovalKind {
+export function normalizeApprovalKind(value: string): ApprovalKind;
+export function normalizeApprovalKind(value: string, allowEmpty: false): ApprovalKind;
+export function normalizeApprovalKind(value: string, allowEmpty: true): ApprovalKind | "";
+export function normalizeApprovalKind(value: string, allowEmpty = false): ApprovalKind | "" {
   const normalized = clean(value).toLowerCase();
+  if (!normalized && allowEmpty) return "";
   if (normalized === "ship-pr" || normalized === "merge-pr" || normalized === "update-snapshot" || normalized === "fleet-remediate" || normalized === "budget-override" || normalized === "custom") return normalized;
   throw new Error(`Unknown approval kind: ${JSON.stringify(value)}`);
+}
+
+export function normalizeTaskActionKind(value: string): TaskActionKind;
+export function normalizeTaskActionKind(value: string, allowEmpty: false): TaskActionKind;
+export function normalizeTaskActionKind(value: string, allowEmpty: true): TaskActionKind | "";
+export function normalizeTaskActionKind(value: string, allowEmpty = false): TaskActionKind | "" {
+  const normalized = clean(value).toLowerCase();
+  if (!normalized && allowEmpty) return "";
+  if (
+    normalized === "review" ||
+    normalized === "qa" ||
+    normalized === "preview" ||
+    normalized === "deploy" ||
+    normalized === "ship-plan" ||
+    normalized === "fleet-collect" ||
+    normalized === "fleet-remediate-plan" ||
+    normalized === "retro" ||
+    normalized === "upgrade" ||
+    normalized === "custom-command"
+  ) return normalized;
+  throw new Error(`Unknown task action kind: ${JSON.stringify(value)}`);
+}
+
+export function normalizeTaskFailureClass(value: string): TaskFailureClass;
+export function normalizeTaskFailureClass(value: string, allowEmpty: false): TaskFailureClass;
+export function normalizeTaskFailureClass(value: string, allowEmpty: true): TaskFailureClass | "";
+export function normalizeTaskFailureClass(value: string, allowEmpty = false): TaskFailureClass | "" {
+  const normalized = clean(value).toLowerCase();
+  if (!normalized && allowEmpty) return "";
+  if (
+    normalized === "transient" ||
+    normalized === "blocked-by-approval" ||
+    normalized === "blocked-by-budget" ||
+    normalized === "blocked-by-dependency" ||
+    normalized === "hard-failure"
+  ) return normalized;
+  throw new Error(`Unknown task failure class: ${JSON.stringify(value)}`);
+}
+
+export function normalizeTaskExecutionStatus(value: string): TaskExecutionStatus;
+export function normalizeTaskExecutionStatus(value: string, allowEmpty: false): TaskExecutionStatus;
+export function normalizeTaskExecutionStatus(value: string, allowEmpty: true): TaskExecutionStatus | "";
+export function normalizeTaskExecutionStatus(value: string, allowEmpty = false): TaskExecutionStatus | "" {
+  const normalized = clean(value).toLowerCase();
+  if (!normalized && allowEmpty) return "";
+  if (normalized === "success" || normalized === "warning" || normalized === "blocked" || normalized === "error" || normalized === "skipped") return normalized;
+  throw new Error(`Unknown task execution status: ${JSON.stringify(value)}`);
 }
 
 export function upsertAgent(state: ControlPlaneState, input: Omit<AgentRecord, "createdAt" | "updatedAt">): AgentRecord {
@@ -465,12 +625,39 @@ export function upsertTask(state: ControlPlaneState, input: Omit<TaskRecord, "cr
     requireTask(state, input.parentTaskId);
   }
   for (const dependency of input.blockedBy) requireTask(state, dependency);
+  for (const dependency of input.delegateBlockedBy) requireTask(state, dependency);
+  if (input.requireApprovalKind) normalizeApprovalKind(input.requireApprovalKind);
+  if (input.actionKind) normalizeTaskActionKind(input.actionKind);
+  if (input.delegateActionKind) normalizeTaskActionKind(input.delegateActionKind);
+  const delegateGoalId = clean(input.delegateGoalId) || input.goalId;
+  if (input.delegateTaskId) requireGoal(state, delegateGoalId);
   const timestamp = now();
   const record: TaskRecord = {
     ...input,
     parentTaskId: clean(input.parentTaskId),
     delegatedBy: clean(input.delegatedBy),
     blockedBy: [...new Set(input.blockedBy.map((dependency) => clean(dependency)).filter(Boolean))],
+    actionKind: normalizeTaskActionKind(input.actionKind, true),
+    actionArgs: [...new Set((input.actionArgs || []).map((value) => String(value)))],
+    expectedDurationMinutes: Number.isFinite(Number(input.expectedDurationMinutes)) ? Number(input.expectedDurationMinutes) : 0,
+    expectedCostUnits: Number.isFinite(Number(input.expectedCostUnits)) ? Number(input.expectedCostUnits) : 0,
+    requireApprovalKind: normalizeApprovalKind(input.requireApprovalKind, true),
+    approvalTarget: clean(input.approvalTarget),
+    nextRunAfter: clean(input.nextRunAfter),
+    failureCount: Number.isFinite(Number(input.failureCount)) ? Number(input.failureCount) : 0,
+    lastFailureClass: normalizeTaskFailureClass(input.lastFailureClass, true),
+    stuck: Boolean(input.stuck),
+    delegateTaskId: clean(input.delegateTaskId),
+    delegateTitle: clean(input.delegateTitle),
+    delegateAssignee: clean(input.delegateAssignee),
+    delegateGoalId,
+    delegateSummary: clean(input.delegateSummary),
+    delegateBlockedReason: clean(input.delegateBlockedReason),
+    delegateBlockedBy: [...new Set((input.delegateBlockedBy || []).map((dependency) => clean(dependency)).filter(Boolean))],
+    delegateActionKind: normalizeTaskActionKind(input.delegateActionKind, true),
+    delegateActionArgs: [...new Set((input.delegateActionArgs || []).map((value) => String(value)))],
+    delegateExpectedDurationMinutes: Number.isFinite(Number(input.delegateExpectedDurationMinutes)) ? Number(input.delegateExpectedDurationMinutes) : 0,
+    delegateExpectedCostUnits: Number.isFinite(Number(input.delegateExpectedCostUnits)) ? Number(input.delegateExpectedCostUnits) : 0,
     claimedAt: input.status === "claimed" || input.status === "working" ? (existing?.claimedAt || input.claimedAt || timestamp) : (input.claimedAt || existing?.claimedAt || ""),
     completedAt: input.status === "done" ? (input.completedAt || existing?.completedAt || timestamp) : (input.completedAt || existing?.completedAt || ""),
     createdAt: existing?.createdAt || timestamp,
@@ -561,6 +748,12 @@ export function delegateTask(state: ControlPlaneState, input: {
   blockedReason?: string;
   blockedBy?: string[];
   delegatedBy?: string;
+  actionKind?: TaskActionKind | "";
+  actionArgs?: string[];
+  expectedDurationMinutes?: number;
+  expectedCostUnits?: number;
+  requireApprovalKind?: ApprovalKind | "";
+  approvalTarget?: string;
 }): { parent: TaskRecord; child: TaskRecord } {
   const parent = requireTask(state, input.parentTaskId);
   if (parent.status === "done") {
@@ -581,6 +774,27 @@ export function delegateTask(state: ControlPlaneState, input: {
     summary: clean(input.summary),
     blockedReason: clean(input.blockedReason),
     blockedBy: input.blockedBy || [],
+    actionKind: input.actionKind || "",
+    actionArgs: input.actionArgs || [],
+    expectedDurationMinutes: Number.isFinite(Number(input.expectedDurationMinutes)) ? Number(input.expectedDurationMinutes) : 0,
+    expectedCostUnits: Number.isFinite(Number(input.expectedCostUnits)) ? Number(input.expectedCostUnits) : 0,
+    requireApprovalKind: input.requireApprovalKind || "",
+    approvalTarget: clean(input.approvalTarget),
+    nextRunAfter: "",
+    failureCount: 0,
+    lastFailureClass: "",
+    stuck: false,
+    delegateTaskId: "",
+    delegateTitle: "",
+    delegateAssignee: "",
+    delegateGoalId: "",
+    delegateSummary: "",
+    delegateBlockedReason: "",
+    delegateBlockedBy: [],
+    delegateActionKind: "",
+    delegateActionArgs: [],
+    delegateExpectedDurationMinutes: 0,
+    delegateExpectedCostUnits: 0,
   });
   return {
     parent: syncDelegatedParent(state, parent.id),
@@ -903,6 +1117,33 @@ export function recordHeartbeat(state: ControlPlaneState, input: {
   };
 }
 
+export function recordExecution(state: ControlPlaneState, input: Omit<TaskExecutionRecord, "id"> & { id?: string }): TaskExecutionRecord {
+  const record: TaskExecutionRecord = {
+    ...input,
+    id: clean(input.id) || randomUUID(),
+    taskId: clean(input.taskId),
+    scheduleId: clean(input.scheduleId),
+    actionKind: normalizeTaskActionKind(input.actionKind, true),
+    status: normalizeTaskExecutionStatus(input.status),
+    summary: clean(input.summary),
+    nextAction: clean(input.nextAction),
+    output: String(input.output || ""),
+    branch: clean(input.branch),
+    prUrl: clean(input.prUrl),
+    failureClass: normalizeTaskFailureClass(input.failureClass, true),
+    approvalId: clean(input.approvalId),
+    budgetExceeded: Boolean(input.budgetExceeded),
+    createdTaskIds: [...new Set((input.createdTaskIds || []).map((value) => clean(value)).filter(Boolean))],
+    durationMinutes: Number.isFinite(Number(input.durationMinutes)) ? Number(input.durationMinutes) : 0,
+    costUnits: Number.isFinite(Number(input.costUnits)) ? Number(input.costUnits) : 0,
+    startedAt: clean(input.startedAt) || now(),
+    finishedAt: clean(input.finishedAt) || clean(input.startedAt) || now(),
+  };
+  state.executions.push(record);
+  state.executions.sort((a, b) => b.startedAt.localeCompare(a.startedAt));
+  return record;
+}
+
 export function buildApprovalGate(state: ControlPlaneState, input: { agent: string; kind: ApprovalKind; target: string }) {
   const pending = findPendingApproval(state, input.agent, input.kind, input.target) || null;
   const approved = findApprovedApproval(state, input.agent, input.kind, input.target) || null;
@@ -954,10 +1195,19 @@ export function listRecentHeartbeats(state: ControlPlaneState, agent = "", limit
     .slice(0, limit);
 }
 
+export function listRecentExecutions(state: ControlPlaneState, agent = "", limit = 20): TaskExecutionRecord[] {
+  const target = clean(agent);
+  return state.executions
+    .filter((execution) => !target || execution.agent === target)
+    .sort((a, b) => b.startedAt.localeCompare(a.startedAt))
+    .slice(0, limit);
+}
+
 export function buildDashboardReport(state: ControlPlaneState, inputPath = ""): DashboardReport {
   const queued = state.tasks.filter((task) => task.status === "queued");
   const active = state.tasks.filter((task) => task.status === "claimed" || task.status === "working");
   const blocked = state.tasks.filter((task) => task.status === "blocked");
+  const stuck = state.tasks.filter((task) => task.stuck);
   const activeSchedules = state.schedules.filter((schedule) => schedule.active);
   const coolingSchedules = activeSchedules.filter((schedule) => {
     const nextRunAt = parseDate(schedule.nextRunAfter);
@@ -978,10 +1228,20 @@ export function buildDashboardReport(state: ControlPlaneState, inputPath = ""): 
       return Boolean(createdAt && Date.now() - createdAt.getTime() <= 24 * 60 * 60 * 1000);
     })
     .sort((a, b) => b.createdAt.localeCompare(a.createdAt));
+  const recentExecutions = state.executions
+    .filter((execution) => {
+      const startedAt = parseDate(execution.startedAt);
+      return Boolean(startedAt && Date.now() - startedAt.getTime() <= 24 * 60 * 60 * 1000);
+    })
+    .sort((a, b) => b.startedAt.localeCompare(a.startedAt));
   const pendingApprovals = state.approvals.filter((approval) => approval.status === "pending");
   const exceededBudgets = state.budgets
     .map((policy) => computeBudgetUsage(state, policy))
     .filter((usage) => usage.exceeded);
+  const runnableAgents = state.agents.filter((agent) => {
+    if (agent.status === "paused" || agent.status === "offline") return false;
+    return state.tasks.some((task) => task.assignee === agent.name && !task.stuck && task.status !== "done");
+  });
   return {
     generatedAt: now(),
     statePath: resolveStatePath(inputPath),
@@ -998,8 +1258,11 @@ export function buildDashboardReport(state: ControlPlaneState, inputPath = ""): 
       pausedSchedules: pausedSchedules.length,
       exhaustedSchedules: exhaustedSchedules.length,
       recentHeartbeats: recentHeartbeats.length,
+      recentExecutions: recentExecutions.length,
       pendingApprovals: pendingApprovals.length,
       exceededBudgets: exceededBudgets.length,
+      stuckTasks: stuck.length,
+      runnableAgents: runnableAgents.length,
     },
     agents: state.agents.map((agent) => ({
       ...agent,
@@ -1007,9 +1270,11 @@ export function buildDashboardReport(state: ControlPlaneState, inputPath = ""): 
       queuedTasks: queued.filter((task) => task.assignee === agent.name).length,
       activeTasks: active.filter((task) => task.assignee === agent.name).length,
       blockedTasks: blocked.filter((task) => task.assignee === agent.name).length,
+      stuckTasks: stuck.filter((task) => task.assignee === agent.name).length,
       session: findSession(state, agent.name) || null,
       budget: findBudgetPolicy(state, agent.name) ? computeBudgetUsage(state, findBudgetPolicy(state, agent.name) as BudgetPolicyRecord) : null,
       pendingApprovals: pendingApprovals.filter((approval) => approval.agent === agent.name).length,
+      runnable: runnableAgents.some((candidate) => candidate.name === agent.name),
     })),
     goals: state.goals.map((goal) => ({
       ...goal,
@@ -1019,8 +1284,10 @@ export function buildDashboardReport(state: ControlPlaneState, inputPath = ""): 
     queue: queued,
     active,
     blocked,
+    stuck,
     schedules: [...state.schedules].sort((a, b) => a.id.localeCompare(b.id)),
     heartbeats: recentHeartbeats,
+    executions: recentExecutions,
     approvals: pendingApprovals.sort((a, b) => b.requestedAt.localeCompare(a.requestedAt)),
   };
 }
@@ -1041,11 +1308,13 @@ function card(title: string, value: string, tone = "neutral"): string {
 function renderAgentRow(agent: DashboardReport["agents"][number]): string {
   const session = agent.session?.nextAction ? ` / ${agent.session.nextAction}` : "";
   const budget = agent.budget?.exceeded ? `over ${agent.budget.window}` : agent.budget ? `${agent.budget.runs} runs` : "-";
-  return `<tr><td>${escapeHtml(agent.name)}</td><td>${escapeHtml(agent.role)}</td><td>${escapeHtml(agent.runtime)}</td><td>${escapeHtml(agent.team || "-")}</td><td>${escapeHtml(agent.manager || "-")}</td><td>${escapeHtml(agent.status)}</td><td>${agent.queuedTasks}</td><td>${agent.activeTasks}</td><td>${agent.blockedTasks}</td><td>${escapeHtml(budget)}</td><td>${escapeHtml(session || "-")}</td><td>${agent.pendingApprovals}</td></tr>`;
+  return `<tr><td>${escapeHtml(agent.name)}</td><td>${escapeHtml(agent.role)}</td><td>${escapeHtml(agent.runtime)}</td><td>${escapeHtml(agent.team || "-")}</td><td>${escapeHtml(agent.manager || "-")}</td><td>${escapeHtml(agent.status)}</td><td>${agent.runnable ? "yes" : "no"}</td><td>${agent.queuedTasks}</td><td>${agent.activeTasks}</td><td>${agent.blockedTasks}</td><td>${agent.stuckTasks}</td><td>${escapeHtml(budget)}</td><td>${escapeHtml(session || "-")}</td><td>${agent.pendingApprovals}</td></tr>`;
 }
 
 function renderTaskRow(task: TaskRecord): string {
-  return `<tr><td>${escapeHtml(task.id)}</td><td>${escapeHtml(task.goalId)}</td><td>${escapeHtml(task.title)}</td><td>${escapeHtml(task.assignee || "-")}</td><td>${escapeHtml(task.parentTaskId || "-")}</td><td>${escapeHtml(task.status)}</td><td>${escapeHtml(task.blockedReason || "-")}</td></tr>`;
+  const action = task.actionKind || (task.delegateTaskId ? `delegate:${task.delegateTaskId}` : "-");
+  const failure = task.lastFailureClass || "-";
+  return `<tr><td>${escapeHtml(task.id)}</td><td>${escapeHtml(task.goalId)}</td><td>${escapeHtml(task.title)}</td><td>${escapeHtml(task.assignee || "-")}</td><td>${escapeHtml(task.parentTaskId || "-")}</td><td>${escapeHtml(task.status)}</td><td>${escapeHtml(action)}</td><td>${escapeHtml(failure)}</td><td>${task.failureCount}</td><td>${task.stuck ? "yes" : "no"}</td><td>${escapeHtml(task.blockedReason || "-")}</td></tr>`;
 }
 
 function renderGoalRow(goal: DashboardReport["goals"][number]): string {
@@ -1054,6 +1323,10 @@ function renderGoalRow(goal: DashboardReport["goals"][number]): string {
 
 function renderHeartbeatRow(heartbeat: HeartbeatRecord): string {
   return `<tr><td>${escapeHtml(heartbeat.agent)}</td><td>${escapeHtml(heartbeat.taskId || "-")}</td><td>${escapeHtml(heartbeat.trigger)}</td><td>${escapeHtml(heartbeat.status)}</td><td>${escapeHtml(heartbeat.summary || "-")}</td><td>${escapeHtml(heartbeat.nextAction || "-")}</td><td>${heartbeat.durationMinutes}</td></tr>`;
+}
+
+function renderExecutionRow(execution: TaskExecutionRecord): string {
+  return `<tr><td>${escapeHtml(execution.agent)}</td><td>${escapeHtml(execution.taskId || "-")}</td><td>${escapeHtml(execution.actionKind || "-")}</td><td>${escapeHtml(execution.status)}</td><td>${escapeHtml(execution.failureClass || "-")}</td><td>${escapeHtml(execution.summary || "-")}</td><td>${escapeHtml(execution.nextAction || "-")}</td><td>${execution.createdTaskIds.length}</td></tr>`;
 }
 
 function renderApprovalRow(approval: ApprovalRecord): string {
@@ -1145,21 +1418,24 @@ export function renderDashboardHtml(report: DashboardReport): string {
       ${card("Blocked tasks", String(report.counts.blockedTasks), report.counts.blockedTasks ? "danger" : "neutral")}
       ${card("Schedules", String(report.counts.schedules))}
       ${card("Cooling schedules", String(report.counts.coolingSchedules), report.counts.coolingSchedules ? "warn" : "neutral")}
-      ${card("Paused schedules", String(report.counts.pausedSchedules), report.counts.pausedSchedules ? "warn" : "neutral")}
-      ${card("Exhausted schedules", String(report.counts.exhaustedSchedules), report.counts.exhaustedSchedules ? "danger" : "neutral")}
-      ${card("Recent heartbeats", String(report.counts.recentHeartbeats))}
-      ${card("Pending approvals", String(report.counts.pendingApprovals), report.counts.pendingApprovals ? "warn" : "neutral")}
-      ${card("Exceeded budgets", String(report.counts.exceededBudgets), report.counts.exceededBudgets ? "danger" : "neutral")}
-      ${card("Completed tasks", String(report.counts.doneTasks))}
-    </div>
+	      ${card("Paused schedules", String(report.counts.pausedSchedules), report.counts.pausedSchedules ? "warn" : "neutral")}
+	      ${card("Exhausted schedules", String(report.counts.exhaustedSchedules), report.counts.exhaustedSchedules ? "danger" : "neutral")}
+	      ${card("Recent heartbeats", String(report.counts.recentHeartbeats))}
+	      ${card("Recent executions", String(report.counts.recentExecutions))}
+	      ${card("Pending approvals", String(report.counts.pendingApprovals), report.counts.pendingApprovals ? "warn" : "neutral")}
+	      ${card("Exceeded budgets", String(report.counts.exceededBudgets), report.counts.exceededBudgets ? "danger" : "neutral")}
+	      ${card("Stuck tasks", String(report.counts.stuckTasks), report.counts.stuckTasks ? "danger" : "neutral")}
+	      ${card("Runnable agents", String(report.counts.runnableAgents), report.counts.runnableAgents ? "neutral" : "warn")}
+	      ${card("Completed tasks", String(report.counts.doneTasks))}
+	    </div>
     <div class="stack">
       <section class="panel">
         <h2>Agents</h2>
         <table>
-          <thead><tr><th>Name</th><th>Role</th><th>Runtime</th><th>Team</th><th>Manager</th><th>Status</th><th>Queued</th><th>Active</th><th>Blocked</th><th>Budget</th><th>Next action</th><th>Pending approvals</th></tr></thead>
-          <tbody>${report.agents.map(renderAgentRow).join("") || '<tr><td colspan="12">No agents registered.</td></tr>'}</tbody>
-        </table>
-      </section>
+	          <thead><tr><th>Name</th><th>Role</th><th>Runtime</th><th>Team</th><th>Manager</th><th>Status</th><th>Runnable</th><th>Queued</th><th>Active</th><th>Blocked</th><th>Stuck</th><th>Budget</th><th>Next action</th><th>Pending approvals</th></tr></thead>
+	          <tbody>${report.agents.map(renderAgentRow).join("") || '<tr><td colspan="14">No agents registered.</td></tr>'}</tbody>
+	        </table>
+	      </section>
       <section class="panel">
         <h2>Goals</h2>
         <table>
@@ -1170,10 +1446,10 @@ export function renderDashboardHtml(report: DashboardReport): string {
       <section class="panel">
         <h2>Queue</h2>
         <table>
-          <thead><tr><th>ID</th><th>Goal</th><th>Task</th><th>Assignee</th><th>Parent</th><th>Status</th><th>Blocked reason</th></tr></thead>
-          <tbody>${report.queue.map(renderTaskRow).join("") || '<tr><td colspan="7">No queued work.</td></tr>'}</tbody>
-        </table>
-      </section>
+	          <thead><tr><th>ID</th><th>Goal</th><th>Task</th><th>Assignee</th><th>Parent</th><th>Status</th><th>Action</th><th>Failure class</th><th>Failures</th><th>Stuck</th><th>Blocked reason</th></tr></thead>
+	          <tbody>${report.queue.map(renderTaskRow).join("") || '<tr><td colspan="11">No queued work.</td></tr>'}</tbody>
+	        </table>
+	      </section>
       <section class="panel">
         <h2>Schedules</h2>
         <table>
@@ -1181,13 +1457,20 @@ export function renderDashboardHtml(report: DashboardReport): string {
           <tbody>${report.schedules.map(renderScheduleRow).join("") || '<tr><td colspan="9">No schedules recorded.</td></tr>'}</tbody>
         </table>
       </section>
-      <section class="panel">
-        <h2>Recent heartbeats</h2>
-        <table>
-          <thead><tr><th>Agent</th><th>Task</th><th>Trigger</th><th>Status</th><th>Summary</th><th>Next action</th><th>Minutes</th></tr></thead>
-          <tbody>${report.heartbeats.map(renderHeartbeatRow).join("") || '<tr><td colspan="7">No heartbeats recorded.</td></tr>'}</tbody>
-        </table>
-      </section>
+	      <section class="panel">
+	        <h2>Recent heartbeats</h2>
+	        <table>
+	          <thead><tr><th>Agent</th><th>Task</th><th>Trigger</th><th>Status</th><th>Summary</th><th>Next action</th><th>Minutes</th></tr></thead>
+	          <tbody>${report.heartbeats.map(renderHeartbeatRow).join("") || '<tr><td colspan="7">No heartbeats recorded.</td></tr>'}</tbody>
+	        </table>
+	      </section>
+	      <section class="panel">
+	        <h2>Recent executions</h2>
+	        <table>
+	          <thead><tr><th>Agent</th><th>Task</th><th>Action</th><th>Status</th><th>Failure class</th><th>Summary</th><th>Next action</th><th>Delegated</th></tr></thead>
+	          <tbody>${report.executions.map(renderExecutionRow).join("") || '<tr><td colspan="8">No executions recorded.</td></tr>'}</tbody>
+	        </table>
+	      </section>
       <section class="panel">
         <h2>Pending approvals</h2>
         <table>
@@ -1210,6 +1493,6 @@ export function writeDashboard(report: DashboardReport, outDir: string): { outDi
   const markdownPath = path.join(resolvedOutDir, "summary.md");
   fs.writeFileSync(htmlPath, renderDashboardHtml(report));
   fs.writeFileSync(jsonPath, `${JSON.stringify(report, null, 2)}\n`);
-  fs.writeFileSync(markdownPath, `# codex-stack control plane\n\n- Generated: ${report.generatedAt}\n- Agents: ${report.counts.agents}\n- Teams: ${report.counts.teams}\n- Goals: ${report.counts.goals}\n- Queued tasks: ${report.counts.queuedTasks}\n- Active tasks: ${report.counts.activeTasks}\n- Blocked tasks: ${report.counts.blockedTasks}\n- Schedules: ${report.counts.schedules}\n- Cooling schedules: ${report.counts.coolingSchedules}\n- Paused schedules: ${report.counts.pausedSchedules}\n- Exhausted schedules: ${report.counts.exhaustedSchedules}\n- Recent heartbeats: ${report.counts.recentHeartbeats}\n- Pending approvals: ${report.counts.pendingApprovals}\n- Exceeded budgets: ${report.counts.exceededBudgets}\n- Completed tasks: ${report.counts.doneTasks}\n`);
+  fs.writeFileSync(markdownPath, `# codex-stack control plane\n\n- Generated: ${report.generatedAt}\n- Agents: ${report.counts.agents}\n- Runnable agents: ${report.counts.runnableAgents}\n- Teams: ${report.counts.teams}\n- Goals: ${report.counts.goals}\n- Queued tasks: ${report.counts.queuedTasks}\n- Active tasks: ${report.counts.activeTasks}\n- Blocked tasks: ${report.counts.blockedTasks}\n- Stuck tasks: ${report.counts.stuckTasks}\n- Schedules: ${report.counts.schedules}\n- Cooling schedules: ${report.counts.coolingSchedules}\n- Paused schedules: ${report.counts.pausedSchedules}\n- Exhausted schedules: ${report.counts.exhaustedSchedules}\n- Recent heartbeats: ${report.counts.recentHeartbeats}\n- Recent executions: ${report.counts.recentExecutions}\n- Pending approvals: ${report.counts.pendingApprovals}\n- Exceeded budgets: ${report.counts.exceededBudgets}\n- Completed tasks: ${report.counts.doneTasks}\n`);
   return { outDir: resolvedOutDir, htmlPath, jsonPath, markdownPath };
 }

--- a/scripts/goals.ts
+++ b/scripts/goals.ts
@@ -4,8 +4,10 @@ import {
   delegateTask,
   findGoal,
   listQueue,
+  normalizeApprovalKind,
   normalizeGoalStatus,
   normalizeGoalType,
+  normalizeTaskActionKind,
   normalizeTaskStatus,
   readState,
   requireTask,
@@ -72,6 +74,23 @@ interface TaskWriteArgs extends BaseArgs {
   summary: string;
   blockedReason: string;
   blockedBy: string[];
+  actionKind: string;
+  actionArgs: string[];
+  expectedDurationMinutes: number;
+  expectedCostUnits: number;
+  requireApprovalKind: string;
+  approvalTarget: string;
+  delegateTaskId: string;
+  delegateTitle: string;
+  delegateAssignee: string;
+  delegateGoalId: string;
+  delegateSummary: string;
+  delegateBlockedReason: string;
+  delegateBlockedBy: string[];
+  delegateActionKind: string;
+  delegateActionArgs: string[];
+  delegateExpectedDurationMinutes: number;
+  delegateExpectedCostUnits: number;
 }
 
 interface TaskListArgs extends BaseArgs {
@@ -101,6 +120,12 @@ interface TaskDelegateArgs extends BaseArgs {
   summary: string;
   blockedReason: string;
   blockedBy: string[];
+  actionKind: string;
+  actionArgs: string[];
+  expectedDurationMinutes: number;
+  expectedCostUnits: number;
+  requireApprovalKind: string;
+  approvalTarget: string;
 }
 
 function usage(): never {
@@ -111,9 +136,9 @@ Usage:
   bun src/cli.ts goals show <id> [--state <path>] [--json]
   bun src/cli.ts goals add --id <id> --title <title> [--type <org|initiative|repo|objective>] [--owner <agent>] [--repo <repo>] [--parent <goal-id>] [--status <planned|active|blocked|done>] [--summary <text>] [--state <path>] [--json]
   bun src/cli.ts goals queue [--assignee <agent>] [--state <path>] [--json]
-  bun src/cli.ts goals task add --id <id> --goal <goal-id> --title <title> [--assignee <agent>] [--status <queued|claimed|working|blocked|done>] [--summary <text>] [--blocked-by <task-id>] [--blocked-reason <text>] [--state <path>] [--json]
+  bun src/cli.ts goals task add --id <id> --goal <goal-id> --title <title> [--assignee <agent>] [--status <queued|claimed|working|blocked|done>] [--summary <text>] [--blocked-by <task-id>] [--blocked-reason <text>] [--action-kind <kind>] [--action-arg <arg>] [--expected-minutes <n>] [--expected-cost-units <n>] [--require-approval <kind>] [--approval-target <id>] [--delegate-id <id>] [--delegate-title <title>] [--delegate-assignee <agent>] [--delegate-goal <goal-id>] [--delegate-summary <text>] [--delegate-blocked-by <task-id>] [--delegate-blocked-reason <text>] [--delegate-action-kind <kind>] [--delegate-action-arg <arg>] [--delegate-expected-minutes <n>] [--delegate-expected-cost-units <n>] [--state <path>] [--json]
   bun src/cli.ts goals task list [--goal <goal-id>] [--assignee <agent>] [--status <queued|claimed|working|blocked|done>] [--state <path>] [--json]
-  bun src/cli.ts goals task delegate <parent-id> --id <id> --title <title> [--assignee <agent>] [--goal <goal-id>] [--summary <text>] [--blocked-by <task-id>] [--blocked-reason <text>] [--state <path>] [--json]
+  bun src/cli.ts goals task delegate <parent-id> --id <id> --title <title> [--assignee <agent>] [--goal <goal-id>] [--summary <text>] [--blocked-by <task-id>] [--blocked-reason <text>] [--action-kind <kind>] [--action-arg <arg>] [--expected-minutes <n>] [--expected-cost-units <n>] [--require-approval <kind>] [--approval-target <id>] [--state <path>] [--json]
   bun src/cli.ts goals task claim <id> [--assignee <agent>] [--state <path>] [--json]
   bun src/cli.ts goals task reassign <id> --assignee <agent> [--state <path>] [--json]
   bun src/cli.ts goals task block <id> --reason <text> [--state <path>] [--json]
@@ -125,6 +150,11 @@ Usage:
 
 function clean(value: unknown): string {
   return String(value || "").replace(/\s+/g, " ").trim();
+}
+
+function parseNumber(value: string, fallback = 0): number {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : fallback;
 }
 
 function parseArgs(argv: string[]): ParsedArgs {
@@ -219,6 +249,23 @@ function parseTaskArgs(argv: string[]): ParsedArgs {
       summary: "",
       blockedReason: "",
       blockedBy: [],
+      actionKind: "",
+      actionArgs: [],
+      expectedDurationMinutes: 0,
+      expectedCostUnits: 0,
+      requireApprovalKind: "",
+      approvalTarget: "",
+      delegateTaskId: "",
+      delegateTitle: "",
+      delegateAssignee: "",
+      delegateGoalId: "",
+      delegateSummary: "",
+      delegateBlockedReason: "",
+      delegateBlockedBy: [],
+      delegateActionKind: "",
+      delegateActionArgs: [],
+      delegateExpectedDurationMinutes: 0,
+      delegateExpectedCostUnits: 0,
     };
     for (let i = 1; i < argv.length; i += 1) {
       const arg = argv[i];
@@ -232,9 +279,28 @@ function parseTaskArgs(argv: string[]): ParsedArgs {
       else if (arg === "--summary") out.summary = clean(argv[++i]);
       else if (arg === "--blocked-reason") out.blockedReason = clean(argv[++i]);
       else if (arg === "--blocked-by") out.blockedBy.push(clean(argv[++i]));
+      else if (arg === "--action-kind") out.actionKind = clean(argv[++i]);
+      else if (arg === "--action-arg") out.actionArgs.push(String(argv[++i] || ""));
+      else if (arg === "--expected-minutes") out.expectedDurationMinutes = parseNumber(argv[++i], 0);
+      else if (arg === "--expected-cost-units") out.expectedCostUnits = parseNumber(argv[++i], 0);
+      else if (arg === "--require-approval") out.requireApprovalKind = clean(argv[++i]);
+      else if (arg === "--approval-target") out.approvalTarget = clean(argv[++i]);
+      else if (arg === "--delegate-id") out.delegateTaskId = clean(argv[++i]);
+      else if (arg === "--delegate-title") out.delegateTitle = clean(argv[++i]);
+      else if (arg === "--delegate-assignee") out.delegateAssignee = clean(argv[++i]);
+      else if (arg === "--delegate-goal") out.delegateGoalId = clean(argv[++i]);
+      else if (arg === "--delegate-summary") out.delegateSummary = clean(argv[++i]);
+      else if (arg === "--delegate-blocked-reason") out.delegateBlockedReason = clean(argv[++i]);
+      else if (arg === "--delegate-blocked-by") out.delegateBlockedBy.push(clean(argv[++i]));
+      else if (arg === "--delegate-action-kind") out.delegateActionKind = clean(argv[++i]);
+      else if (arg === "--delegate-action-arg") out.delegateActionArgs.push(String(argv[++i] || ""));
+      else if (arg === "--delegate-expected-minutes") out.delegateExpectedDurationMinutes = parseNumber(argv[++i], 0);
+      else if (arg === "--delegate-expected-cost-units") out.delegateExpectedCostUnits = parseNumber(argv[++i], 0);
       else throw new Error(`Unknown argument: ${arg}`);
     }
     if (!out.id || !out.goalId || !out.title) throw new Error("--id, --goal, and --title are required.");
+    if (out.actionKind) normalizeTaskActionKind(out.actionKind);
+    if (out.delegateActionKind) normalizeTaskActionKind(out.delegateActionKind);
     return out;
   }
   if (command === "list") {
@@ -266,6 +332,12 @@ function parseTaskArgs(argv: string[]): ParsedArgs {
       summary: "",
       blockedReason: "",
       blockedBy: [],
+      actionKind: "",
+      actionArgs: [],
+      expectedDurationMinutes: 0,
+      expectedCostUnits: 0,
+      requireApprovalKind: "",
+      approvalTarget: "",
     };
     for (let i = 2; i < argv.length; i += 1) {
       const arg = argv[i];
@@ -278,9 +350,16 @@ function parseTaskArgs(argv: string[]): ParsedArgs {
       else if (arg === "--summary") out.summary = clean(argv[++i]);
       else if (arg === "--blocked-reason") out.blockedReason = clean(argv[++i]);
       else if (arg === "--blocked-by") out.blockedBy.push(clean(argv[++i]));
+      else if (arg === "--action-kind") out.actionKind = clean(argv[++i]);
+      else if (arg === "--action-arg") out.actionArgs.push(String(argv[++i] || ""));
+      else if (arg === "--expected-minutes") out.expectedDurationMinutes = parseNumber(argv[++i], 0);
+      else if (arg === "--expected-cost-units") out.expectedCostUnits = parseNumber(argv[++i], 0);
+      else if (arg === "--require-approval") out.requireApprovalKind = clean(argv[++i]);
+      else if (arg === "--approval-target") out.approvalTarget = clean(argv[++i]);
       else throw new Error(`Unknown argument: ${arg}`);
     }
     if (!out.id || !out.title) throw new Error("--id and --title are required for delegate.");
+    if (out.actionKind) normalizeTaskActionKind(out.actionKind);
     return out;
   }
   if (command === "claim" || command === "reassign" || command === "block" || command === "unblock" || command === "complete") {
@@ -405,6 +484,27 @@ function handleTaskAdd(args: TaskWriteArgs): void {
     summary: args.summary,
     blockedReason: args.blockedReason,
     blockedBy: args.blockedBy,
+    actionKind: normalizeTaskActionKind(args.actionKind, true),
+    actionArgs: args.actionArgs,
+    expectedDurationMinutes: args.expectedDurationMinutes,
+    expectedCostUnits: args.expectedCostUnits,
+    requireApprovalKind: normalizeApprovalKind(args.requireApprovalKind, true),
+    approvalTarget: args.approvalTarget,
+    nextRunAfter: "",
+    failureCount: 0,
+    lastFailureClass: "",
+    stuck: false,
+    delegateTaskId: args.delegateTaskId,
+    delegateTitle: args.delegateTitle,
+    delegateAssignee: args.delegateAssignee,
+    delegateGoalId: args.delegateGoalId,
+    delegateSummary: args.delegateSummary,
+    delegateBlockedReason: args.delegateBlockedReason,
+    delegateBlockedBy: args.delegateBlockedBy,
+    delegateActionKind: normalizeTaskActionKind(args.delegateActionKind, true),
+    delegateActionArgs: args.delegateActionArgs,
+    delegateExpectedDurationMinutes: args.delegateExpectedDurationMinutes,
+    delegateExpectedCostUnits: args.delegateExpectedCostUnits,
   });
   const statePath = writeState(state, args.statePath);
   if (args.json) {
@@ -425,6 +525,12 @@ function handleTaskDelegate(args: TaskDelegateArgs): void {
     summary: args.summary,
     blockedReason: args.blockedReason,
     blockedBy: args.blockedBy,
+    actionKind: normalizeTaskActionKind(args.actionKind, true),
+    actionArgs: args.actionArgs,
+    expectedDurationMinutes: args.expectedDurationMinutes,
+    expectedCostUnits: args.expectedCostUnits,
+    requireApprovalKind: normalizeApprovalKind(args.requireApprovalKind, true),
+    approvalTarget: args.approvalTarget,
   });
   const statePath = writeState(state, args.statePath);
   if (args.json) {
@@ -460,6 +566,9 @@ function handleTaskSingle(args: TaskSingleArgs): void {
   if (args.command === "claim") {
     task.status = task.assignee ? "claimed" : "claimed";
     if (args.assignee) task.assignee = args.assignee;
+    task.stuck = false;
+    task.nextRunAfter = "";
+    task.blockedReason = "";
   } else if (args.command === "reassign") {
     task.assignee = args.assignee;
     task.status = task.status === "done" ? "done" : "queued";
@@ -469,9 +578,13 @@ function handleTaskSingle(args: TaskSingleArgs): void {
   } else if (args.command === "unblock") {
     task.status = "queued";
     task.blockedReason = "";
+    task.nextRunAfter = "";
+    task.stuck = false;
   } else if (args.command === "complete") {
     task.status = "done";
     task.blockedReason = "";
+    task.nextRunAfter = "";
+    task.stuck = false;
   }
   if (task.assignee) {
     const stateCheck = readState(args.statePath);

--- a/scripts/heartbeat.ts
+++ b/scripts/heartbeat.ts
@@ -6,6 +6,7 @@ import {
   findSchedule,
   findSession,
   listDueSchedules,
+  listRecentExecutions,
   listRecentHeartbeats,
   normalizeApprovalKind,
   normalizeHeartbeatStatus,
@@ -16,11 +17,13 @@ import {
   upsertSchedule,
   writeDashboard,
   writeState,
+  type ApprovalKind,
 } from "./control-plane.ts";
+import { runAgentCycle, runDueSchedules } from "./control-plane-runner.ts";
 
-type Command = "list" | "show" | "schedule" | "beat" | "due" | "dashboard";
+type Command = "list" | "show" | "inspect" | "schedule" | "beat" | "due" | "run-due" | "run-agent" | "dashboard";
 
-type ParsedArgs = ListArgs | ShowArgs | ScheduleArgs | BeatArgs | DueArgs | DashboardArgs;
+type ParsedArgs = ListArgs | ShowArgs | InspectArgs | ScheduleArgs | BeatArgs | DueArgs | RunDueArgs | RunAgentArgs | DashboardArgs;
 
 interface BaseArgs {
   command: Command;
@@ -35,6 +38,11 @@ interface ListArgs extends BaseArgs {
 
 interface ShowArgs extends BaseArgs {
   command: "show";
+  agent: string;
+}
+
+interface InspectArgs extends BaseArgs {
+  command: "inspect";
   agent: string;
 }
 
@@ -76,6 +84,18 @@ interface DueArgs extends BaseArgs {
   agent: string;
 }
 
+interface RunDueArgs extends BaseArgs {
+  command: "run-due";
+  agent: string;
+  maxAgents: number;
+  maxTasks: number;
+}
+
+interface RunAgentArgs extends BaseArgs {
+  command: "run-agent";
+  agent: string;
+}
+
 interface DashboardArgs extends BaseArgs {
   command: "dashboard";
   outDir: string;
@@ -87,11 +107,14 @@ function usage(): never {
 Usage:
   bun src/cli.ts heartbeat list [--agent <name>] [--state <path>] [--json]
   bun src/cli.ts heartbeat show <agent> [--state <path>] [--json]
+  bun src/cli.ts heartbeat inspect [--agent <name>] [--state <path>] [--json]
   bun src/cli.ts heartbeat schedule add --agent <name> [--task <id>] [--trigger <manual|cron|event>] [--expression <expr>] [--summary <text>] [--id <schedule-id>] [--state <path>] [--json]
   bun src/cli.ts heartbeat schedule list [--agent <name>] [--state <path>] [--json]
   bun src/cli.ts heartbeat schedule pause <id> [--state <path>] [--json]
   bun src/cli.ts heartbeat schedule resume <id> [--state <path>] [--json]
   bun src/cli.ts heartbeat due [--agent <name>] [--state <path>] [--json]
+  bun src/cli.ts heartbeat run-due [--agent <name>] [--max-agents <n>] [--max-tasks <n>] [--state <path>] [--json]
+  bun src/cli.ts heartbeat run-agent --agent <name> [--state <path>] [--json]
   bun src/cli.ts heartbeat beat [--agent <name>] [--schedule <id>] [--task <id>] [--trigger <manual|cron|event>] [--status <ok|warning|blocked|error>] [--summary <text>] [--next-action <text>] [--output <text>] [--branch <name>] [--pr-url <url>] [--duration-minutes <n>] [--cost-units <n>] [--scheduled-by <name>] [--require-approval <ship-pr|merge-pr|update-snapshot|fleet-remediate|budget-override|custom>] [--approval-target <id>] [--requested-by <name>] [--state <path>] [--json]
   bun src/cli.ts heartbeat dashboard [--out <dir>] [--state <path>] [--json]
 `);
@@ -129,6 +152,17 @@ function parseArgs(argv: string[]): ParsedArgs {
       const arg = argv[i];
       if (arg === "--json") out.json = true;
       else if (arg === "--state") out.statePath = clean(argv[++i]);
+      else throw new Error(`Unknown argument: ${arg}`);
+    }
+    return out;
+  }
+  if (command === "inspect") {
+    const out: InspectArgs = { command, json: false, statePath: "", agent: "" };
+    for (let i = 1; i < argv.length; i += 1) {
+      const arg = argv[i];
+      if (arg === "--json") out.json = true;
+      else if (arg === "--state") out.statePath = clean(argv[++i]);
+      else if (arg === "--agent") out.agent = clean(argv[++i]);
       else throw new Error(`Unknown argument: ${arg}`);
     }
     return out;
@@ -226,6 +260,31 @@ function parseArgs(argv: string[]): ParsedArgs {
     }
     return out;
   }
+  if (command === "run-due") {
+    const out: RunDueArgs = { command, json: false, statePath: "", agent: "", maxAgents: 1, maxTasks: 1 };
+    for (let i = 1; i < argv.length; i += 1) {
+      const arg = argv[i];
+      if (arg === "--json") out.json = true;
+      else if (arg === "--state") out.statePath = clean(argv[++i]);
+      else if (arg === "--agent") out.agent = clean(argv[++i]);
+      else if (arg === "--max-agents") out.maxAgents = parseNumber(argv[++i], 1);
+      else if (arg === "--max-tasks") out.maxTasks = parseNumber(argv[++i], 1);
+      else throw new Error(`Unknown argument: ${arg}`);
+    }
+    return out;
+  }
+  if (command === "run-agent") {
+    const out: RunAgentArgs = { command, json: false, statePath: "", agent: "" };
+    for (let i = 1; i < argv.length; i += 1) {
+      const arg = argv[i];
+      if (arg === "--json") out.json = true;
+      else if (arg === "--state") out.statePath = clean(argv[++i]);
+      else if (arg === "--agent") out.agent = clean(argv[++i]);
+      else throw new Error(`Unknown argument: ${arg}`);
+    }
+    if (!out.agent) throw new Error("--agent is required.");
+    return out;
+  }
   if (command === "dashboard") {
     const out: DashboardArgs = { command, json: false, statePath: "", outDir: ".codex-stack/control-plane/dashboard" };
     for (let i = 1; i < argv.length; i += 1) {
@@ -263,6 +322,7 @@ function showHeartbeat(args: ShowArgs): void {
     session: findSession(state, args.agent) || null,
     schedules: state.schedules.filter((schedule) => schedule.agent === args.agent),
     heartbeats: listRecentHeartbeats(state, args.agent, 10),
+    executions: listRecentExecutions(state, args.agent, 10),
     approvals: state.approvals.filter((approval) => approval.agent === args.agent && approval.status === "pending"),
   };
   if (args.json) {
@@ -274,6 +334,30 @@ function showHeartbeat(args: ShowArgs): void {
   console.log(`Next action: ${payload.session?.nextAction || "-"}`);
   console.log(`Schedules: ${payload.schedules.length}`);
   console.log(`Recent heartbeats: ${payload.heartbeats.length}`);
+  console.log(`Recent executions: ${payload.executions.length}`);
+  console.log(`Pending approvals: ${payload.approvals.length}`);
+}
+
+function inspect(args: InspectArgs): void {
+  const state = readState(args.statePath);
+  const payload = {
+    statePath: args.statePath,
+    counts: buildDashboardReport(state, args.statePath).counts,
+    dueSchedules: listDueSchedules(state, args.agent),
+    queue: args.agent ? state.tasks.filter((task) => task.assignee === args.agent && task.status !== "done") : state.tasks.filter((task) => task.status !== "done"),
+    sessions: args.agent ? [findSession(state, args.agent)].filter(Boolean) : state.sessions,
+    heartbeats: listRecentHeartbeats(state, args.agent, 20),
+    executions: listRecentExecutions(state, args.agent, 20),
+    approvals: state.approvals.filter((approval) => approval.status === "pending" && (!args.agent || approval.agent === args.agent)),
+  };
+  if (args.json) {
+    console.log(JSON.stringify(payload, null, 2));
+    return;
+  }
+  console.log(`Due schedules: ${payload.dueSchedules.length}`);
+  console.log(`Queued tasks: ${payload.queue.length}`);
+  console.log(`Recent heartbeats: ${payload.heartbeats.length}`);
+  console.log(`Recent executions: ${payload.executions.length}`);
   console.log(`Pending approvals: ${payload.approvals.length}`);
 }
 
@@ -353,7 +437,7 @@ function beat(args: BeatArgs): void {
     durationMinutes: args.durationMinutes,
     costUnits: args.costUnits,
     scheduledBy: args.scheduledBy,
-    requireApprovalKind: args.requireApproval ? normalizeApprovalKind(args.requireApproval) : undefined,
+    requireApprovalKind: args.requireApproval ? normalizeApprovalKind(args.requireApproval) as ApprovalKind : undefined,
     approvalTarget: args.approvalTarget,
     requestedBy: args.requestedBy,
   });
@@ -385,6 +469,40 @@ function due(args: DueArgs): void {
   }
 }
 
+function runDue(args: RunDueArgs): void {
+  const state = readState(args.statePath);
+  const results = runDueSchedules(state, {
+    agent: args.agent,
+    maxAgents: Math.max(1, args.maxAgents || 1),
+    maxTasks: Math.max(1, args.maxTasks || args.maxAgents || 1),
+  });
+  const statePath = writeState(state, args.statePath);
+  const payload = { statePath, results };
+  if (args.json) {
+    console.log(JSON.stringify(payload, null, 2));
+    return;
+  }
+  if (!results.length) {
+    console.log("No due schedules executed.");
+    return;
+  }
+  for (const result of results) {
+    console.log(`${result.agent}\t${result.taskId || "-"}\t${result.execution.status}\t${result.reason}`);
+  }
+}
+
+function runAgent(args: RunAgentArgs): void {
+  const state = readState(args.statePath);
+  const result = runAgentCycle(state, args.agent);
+  const statePath = writeState(state, args.statePath);
+  const payload = { statePath, result };
+  if (args.json) {
+    console.log(JSON.stringify(payload, null, 2));
+    return;
+  }
+  console.log(`${result.agent}\t${result.taskId || "-"}\t${result.execution.status}\t${result.reason}`);
+}
+
 function dashboard(args: DashboardArgs): void {
   const state = readState(args.statePath);
   const report = buildDashboardReport(state, args.statePath);
@@ -400,9 +518,12 @@ function main(): void {
   const args = parseArgs(process.argv.slice(2));
   if (args.command === "list") listHeartbeats(args);
   else if (args.command === "show") showHeartbeat(args);
+  else if (args.command === "inspect") inspect(args);
   else if (args.command === "schedule") scheduleHeartbeat(args);
   else if (args.command === "beat") beat(args);
   else if (args.command === "due") due(args);
+  else if (args.command === "run-due") runDue(args);
+  else if (args.command === "run-agent") runAgent(args);
   else if (args.command === "dashboard") dashboard(args);
 }
 

--- a/skills/goals/SKILL.md
+++ b/skills/goals/SKILL.md
@@ -6,16 +6,18 @@ allowed-tools: Bash, Read, Grep, Glob
 
 # Goals
 
-Use this mode when you need to model an initiative, attach repo goals, or assign persistent tasks to named agents.
+Use this mode when you need to model an initiative, attach repo goals, or assign persistent tasks to named agents that the heartbeat executor can actually run.
 
 ## What it does
 - records goal hierarchy with owners and status
-- maintains a local task queue with assignees and blocked/completed state
+- maintains a local task queue with assignees, blocked/completed state, and executable action metadata
+- supports one built-in delegation template per parent task so a manager loop can spawn worker tasks automatically
 - exposes a queue view for manager-style triage
 
 ## Useful commands
 ```bash
 bun src/cli.ts goals add --id release-q2 --title "Release Q2 hardening" --owner lead-1 --status active
-bun src/cli.ts goals task add --id task-review --goal release-q2 --title "Review agent contracts" --assignee reviewer-1
+bun src/cli.ts goals task add --id task-review --goal release-q2 --title "Review agent contracts" --assignee reviewer-1 --action-kind review --action-arg --base --action-arg origin/main --expected-minutes 10
+bun src/cli.ts goals task add --id release-train --goal release-q2 --title "Coordinate release" --assignee lead-1 --action-kind custom-command --action-arg node --action-arg -e --action-arg "console.log(JSON.stringify({summary:'lead ok',nextAction:'complete'}))" --delegate-id qa-contracts --delegate-title "Run delegated QA" --delegate-assignee qa-1 --delegate-action-kind qa --delegate-action-arg http://127.0.0.1:4173/dashboard --delegate-action-arg --flow --delegate-action-arg release-dashboard
 bun src/cli.ts goals queue --json
 ```

--- a/skills/heartbeat/SKILL.md
+++ b/skills/heartbeat/SKILL.md
@@ -6,16 +6,21 @@ allowed-tools: Bash, Read, Grep, Glob
 
 # Heartbeat
 
-Use this mode when you want to wake an agent on a loop, record what it just did, and preserve the next action for the next run.
+Use this mode when you want to wake an agent on a loop, claim executable work, run one bounded workflow step, and preserve the next action for the next run.
 
 ## What it does
-- records heartbeat schedules and live heartbeat runs
+- records heartbeat schedules, autonomous execution runs, and live/manual heartbeat runs
 - persists per-agent continuity state such as current task, branch, PR, summary, and next action
 - enforces approval and budget checks through the shared control-plane state
+- writes an execution ledger so you can inspect blocked, skipped, warning, and successful loop steps separately from raw heartbeat records
 
 ## Useful commands
 ```bash
 bun src/cli.ts heartbeat schedule add --agent ship-1 --task ship-pr --trigger cron --expression "*/15 * * * *" --summary "Check release branch"
+bun src/cli.ts goals task add --id review-contracts --goal release-q2 --title "Review agent contracts" --assignee reviewer-1 --action-kind review --action-arg --base --action-arg origin/main --expected-minutes 10
+bun src/cli.ts heartbeat run-due --max-agents 1 --max-tasks 1 --json
+bun src/cli.ts heartbeat run-agent --agent ship-1 --json
 bun src/cli.ts heartbeat beat --agent ship-1 --task ship-pr --summary "Ready to open PR" --next-action "Open PR after approval" --require-approval ship-pr --approval-target ship-pr --json
 bun src/cli.ts heartbeat show ship-1 --json
+bun src/cli.ts heartbeat inspect --agent ship-1 --json
 ```

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -29,7 +29,7 @@ Usage:
   codex-stack fleet <validate|sync|collect|dashboard> --manifest <path> [args...]
   codex-stack agents <list|show|add|update|dashboard> [args...]
   codex-stack goals <list|show|add|queue|task> [args...]
-  codex-stack heartbeat <list|show|schedule|beat|dashboard> [args...]
+  codex-stack heartbeat <list|show|inspect|schedule|beat|due|run-due|run-agent|dashboard> [args...]
   codex-stack approvals <request|list|show|approve|reject|cancel|gate> [args...]
   codex-stack mcp <serve|inspect> [args...]
   codex-stack retro [--since <range>] [--out <path>] [--json] [--artifact-dir <path>] [--no-artifacts] [--repo <owner/name>] [--no-github]


### PR DESCRIPTION
## Summary
- add bounded heartbeat execution with run-due, run-agent, and inspect
- add executable task metadata plus delegation templates to the control plane
- add execution history, stuck-task surfacing, and loop regression coverage

## Validation
- bun run typecheck
- bun run smoke
- bun scripts/control-plane-loop.spec.ts
